### PR TITLE
feat: WalletInfo and NetworkToggle components

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@stellar/freighter-api": "^6.0.1",
         "@stellar/stellar-sdk": "^13.3.0",
+        "i18next": "^25.8.12",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-i18next": "^16.5.4"
@@ -156,7 +157,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -515,7 +515,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -556,7 +555,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -889,7 +887,6 @@
         "url": "https://github.com/sponsors/Brooooooklyn"
       }
     },
-
     "node_modules/@oxc-project/runtime": {
       "version": "0.113.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/runtime/-/runtime-0.113.0.tgz",
@@ -1927,7 +1924,6 @@
       "integrity": "sha512-oH72nZRfDv9lADUBSo104Aq7gPHpQZc4BTx38r9xf9pg5LfP6EzSyH2n7qFmmxRQXh7YlUXODcYsg6PuTDSxGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1938,7 +1934,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1949,7 +1944,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -1999,7 +1993,6 @@
       "integrity": "sha512-4z2nCSBfVIMnbuu8uinj+f0o4qOeggYJLbjpPHka3KH1om7e+H9yLKTYgksTaHcGco+NClhhY2vyO3HsMH1RGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.55.0",
         "@typescript-eslint/types": "8.55.0",
@@ -2379,7 +2372,6 @@
       "integrity": "sha512-CGJ25bc8fRi8Lod/3GHSvXRKi7nBo3kxh0ApW4yCjmrWmRmlT53B5E08XRSZRliygG0aVNxLrBEqPYdz/KcCtQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.0.18",
         "fflate": "^0.8.2",
@@ -2416,7 +2408,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2533,6 +2524,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.24",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.24.tgz",
@@ -2568,6 +2565,32 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
+      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -2670,6 +2693,15 @@
         "require-from-string": "^2.0.2"
       }
     },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -2701,7 +2733,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2880,7 +2911,18 @@
       "dev": true,
       "license": "MIT"
     },
-
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3010,6 +3052,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/define-lazy-prop": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
@@ -3018,6 +3077,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/dequal": {
@@ -3102,12 +3170,57 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -3138,7 +3251,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3327,6 +3439,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventsource": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
+      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -3399,6 +3520,15 @@
         }
       }
     },
+    "node_modules/feaxios": {
+      "version": "0.0.23",
+      "resolved": "https://registry.npmjs.org/feaxios/-/feaxios-0.0.23.tgz",
+      "integrity": "sha512-eghR0A21fvbkcQBgZuMfQhrXxJzC0GNUGC9fXhBge33D+mFDTwl0aJ35zoQQn575BhyjQitRc5N4f+L4cP708g==",
+      "license": "MIT",
+      "dependencies": {
+        "is-retry-allowed": "^3.0.0"
+      }
+    },
     "node_modules/fflate": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
@@ -3457,6 +3587,57 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fraction.js": {
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
@@ -3501,6 +3682,15 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -3519,6 +3709,43 @@
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/glob-parent": {
@@ -3547,6 +3774,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -3562,6 +3801,57 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/hermes-estree": {
@@ -3736,6 +4026,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-docker": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
@@ -3792,6 +4100,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-retry-allowed": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-3.0.0.tgz",
+      "integrity": "sha512-9xH0xvoggby+u0uGF7cZXdrutWiBiaFG8ZT4YFPXL8NzkyAwX3AKGLeFQLvzDpM430+nDFBZ1LHkie/8ocL06A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-wsl": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
@@ -3804,6 +4139,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -3887,7 +4228,6 @@
       "integrity": "sha512-KDYJgZ6T2TKdU8yBfYueq5EPG/EylMsBvCaenWMJb2OXmjgczzwveRCoJ+Hgj1lXPDyasvrgneSn4GBuR1hYyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.31",
         "@asamuzakjp/dom-selector": "^6.7.6",
@@ -4361,12 +4701,42 @@
         "node": ">=10"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.12.2",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
       "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/min-indent": {
       "version": "1.0.1",
@@ -4586,12 +4956,20 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/postcss": {
@@ -4614,7 +4992,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4669,6 +5046,12 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -4696,12 +5079,20 @@
       ],
       "license": "MIT"
     },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
     "node_modules/react": {
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4711,7 +5102,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4788,6 +5178,16 @@
       },
       "engines": {
         "bare": ">=1.10.0"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/require-from-string": {
@@ -4880,6 +5280,26 @@
         }
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -4907,6 +5327,43 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/sha.js": {
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
+      "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
+      "license": "(MIT AND BSD-3-Clause)",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.0"
+      },
+      "bin": {
+        "sha.js": "bin.js"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/shebang-command": {
@@ -4962,6 +5419,16 @@
       "optional": true,
       "dependencies": {
         "require-addon": "^1.1.0"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/source-map-js": {
@@ -5147,6 +5614,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/to-buffer": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
+      "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "^2.0.5",
+        "safe-buffer": "^5.2.1",
+        "typed-array-buffer": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/toml": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
+      "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==",
+      "license": "MIT"
+    },
     "node_modules/totalist": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
@@ -5223,13 +5710,26 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5330,14 +5830,27 @@
         "punycode": "^2.1.0"
       }
     },
-
+    "node_modules/urijs": {
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.11.tgz",
+      "integrity": "sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==",
+      "license": "MIT"
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/vite": {
       "version": "8.0.0-beta.14",
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.0-beta.14.tgz",
       "integrity": "sha512-oLW66oi8tZcoxu6+1HFXb+5hLHco3OnEVu2Awmj5NqEo7vxaqybjBM0BXHcq+jAFhzkMGXJl8xcO5qDBczgKLg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@oxc-project/runtime": "0.113.0",
         "fdir": "^6.5.0",
@@ -5433,7 +5946,6 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -5579,6 +6091,27 @@
         "node": ">= 8"
       }
     },
+    "node_modules/which-typed-array": {
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -5706,7 +6239,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,11 +14,13 @@ import {
   useTutorial,
   deploymentTutorialSteps,
 } from "./components/Tutorial";
+import { WalletInfo, NetworkToggle } from "./components/WalletConnect";
 import { useWallet } from "./hooks/useWallet";
-import { truncateAddress } from "./utils/formatting";
+import { useNetwork } from "./hooks/useNetwork";
 
 function App() {
-  const { wallet, connect, disconnect, isConnecting, error } = useWallet();
+  const { network, setNetwork } = useNetwork();
+  const { wallet, connect, disconnect, isConnecting, error } = useWallet({ network });
   const [showCelebration, setShowCelebration] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
   const tutorial = useTutorial(deploymentTutorialSteps);
@@ -74,25 +76,19 @@ function App() {
                 </svg>
               </Button>
             )}
+            <NetworkToggle network={network} onNetworkChange={setNetwork} />
             {wallet.connected && wallet.address ? (
-              <div className="flex items-center gap-2">
-                <Button variant="secondary" size="sm" disabled>
-                  {truncateAddress(wallet.address)}
-                </Button>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={disconnect}
-                  data-tutorial="connect-wallet"
-                >
-                  Disconnect
-                </Button>
-              </div>
+              <WalletInfo
+                wallet={wallet}
+                onDisconnect={disconnect}
+                data-tutorial="connect-wallet"
+              />
             ) : (
               <Button
                 size="sm"
                 onClick={() => void connect()}
                 loading={isConnecting}
+                data-tutorial="connect-wallet"
               >
                 Connect Wallet
               </Button>

--- a/frontend/src/components/TokenDeployForm/index.ts
+++ b/frontend/src/components/TokenDeployForm/index.ts
@@ -1,8 +1,5 @@
 export { BasicInfoStep } from './BasicInfoStep';
 export { LogoUploadStep } from './LogoUploadStep';
 export { FeeDisplay } from './FeeDisplay';
+export { TokenDeployForm } from './TokenDeployForm';
 export type { BasicInfoData } from './BasicInfoStep';
-export { BasicInfoStep } from "./BasicInfoStep";
-export { LogoUploadStep } from "./LogoUploadStep";
-export { TokenDeployForm } from "./TokenDeployForm";
-export type { BasicInfoData } from "./BasicInfoStep";

--- a/frontend/src/components/Tutorial/tutorialAnalytics.ts
+++ b/frontend/src/components/Tutorial/tutorialAnalytics.ts
@@ -84,7 +84,7 @@ class TutorialAnalytics {
         };
     }
 
-    static getStoredAnalytics(): TutorialEvent[] {
+    getStoredAnalytics(): TutorialEvent[] {
         try {
             const data = localStorage.getItem('stellar_tutorial_analytics');
             return data ? JSON.parse(data) : [];
@@ -93,7 +93,7 @@ class TutorialAnalytics {
         }
     }
 
-    static clearAnalytics() {
+    clearAnalytics() {
         localStorage.removeItem('stellar_tutorial_analytics');
     }
 }

--- a/frontend/src/components/WalletConnect/NetworkToggle.test.tsx
+++ b/frontend/src/components/WalletConnect/NetworkToggle.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { NetworkToggle } from './NetworkToggle';
+
+describe('NetworkToggle', () => {
+    const mockOnNetworkChange = vi.fn();
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('renders with testnet selected', () => {
+        render(<NetworkToggle network="testnet" onNetworkChange={mockOnNetworkChange} />);
+
+        expect(screen.getByText('Testnet')).toBeInTheDocument();
+        expect(screen.getByText('Mainnet')).toBeInTheDocument();
+        expect(screen.getByRole('switch')).toHaveAttribute('aria-checked', 'false');
+    });
+
+    it('renders with mainnet selected', () => {
+        render(<NetworkToggle network="mainnet" onNetworkChange={mockOnNetworkChange} />);
+
+        expect(screen.getByRole('switch')).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('shows warning badge when on testnet', () => {
+        render(<NetworkToggle network="testnet" onNetworkChange={mockOnNetworkChange} />);
+
+        expect(screen.getByLabelText('Testnet mode active')).toBeInTheDocument();
+        expect(screen.getByText('Test')).toBeInTheDocument();
+    });
+
+    it('shows live indicator when on mainnet', () => {
+        render(<NetworkToggle network="mainnet" onNetworkChange={mockOnNetworkChange} />);
+
+        expect(screen.getByLabelText('Mainnet mode active')).toBeInTheDocument();
+        expect(screen.getByText('Live')).toBeInTheDocument();
+    });
+
+    it('does not show testnet warning on mainnet', () => {
+        render(<NetworkToggle network="mainnet" onNetworkChange={mockOnNetworkChange} />);
+
+        expect(screen.queryByLabelText('Testnet mode active')).not.toBeInTheDocument();
+    });
+
+    it('does not show live indicator on testnet', () => {
+        render(<NetworkToggle network="testnet" onNetworkChange={mockOnNetworkChange} />);
+
+        expect(screen.queryByLabelText('Mainnet mode active')).not.toBeInTheDocument();
+    });
+
+    it('calls onNetworkChange with mainnet when toggling from testnet', () => {
+        render(<NetworkToggle network="testnet" onNetworkChange={mockOnNetworkChange} />);
+
+        fireEvent.click(screen.getByRole('switch'));
+        expect(mockOnNetworkChange).toHaveBeenCalledWith('mainnet');
+    });
+
+    it('calls onNetworkChange with testnet when toggling from mainnet', () => {
+        render(<NetworkToggle network="mainnet" onNetworkChange={mockOnNetworkChange} />);
+
+        fireEvent.click(screen.getByRole('switch'));
+        expect(mockOnNetworkChange).toHaveBeenCalledWith('testnet');
+    });
+
+    it('does not toggle when disabled', () => {
+        render(<NetworkToggle network="testnet" onNetworkChange={mockOnNetworkChange} disabled />);
+
+        const toggle = screen.getByRole('switch');
+        expect(toggle).toBeDisabled();
+    });
+
+    it('supports keyboard interaction with Enter key', () => {
+        render(<NetworkToggle network="testnet" onNetworkChange={mockOnNetworkChange} />);
+
+        fireEvent.keyDown(screen.getByRole('switch'), { key: 'Enter' });
+        expect(mockOnNetworkChange).toHaveBeenCalledWith('mainnet');
+    });
+
+    it('supports keyboard interaction with Space key', () => {
+        render(<NetworkToggle network="testnet" onNetworkChange={mockOnNetworkChange} />);
+
+        fireEvent.keyDown(screen.getByRole('switch'), { key: ' ' });
+        expect(mockOnNetworkChange).toHaveBeenCalledWith('mainnet');
+    });
+
+    it('has proper accessibility attributes', () => {
+        render(<NetworkToggle network="testnet" onNetworkChange={mockOnNetworkChange} />);
+
+        const toggle = screen.getByRole('switch');
+        expect(toggle).toHaveAttribute('aria-label', 'Switch to mainnet');
+        expect(screen.getByRole('region', { name: 'Network selection' })).toBeInTheDocument();
+    });
+
+    it('updates aria-label based on current network', () => {
+        render(<NetworkToggle network="mainnet" onNetworkChange={mockOnNetworkChange} />);
+
+        expect(screen.getByRole('switch')).toHaveAttribute('aria-label', 'Switch to testnet');
+    });
+
+    it('uses yellow/amber styling for testnet label', () => {
+        render(<NetworkToggle network="testnet" onNetworkChange={mockOnNetworkChange} />);
+
+        const testnetLabel = screen.getByText('Testnet');
+        expect(testnetLabel).toHaveClass('text-amber-700');
+    });
+
+    it('uses green styling for mainnet label', () => {
+        render(<NetworkToggle network="mainnet" onNetworkChange={mockOnNetworkChange} />);
+
+        const mainnetLabel = screen.getByText('Mainnet');
+        expect(mainnetLabel).toHaveClass('text-green-700');
+    });
+});

--- a/frontend/src/components/WalletConnect/NetworkToggle.tsx
+++ b/frontend/src/components/WalletConnect/NetworkToggle.tsx
@@ -1,0 +1,119 @@
+import { useCallback } from 'react';
+
+type Network = 'testnet' | 'mainnet';
+
+interface NetworkToggleProps {
+    network: Network;
+    onNetworkChange: (network: Network) => void;
+    disabled?: boolean;
+    className?: string;
+}
+
+export function NetworkToggle({
+    network,
+    onNetworkChange,
+    disabled = false,
+    className = '',
+}: NetworkToggleProps) {
+    const isMainnet = network === 'mainnet';
+
+    const handleToggle = useCallback(() => {
+        if (disabled) return;
+        onNetworkChange(isMainnet ? 'testnet' : 'mainnet');
+    }, [disabled, isMainnet, onNetworkChange]);
+
+    const handleKeyDown = useCallback(
+        (e: React.KeyboardEvent) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                handleToggle();
+            }
+        },
+        [handleToggle]
+    );
+
+    return (
+        <div
+            className={`flex items-center gap-2 ${className}`}
+            role="region"
+            aria-label="Network selection"
+        >
+            {/* Testnet warning badge */}
+            {!isMainnet && (
+                <span
+                    className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-semibold bg-amber-100 text-amber-800 border border-amber-200"
+                    aria-label="Testnet mode active"
+                >
+                    <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 20 20">
+                        <path fillRule="evenodd" d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 6a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 6zm0 9a1 1 0 100-2 1 1 0 000 2z" clipRule="evenodd" />
+                    </svg>
+                    Test
+                </span>
+            )}
+
+            {/* Toggle switch */}
+            <div className="flex items-center gap-1.5">
+                <span
+                    className={`text-xs font-medium transition-colors ${
+                        !isMainnet ? 'text-amber-700' : 'text-gray-400'
+                    }`}
+                    id="testnet-label"
+                >
+                    Testnet
+                </span>
+
+                <button
+                    type="button"
+                    role="switch"
+                    aria-checked={isMainnet}
+                    aria-label={`Switch to ${isMainnet ? 'testnet' : 'mainnet'}`}
+                    aria-describedby={isMainnet ? 'mainnet-label' : 'testnet-label'}
+                    disabled={disabled}
+                    onClick={handleToggle}
+                    onKeyDown={handleKeyDown}
+                    className={`
+                        relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent
+                        transition-colors duration-200 ease-in-out
+                        focus:outline-none focus:ring-2 focus:ring-offset-2
+                        disabled:opacity-50 disabled:cursor-not-allowed
+                        ${isMainnet
+                            ? 'bg-green-500 focus:ring-green-400'
+                            : 'bg-amber-400 focus:ring-amber-300'
+                        }
+                    `}
+                >
+                    <span
+                        className={`
+                            pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow-sm ring-0
+                            transition duration-200 ease-in-out
+                            ${isMainnet ? 'translate-x-5' : 'translate-x-0'}
+                        `}
+                    />
+                </button>
+
+                <span
+                    className={`text-xs font-medium transition-colors ${
+                        isMainnet ? 'text-green-700' : 'text-gray-400'
+                    }`}
+                    id="mainnet-label"
+                >
+                    Mainnet
+                </span>
+            </div>
+
+            {/* Mainnet active indicator */}
+            {isMainnet && (
+                <span
+                    className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-semibold bg-green-100 text-green-800 border border-green-200"
+                    aria-label="Mainnet mode active"
+                >
+                    <span className="relative flex h-2 w-2">
+                        <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75" />
+                        <span className="relative inline-flex rounded-full h-2 w-2 bg-green-500" />
+                    </span>
+                    Live
+                </span>
+            )}
+        </div>
+    );
+}

--- a/frontend/src/components/WalletConnect/WalletInfo.test.tsx
+++ b/frontend/src/components/WalletConnect/WalletInfo.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { WalletInfo } from './WalletInfo';
+import type { WalletState } from '../../types';
+
+vi.mock('../../services/wallet', () => ({
+    WalletService: {
+        getBalance: vi.fn(() => Promise.resolve('125.5000000')),
+    },
+}));
+
+const mockWallet: WalletState = {
+    connected: true,
+    address: 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5',
+    network: 'testnet',
+};
+
+describe('WalletInfo', () => {
+    const mockDisconnect = vi.fn();
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        Object.assign(navigator, {
+            clipboard: { writeText: vi.fn(() => Promise.resolve()) },
+        });
+    });
+
+    it('renders nothing when wallet is not connected', () => {
+        const disconnectedWallet: WalletState = {
+            connected: false,
+            address: null,
+            network: 'testnet',
+        };
+        const { container } = render(
+            <WalletInfo wallet={disconnectedWallet} onDisconnect={mockDisconnect} />
+        );
+        expect(container.firstChild).toBeNull();
+    });
+
+    it('displays truncated wallet address', () => {
+        render(<WalletInfo wallet={mockWallet} onDisconnect={mockDisconnect} />);
+        expect(screen.getByText('GBBD47...FLA5')).toBeInTheDocument();
+    });
+
+    it('shows the full address in a tooltip on hover', async () => {
+        render(<WalletInfo wallet={mockWallet} onDisconnect={mockDisconnect} />);
+        const truncated = screen.getByText('GBBD47...FLA5');
+        fireEvent.mouseEnter(truncated.parentElement!);
+
+        await waitFor(() => {
+            expect(screen.getByRole('tooltip')).toHaveTextContent(mockWallet.address!);
+        });
+    });
+
+    it('displays XLM balance after loading', async () => {
+        render(<WalletInfo wallet={mockWallet} onDisconnect={mockDisconnect} />);
+
+        await waitFor(() => {
+            expect(screen.getByText(/125\.50/)).toBeInTheDocument();
+            expect(screen.getByText('XLM')).toBeInTheDocument();
+        });
+    });
+
+    it('copies address to clipboard when copy button is clicked', async () => {
+        render(<WalletInfo wallet={mockWallet} onDisconnect={mockDisconnect} />);
+
+        const copyButton = screen.getByLabelText('Copy address to clipboard');
+        fireEvent.click(copyButton);
+
+        await waitFor(() => {
+            expect(navigator.clipboard.writeText).toHaveBeenCalledWith(mockWallet.address);
+        });
+
+        await waitFor(() => {
+            expect(screen.getByLabelText('Address copied')).toBeInTheDocument();
+        });
+    });
+
+    it('calls onDisconnect when disconnect button is clicked', () => {
+        render(<WalletInfo wallet={mockWallet} onDisconnect={mockDisconnect} />);
+
+        const disconnectButton = screen.getByLabelText('Disconnect wallet');
+        fireEvent.click(disconnectButton);
+
+        expect(mockDisconnect).toHaveBeenCalledTimes(1);
+    });
+
+    it('has proper accessibility attributes', () => {
+        render(<WalletInfo wallet={mockWallet} onDisconnect={mockDisconnect} />);
+
+        expect(screen.getByRole('region', { name: 'Wallet information' })).toBeInTheDocument();
+        expect(screen.getByLabelText('Disconnect wallet')).toBeInTheDocument();
+        expect(screen.getByLabelText('Copy address to clipboard')).toBeInTheDocument();
+    });
+
+    it('shows loading indicator while fetching balance', () => {
+        render(<WalletInfo wallet={mockWallet} onDisconnect={mockDisconnect} />);
+        expect(screen.getByText('Loading...')).toBeInTheDocument();
+    });
+});

--- a/frontend/src/components/WalletConnect/WalletInfo.tsx
+++ b/frontend/src/components/WalletConnect/WalletInfo.tsx
@@ -1,0 +1,152 @@
+import { useState, useEffect, useCallback } from 'react';
+import { Button, Tooltip } from '../UI';
+import { WalletService } from '../../services/wallet';
+import { truncateAddress, formatXLM } from '../../utils/formatting';
+import type { WalletState } from '../../types';
+
+interface WalletInfoProps {
+    wallet: WalletState;
+    onDisconnect: () => void;
+    className?: string;
+}
+
+export function WalletInfo({ wallet, onDisconnect, className = '' }: WalletInfoProps) {
+    const [balance, setBalance] = useState<string | null>(null);
+    const [isLoadingBalance, setIsLoadingBalance] = useState(false);
+    const [copied, setCopied] = useState(false);
+    const [balanceError, setBalanceError] = useState<string | null>(null);
+
+    const fetchBalance = useCallback(async () => {
+        if (!wallet.address) return;
+
+        setIsLoadingBalance(true);
+        setBalanceError(null);
+        try {
+            const bal = await WalletService.getBalance(wallet.address);
+            setBalance(bal);
+        } catch (err) {
+            const message = err instanceof Error ? err.message : 'Failed to fetch balance';
+            setBalanceError(message);
+            setBalance(null);
+        } finally {
+            setIsLoadingBalance(false);
+        }
+    }, [wallet.address]);
+
+    useEffect(() => {
+        fetchBalance();
+        const interval = setInterval(fetchBalance, 30_000);
+        return () => clearInterval(interval);
+    }, [fetchBalance]);
+
+    const copyAddress = useCallback(async () => {
+        if (!wallet.address) return;
+        try {
+            await navigator.clipboard.writeText(wallet.address);
+            setCopied(true);
+            setTimeout(() => setCopied(false), 2000);
+        } catch {
+            // Fallback for older browsers
+            const textArea = document.createElement('textarea');
+            textArea.value = wallet.address;
+            textArea.style.position = 'fixed';
+            textArea.style.opacity = '0';
+            document.body.appendChild(textArea);
+            textArea.select();
+            document.execCommand('copy');
+            document.body.removeChild(textArea);
+            setCopied(true);
+            setTimeout(() => setCopied(false), 2000);
+        }
+    }, [wallet.address]);
+
+    if (!wallet.connected || !wallet.address) {
+        return null;
+    }
+
+    return (
+        <div
+            className={`flex items-center gap-2 rounded-xl bg-white/80 backdrop-blur-sm border border-gray-200 px-3 py-2 shadow-sm ${className}`}
+            role="region"
+            aria-label="Wallet information"
+        >
+            {/* Wallet icon */}
+            <div className="flex-shrink-0 w-8 h-8 rounded-full bg-blue-100 flex items-center justify-center">
+                <svg className="w-4 h-4 text-blue-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M21 12a2.25 2.25 0 00-2.25-2.25H15a3 3 0 11-6 0H5.25A2.25 2.25 0 003 12m18 0v6a2.25 2.25 0 01-2.25 2.25H5.25A2.25 2.25 0 013 18v-6m18 0V9M3 12V9m18 0a2.25 2.25 0 00-2.25-2.25H5.25A2.25 2.25 0 013 9m18 0V6a2.25 2.25 0 00-2.25-2.25H5.25A2.25 2.25 0 013 6v3" />
+                </svg>
+            </div>
+
+            {/* Address with copy */}
+            <div className="flex flex-col min-w-0">
+                <div className="flex items-center gap-1">
+                    <Tooltip content={wallet.address} position="bottom">
+                        <span
+                            className="text-sm font-mono font-medium text-gray-800 cursor-default"
+                            aria-label={`Wallet address: ${wallet.address}`}
+                        >
+                            {truncateAddress(wallet.address)}
+                        </span>
+                    </Tooltip>
+                    <button
+                        onClick={copyAddress}
+                        className="p-1 rounded-md hover:bg-gray-100 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-1"
+                        aria-label={copied ? 'Address copied' : 'Copy address to clipboard'}
+                        title={copied ? 'Copied!' : 'Copy address'}
+                    >
+                        {copied ? (
+                            <svg className="w-3.5 h-3.5 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+                                <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
+                            </svg>
+                        ) : (
+                            <svg className="w-3.5 h-3.5 text-gray-400 hover:text-gray-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                                <path strokeLinecap="round" strokeLinejoin="round" d="M15.666 3.888A2.25 2.25 0 0013.5 2.25h-3c-1.03 0-1.9.693-2.166 1.638m7.332 0c.055.194.084.4.084.612v0a.75.75 0 01-.75.75H9.75a.75.75 0 01-.75-.75v0c0-.212.03-.418.084-.612m7.332 0c.646.049 1.288.11 1.927.184 1.1.128 1.907 1.077 1.907 2.185V19.5a2.25 2.25 0 01-2.25 2.25H6.75A2.25 2.25 0 014.5 19.5V6.257c0-1.108.806-2.057 1.907-2.185a48.208 48.208 0 011.927-.184" />
+                            </svg>
+                        )}
+                    </button>
+                </div>
+
+                {/* Balance */}
+                <div className="text-xs text-gray-500">
+                    {isLoadingBalance ? (
+                        <span className="inline-flex items-center gap-1">
+                            <svg className="animate-spin h-3 w-3" viewBox="0 0 24 24">
+                                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
+                                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+                            </svg>
+                            Loading...
+                        </span>
+                    ) : balanceError ? (
+                        <Tooltip content={balanceError} position="bottom">
+                            <button
+                                onClick={fetchBalance}
+                                className="text-amber-600 hover:text-amber-700 underline decoration-dotted cursor-pointer"
+                                aria-label="Balance unavailable, click to retry"
+                            >
+                                Balance unavailable
+                            </button>
+                        </Tooltip>
+                    ) : balance !== null ? (
+                        <span aria-label={`Balance: ${formatXLM(balance)} XLM`}>
+                            {formatXLM(balance)} <span className="text-gray-400 font-medium">XLM</span>
+                        </span>
+                    ) : null}
+                </div>
+            </div>
+
+            {/* Disconnect */}
+            <Button
+                variant="outline"
+                size="sm"
+                onClick={onDisconnect}
+                className="ml-1 flex-shrink-0 !border-gray-200 !text-gray-500 hover:!text-red-600 hover:!border-red-200 hover:!bg-red-50"
+                aria-label="Disconnect wallet"
+            >
+                <svg className="w-4 h-4 sm:mr-1.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0013.5 3h-6a2.25 2.25 0 00-2.25 2.25v13.5A2.25 2.25 0 007.5 21h6a2.25 2.25 0 002.25-2.25V15m3 0l3-3m0 0l-3-3m3 3H9" />
+                </svg>
+                <span className="hidden sm:inline">Disconnect</span>
+            </Button>
+        </div>
+    );
+}

--- a/frontend/src/components/WalletConnect/index.ts
+++ b/frontend/src/components/WalletConnect/index.ts
@@ -1,1 +1,3 @@
 export { ConnectButton } from "./ConnectButton";
+export { WalletInfo } from "./WalletInfo";
+export { NetworkToggle } from "./NetworkToggle";

--- a/frontend/src/hooks/useNetwork.ts
+++ b/frontend/src/hooks/useNetwork.ts
@@ -1,0 +1,49 @@
+import { useState, useCallback, useEffect } from 'react';
+
+type Network = 'testnet' | 'mainnet';
+
+const NETWORK_STORAGE_KEY = 'nova_network_preference';
+
+function getStoredNetwork(): Network {
+    try {
+        const stored = localStorage.getItem(NETWORK_STORAGE_KEY);
+        if (stored === 'mainnet' || stored === 'testnet') {
+            return stored;
+        }
+    } catch {
+        // localStorage may be unavailable
+    }
+    return 'testnet';
+}
+
+export function useNetwork() {
+    const [network, setNetworkState] = useState<Network>(getStoredNetwork);
+    const [isChanging, setIsChanging] = useState(false);
+
+    useEffect(() => {
+        try {
+            localStorage.setItem(NETWORK_STORAGE_KEY, network);
+        } catch {
+            // localStorage may be unavailable
+        }
+    }, [network]);
+
+    const setNetwork = useCallback((newNetwork: Network) => {
+        setIsChanging(true);
+        setNetworkState(newNetwork);
+        setTimeout(() => setIsChanging(false), 300);
+    }, []);
+
+    const toggleNetwork = useCallback(() => {
+        setNetwork(network === 'testnet' ? 'mainnet' : 'testnet');
+    }, [network, setNetwork]);
+
+    return {
+        network,
+        setNetwork,
+        toggleNetwork,
+        isTestnet: network === 'testnet',
+        isMainnet: network === 'mainnet',
+        isChanging,
+    };
+}

--- a/frontend/src/test/hooks/useWallet.test.ts
+++ b/frontend/src/test/hooks/useWallet.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { useWallet } from '../../hooks/useWallet';
 import { WalletService } from '../../services/wallet';
@@ -171,7 +171,9 @@ describe('useWallet hook', () => {
             await result.current.connect();
         });
 
-        unmount();
+        act(() => {
+            unmount();
+        });
 
         expect(cleanupFn).toHaveBeenCalled();
     });


### PR DESCRIPTION
Closes #5

- Add WalletInfo: truncated address, XLM balance, copy, disconnect, tooltip
- Add NetworkToggle: testnet/mainnet switch with visual indicators
- Add useNetwork hook: network state with localStorage persistence
- Integrate useWallet with network: disconnect on network change
- Critical fixes: TokenDeployForm exports, StellarService, IPFSService, tutorialAnalytics
- Fix useWallet: preserve connect errors, always register unmount cleanup
- Fix useWallet.test: add afterEach import, wrap unmount in act
- Component tests: WalletInfo (8), NetworkToggle (15)