### PR TITLE
feat: Implement useWallet custom hook for wallet state management

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@stellar/freighter-api": "^6.0.1",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
       },
@@ -1142,6 +1143,28 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@stellar/freighter-api": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@stellar/freighter-api/-/freighter-api-6.0.1.tgz",
+      "integrity": "sha512-eqwakEqSg+zoLuPpSbKyrX0pG8DQFzL/J5GtbfuMCmJI+h+oiC9pQ5C6QLc80xopZQKdGt8dUAFCmDMNdAG95w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "buffer": "6.0.3",
+        "semver": "7.7.1"
+      }
+    },
+    "node_modules/@stellar/freighter-api/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/@tailwindcss/node": {
       "version": "4.1.18",
@@ -2498,6 +2521,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.19",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
@@ -2561,6 +2604,30 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/callsites": {
@@ -3332,6 +3399,26 @@
       "engines": {
         "node": ">= 14"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "test:coverage": "vitest --coverage --run"
   },
   "dependencies": {
+    "@stellar/freighter-api": "^6.0.1",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"
   },

--- a/frontend/src/hooks/useWallet.ts
+++ b/frontend/src/hooks/useWallet.ts
@@ -1,0 +1,135 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { WalletService } from '../services/wallet';
+import type { WalletState } from '../types';
+
+const WALLET_CONNECTED_KEY = 'nova_wallet_connected';
+
+export const useWallet = () => {
+    const [wallet, setWallet] = useState<WalletState>({
+        connected: false,
+        address: null,
+        network: 'testnet',
+    });
+    const [isConnecting, setIsConnecting] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    // Use a ref to store the current listener cleanup function
+    const cleanupRef = useRef<(() => void) | null>(null);
+
+    const disconnect = useCallback(() => {
+        setWallet({
+            connected: false,
+            address: null,
+            network: 'testnet',
+        });
+        localStorage.removeItem(WALLET_CONNECTED_KEY);
+
+        // Remove listener when disconnected
+        if (cleanupRef.current) {
+            cleanupRef.current();
+            cleanupRef.current = null;
+        }
+    }, []);
+
+    const updateWalletState = useCallback(async () => {
+        try {
+            const isInstalled = await WalletService.isInstalled();
+            if (!isInstalled) {
+                return false;
+            }
+
+            const address = await WalletService.getPublicKey();
+            const network = await WalletService.getNetwork();
+
+            if (address) {
+                setWallet({
+                    connected: true,
+                    address,
+                    network,
+                });
+                localStorage.setItem(WALLET_CONNECTED_KEY, 'true');
+                return true;
+            } else {
+                disconnect();
+                return false;
+            }
+        } catch (err) {
+            console.error('Failed to update wallet state:', err);
+            return false;
+        }
+    }, [disconnect]);
+
+    const setupListeners = useCallback(() => {
+        // Clean up existing listener if any
+        if (cleanupRef.current) cleanupRef.current();
+
+        cleanupRef.current = WalletService.watchChanges(({ address, network }) => {
+            const net = network.toLowerCase().includes('public') ? 'mainnet' : 'testnet';
+            if (address) {
+                setWallet({
+                    connected: true,
+                    address,
+                    network: net as 'testnet' | 'mainnet',
+                });
+            } else {
+                disconnect();
+            }
+        });
+    }, [disconnect]);
+
+    const connect = useCallback(async () => {
+        setIsConnecting(true);
+        setError(null);
+
+        try {
+            const isInstalled = await WalletService.isInstalled();
+            if (!isInstalled) {
+                throw new Error('Freighter wallet is not installed');
+            }
+
+            const success = await updateWalletState();
+            if (success) {
+                setupListeners();
+            } else {
+                throw new Error('User rejected connection or account not found');
+            }
+        } catch (err: any) {
+            setError(err.message || 'Failed to connect wallet');
+            disconnect();
+        } finally {
+            setIsConnecting(false);
+        }
+    }, [updateWalletState, setupListeners, disconnect]);
+
+    // Initial silent reconnect
+    useEffect(() => {
+        const wasConnected = localStorage.getItem(WALLET_CONNECTED_KEY) === 'true';
+
+        const init = async () => {
+            if (wasConnected) {
+                const isInstalled = await WalletService.isInstalled();
+                if (isInstalled) {
+                    const success = await updateWalletState();
+                    if (success) {
+                        setupListeners();
+                    }
+                }
+            }
+        };
+
+        init();
+
+        // Cleanup on unmount
+        return () => {
+            if (cleanupRef.current) cleanupRef.current();
+        };
+    }, [updateWalletState, setupListeners]);
+
+    return {
+        wallet,
+        connect,
+        disconnect,
+        isConnecting,
+        error,
+    };
+};

--- a/frontend/src/services/wallet.ts
+++ b/frontend/src/services/wallet.ts
@@ -1,0 +1,68 @@
+import {
+    isConnected,
+    getAddress,
+    getNetwork,
+    signTransaction,
+    WatchWalletChanges,
+} from '@stellar/freighter-api';
+
+export class WalletService {
+    // Check if Freighter is installed and ready
+    static async isInstalled(): Promise<boolean> {
+        try {
+            const result = await isConnected();
+            return !!result.isConnected;
+        } catch (error) {
+            console.error('Error checking Freighter connection:', error);
+            return false;
+        }
+    }
+
+    // Get current user's public key
+    static async getPublicKey(): Promise<string | null> {
+        try {
+            const result = await getAddress();
+            return result.address || null;
+        } catch (error) {
+            console.error('Error getting public key:', error);
+            return null;
+        }
+    }
+
+    // Check what network is active in Freighter
+    static async getNetwork(): Promise<'testnet' | 'mainnet'> {
+        try {
+            const result = await getNetwork();
+            const network = result.network || 'testnet';
+            return network.toLowerCase().includes('public') ? 'mainnet' : 'testnet';
+        } catch (error) {
+            console.error('Error getting network:', error);
+            return 'testnet';
+        }
+    }
+
+    // Sign transaction XDR
+    static async signTransaction(xdr: string, networkPassphrase?: string): Promise<string | null> {
+        try {
+            const result = await signTransaction(xdr, {
+                networkPassphrase,
+            });
+            return result.signedTxXdr || null;
+        } catch (error) {
+            console.error('Error signing transaction:', error);
+            return null;
+        }
+    }
+
+    // Watch for any changes (account or network)
+    static watchChanges(callback: (params: { address: string; network: string }) => void) {
+        const watcher = new WatchWalletChanges();
+        watcher.watch((params) => {
+            callback({
+                address: params.address,
+                network: params.network,
+            });
+        });
+        return () => watcher.stop();
+    }
+}

--- a/frontend/src/test/hooks/useWallet.test.ts
+++ b/frontend/src/test/hooks/useWallet.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useWallet } from '../../hooks/useWallet';
+import { WalletService } from '../../services/wallet';
+
+// Mock WalletService
+vi.mock('../../services/wallet', () => ({
+    WalletService: {
+        isInstalled: vi.fn(),
+        getPublicKey: vi.fn(),
+        getNetwork: vi.fn(),
+        watchChanges: vi.fn(),
+    },
+}));
+
+describe('useWallet hook', () => {
+    const mockPublicKey = 'GBTEST...';
+    const mockNetwork = 'testnet';
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        localStorage.clear();
+
+        // Default mocks
+        vi.mocked(WalletService.isInstalled).mockResolvedValue(true);
+        vi.mocked(WalletService.getPublicKey).mockResolvedValue(mockPublicKey);
+        vi.mocked(WalletService.getNetwork).mockResolvedValue(mockNetwork as any);
+        vi.mocked(WalletService.watchChanges).mockReturnValue(() => { });
+    });
+
+    it('should initialize with disconnected state', () => {
+        const { result } = renderHook(() => useWallet());
+
+        expect(result.current.wallet.connected).toBe(false);
+        expect(result.current.wallet.address).toBe(null);
+        expect(result.current.isConnecting).toBe(false);
+        expect(result.current.error).toBe(null);
+    });
+
+    it('should connect successfully', async () => {
+        const { result } = renderHook(() => useWallet());
+
+        await act(async () => {
+            await result.current.connect();
+        });
+
+        expect(result.current.wallet.connected).toBe(true);
+        expect(result.current.wallet.address).toBe(mockPublicKey);
+        expect(localStorage.getItem('nova_wallet_connected')).toBe('true');
+        expect(WalletService.watchChanges).toHaveBeenCalled();
+    });
+
+    it('should handle disconnect', async () => {
+        const { result } = renderHook(() => useWallet());
+
+        // First connect
+        await act(async () => {
+            await result.current.connect();
+        });
+
+        // Then disconnect
+        act(() => {
+            result.current.disconnect();
+        });
+
+        expect(result.current.wallet.connected).toBe(false);
+        expect(result.current.wallet.address).toBe(null);
+        expect(localStorage.getItem('nova_wallet_connected')).toBe(null);
+    });
+
+    it('should attempt silent reconnect on mount if flag is set', async () => {
+        localStorage.setItem('nova_wallet_connected', 'true');
+
+        let result: any;
+        await act(async () => {
+            result = renderHook(() => useWallet()).result;
+        });
+
+        await act(async () => {
+            await Promise.resolve(); // wait for init()
+        });
+
+        expect(result.current.wallet.connected).toBe(true);
+        expect(result.current.wallet.address).toBe(mockPublicKey);
+    });
+
+    it('should handle error when Freighter is not installed', async () => {
+        vi.mocked(WalletService.isInstalled).mockResolvedValue(false);
+        const { result } = renderHook(() => useWallet());
+
+        await act(async () => {
+            await result.current.connect();
+        });
+
+        expect(result.current.wallet.connected).toBe(false);
+        expect(result.current.error).toBe('Freighter wallet is not installed');
+    });
+
+    it('should handle changes from watcher', async () => {
+        let watchCallback: any;
+        vi.mocked(WalletService.watchChanges).mockImplementation((cb: any) => {
+            watchCallback = cb;
+            return () => { };
+        });
+
+        const { result } = renderHook(() => useWallet());
+
+        await act(async () => {
+            await result.current.connect();
+        });
+
+        const newAddress = 'GBNEW...';
+        await act(async () => {
+            watchCallback({ address: newAddress, network: 'testnet' });
+        });
+
+        expect(result.current.wallet.address).toBe(newAddress);
+
+        await act(async () => {
+            watchCallback({ address: newAddress, network: 'public' });
+        });
+
+        expect(result.current.wallet.network).toBe('mainnet');
+    });
+
+    it('should clean up watcher on unmount', async () => {
+        const cleanupWatcher = vi.fn();
+        vi.mocked(WalletService.watchChanges).mockReturnValue(cleanupWatcher);
+
+        const { result, unmount } = renderHook(() => useWallet());
+
+        await act(async () => {
+            await result.current.connect();
+        });
+
+        unmount();
+
+        expect(cleanupWatcher).toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
Closes #3

---

## Description
Implemented a custom `useWallet` hook to manage Stellar wallet state via Freighter. This includes:
- A `WalletService` abstraction Layer for `@stellar/freighter-api`.
- Persistent connection state using `localStorage`.
- Reactive updates for account/network changes using `WatchWalletChanges`.
- Comprehensive unit tests verifying connection logic and event handling.
- Proper cleanup of listeners on unmount.

## Changes
- [NEW] `frontend/src/hooks/useWallet.ts`
- [NEW] `frontend/src/services/wallet.ts`
- [NEW] `frontend/src/test/hooks/useWallet.test.ts`
- [MODIFY] `frontend/package.json` (Added `@stellar/freighter-api`)

## Verification
- Ran `npm test` - 7/7 tests passed.
- Ran `npm run type-check` - No errors.