### PR TITLE
feat: implement burn events analytics module

### DIFF
--- a/backend/src/token-analytics/1700000000000-CreateBurnEvents.ts
+++ b/backend/src/token-analytics/1700000000000-CreateBurnEvents.ts
@@ -1,0 +1,44 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateBurnEvents1700000000000 implements MigrationInterface {
+  name = 'CreateBurnEvents1700000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TYPE "public"."burn_events_burn_type_enum" AS ENUM('self', 'admin')
+    `);
+
+    await queryRunner.query(`
+      CREATE TABLE "burn_events" (
+        "id"               UUID         NOT NULL DEFAULT gen_random_uuid(),
+        "token_address"    VARCHAR      NOT NULL,
+        "burner_address"   VARCHAR      NOT NULL,
+        "amount"           NUMERIC(78,0) NOT NULL,
+        "burn_type"        "public"."burn_events_burn_type_enum" NOT NULL DEFAULT 'self',
+        "transaction_hash" VARCHAR,
+        "block_number"     BIGINT,
+        "burned_at"        TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+        CONSTRAINT "PK_burn_events" PRIMARY KEY ("id")
+      )
+    `);
+
+    // Composite index for most analytic queries
+    await queryRunner.query(`
+      CREATE INDEX "IDX_burn_events_token_burned_at"
+        ON "burn_events" ("token_address", "burned_at" DESC)
+    `);
+
+    // Index for unique-burner aggregation
+    await queryRunner.query(`
+      CREATE INDEX "IDX_burn_events_token_burner"
+        ON "burn_events" ("token_address", "burner_address")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "IDX_burn_events_token_burner"`);
+    await queryRunner.query(`DROP INDEX "IDX_burn_events_token_burned_at"`);
+    await queryRunner.query(`DROP TABLE "burn_events"`);
+    await queryRunner.query(`DROP TYPE "public"."burn_events_burn_type_enum"`);
+  }
+}

--- a/backend/src/token-analytics/analytics.controller.spec.ts
+++ b/backend/src/token-analytics/analytics.controller.spec.ts
@@ -1,0 +1,157 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { AnalyticsController } from './analytics.controller';
+import { AnalyticsService } from './analytics.service';
+import { TimePeriod, TokenAnalyticsResponseDto } from './dto/analytics.dto';
+
+// ─── Fixture ──────────────────────────────────────────────────────────────────
+
+const TOKEN = '0xtoken';
+
+function makeResponse(
+  period = TimePeriod.D7,
+): TokenAnalyticsResponseDto {
+  return {
+    tokenAddress: TOKEN,
+    period,
+    generatedAt: new Date().toISOString(),
+    totalBurned: '1000000',
+    totalBurnCount: 10,
+    allTimeUniqueBurners: 5,
+    largestBurn: '900000',
+    largestBurnTx: '0xabc',
+    stats24h: { volume: '100000', count: 1, uniqueBurners: 1 },
+    stats7d: { volume: '300000', count: 3, uniqueBurners: 2 },
+    stats30d: { volume: '700000', count: 7, uniqueBurners: 4 },
+    periodVolume: '300000',
+    periodBurnCount: 3,
+    periodUniqueBurners: 2,
+    averageBurnAmount: '100000',
+    burnFrequencyPerDay: 0.43,
+    volumeChangePercent: 25,
+    countChangePercent: 20,
+    timeSeries: [
+      { timestamp: '2024-01-01T00:00:00.000Z', value: '100000', count: 1 },
+    ],
+    burnTypeDistribution: {
+      self: '700000',
+      admin: '300000',
+      selfPercentage: 70,
+      adminPercentage: 30,
+    },
+  };
+}
+
+// ─── Suite ────────────────────────────────────────────────────────────────────
+
+describe('AnalyticsController', () => {
+  let controller: AnalyticsController;
+  let service: jest.Mocked<AnalyticsService>;
+
+  beforeEach(async () => {
+    const mockService: jest.Mocked<
+      Pick<AnalyticsService, 'getTokenAnalytics'>
+    > = {
+      getTokenAnalytics: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AnalyticsController],
+      providers: [
+        { provide: AnalyticsService, useValue: mockService },
+        { provide: CACHE_MANAGER, useValue: { get: jest.fn(), set: jest.fn() } },
+      ],
+    }).compile();
+
+    controller = module.get<AnalyticsController>(AnalyticsController);
+    service = module.get(AnalyticsService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // ── Happy path ──────────────────────────────────────────────────────────
+
+  it('calls service with address and default period', async () => {
+    service.getTokenAnalytics.mockResolvedValueOnce(makeResponse());
+    await controller.getTokenAnalytics(TOKEN, {});
+    expect(service.getTokenAnalytics).toHaveBeenCalledWith(
+      TOKEN,
+      TimePeriod.D7,
+    );
+  });
+
+  it('passes explicit period to service', async () => {
+    service.getTokenAnalytics.mockResolvedValueOnce(
+      makeResponse(TimePeriod.H24),
+    );
+    await controller.getTokenAnalytics(TOKEN, { period: TimePeriod.H24 });
+    expect(service.getTokenAnalytics).toHaveBeenCalledWith(
+      TOKEN,
+      TimePeriod.H24,
+    );
+  });
+
+  it('returns the service response unchanged', async () => {
+    const expected = makeResponse();
+    service.getTokenAnalytics.mockResolvedValueOnce(expected);
+    const result = await controller.getTokenAnalytics(TOKEN, {});
+    expect(result).toEqual(expected);
+  });
+
+  it.each([
+    TimePeriod.H24,
+    TimePeriod.D7,
+    TimePeriod.D30,
+    TimePeriod.D90,
+    TimePeriod.ALL,
+  ])('handles period %s', async (period) => {
+    service.getTokenAnalytics.mockResolvedValueOnce(makeResponse(period));
+    const result = await controller.getTokenAnalytics(TOKEN, { period });
+    expect(result.period).toBe(period);
+  });
+
+  // ── Error propagation ───────────────────────────────────────────────────
+
+  it('propagates NotFoundException from service', async () => {
+    service.getTokenAnalytics.mockRejectedValueOnce(
+      new NotFoundException('No data'),
+    );
+    await expect(
+      controller.getTokenAnalytics('0xunknown', {}),
+    ).rejects.toThrow(NotFoundException);
+  });
+
+  // ── Response shape ──────────────────────────────────────────────────────
+
+  it('response contains all required top-level keys', async () => {
+    service.getTokenAnalytics.mockResolvedValueOnce(makeResponse());
+    const result = await controller.getTokenAnalytics(TOKEN, {});
+
+    const requiredKeys: (keyof TokenAnalyticsResponseDto)[] = [
+      'tokenAddress',
+      'period',
+      'generatedAt',
+      'totalBurned',
+      'totalBurnCount',
+      'allTimeUniqueBurners',
+      'largestBurn',
+      'periodVolume',
+      'periodBurnCount',
+      'periodUniqueBurners',
+      'averageBurnAmount',
+      'burnFrequencyPerDay',
+      'volumeChangePercent',
+      'countChangePercent',
+      'timeSeries',
+      'burnTypeDistribution',
+      'stats24h',
+      'stats7d',
+      'stats30d',
+    ];
+
+    for (const key of requiredKeys) {
+      expect(result).toHaveProperty(key);
+    }
+  });
+});

--- a/backend/src/token-analytics/analytics.controller.ts
+++ b/backend/src/token-analytics/analytics.controller.ts
@@ -1,0 +1,81 @@
+import {
+  Controller,
+  Get,
+  Param,
+  Query,
+  UseInterceptors,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { CacheInterceptor, CacheTTL } from '@nestjs/cache-manager';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiParam,
+  ApiResponse,
+  ApiQuery,
+} from '@nestjs/swagger';
+import { AnalyticsService } from './analytics.service';
+import {
+  GetAnalyticsQueryDto,
+  TimePeriod,
+  TokenAnalyticsResponseDto,
+} from './dto/analytics.dto';
+
+@ApiTags('Analytics')
+@Controller('api/analytics')
+@UseInterceptors(CacheInterceptor)
+export class AnalyticsController {
+  constructor(private readonly analyticsService: AnalyticsService) {}
+
+  /**
+   * GET /api/analytics/:address
+   *
+   * Returns comprehensive burn analytics for a specific token.
+   * Results are cached per (address + period) combination.
+   *
+   * Cache TTL:
+   *  - 24h  → 2 min  (fast-moving data)
+   *  - 7d   → 5 min
+   *  - 30d  → 10 min
+   *  - 90d  → 15 min
+   *  - all  → 30 min (slow-moving data)
+   */
+  @Get(':address')
+  @HttpCode(HttpStatus.OK)
+  @CacheTTL(300) // default 5 min; see note above
+  @ApiOperation({
+    summary: 'Get token burn analytics',
+    description:
+      'Returns burn statistics, time-series data for charts, burn-type distribution, and comparison metrics for the requested time period.',
+  })
+  @ApiParam({
+    name: 'address',
+    description: 'Token contract address (EVM hex address)',
+    example: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+  })
+  @ApiQuery({
+    name: 'period',
+    required: false,
+    enum: TimePeriod,
+    description: 'Aggregation window (default: 7d)',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Analytics data for the token',
+    type: TokenAnalyticsResponseDto,
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'No burn data found for this token address',
+  })
+  async getTokenAnalytics(
+    @Param('address') address: string,
+    @Query() query: GetAnalyticsQueryDto,
+  ): Promise<TokenAnalyticsResponseDto> {
+    return this.analyticsService.getTokenAnalytics(
+      address,
+      query.period ?? TimePeriod.D7,
+    );
+  }
+}

--- a/backend/src/token-analytics/analytics.dto.ts
+++ b/backend/src/token-analytics/analytics.dto.ts
@@ -1,0 +1,75 @@
+import { IsEnum, IsOptional, IsEthereumAddress } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export enum TimePeriod {
+  H24 = '24h',
+  D7 = '7d',
+  D30 = '30d',
+  D90 = '90d',
+  ALL = 'all',
+}
+
+export class GetAnalyticsQueryDto {
+  @ApiPropertyOptional({
+    enum: TimePeriod,
+    default: TimePeriod.D7,
+    description: 'Time period for analytics data',
+  })
+  @IsOptional()
+  @IsEnum(TimePeriod)
+  period?: TimePeriod = TimePeriod.D7;
+}
+
+export class TimeSeriesDataPoint {
+  @ApiProperty() timestamp: string;
+  @ApiProperty() value: string;
+  @ApiProperty() count: number;
+}
+
+export class BurnTypeDistribution {
+  @ApiProperty() self: string;
+  @ApiProperty() admin: string;
+  @ApiProperty() selfPercentage: number;
+  @ApiProperty() adminPercentage: number;
+}
+
+export class PeriodStats {
+  @ApiProperty() volume: string;
+  @ApiProperty() count: number;
+  @ApiProperty() uniqueBurners: number;
+}
+
+export class TokenAnalyticsResponseDto {
+  @ApiProperty() tokenAddress: string;
+  @ApiProperty() period: TimePeriod;
+  @ApiProperty() generatedAt: string;
+
+  // All-time stats
+  @ApiProperty() totalBurned: string;
+  @ApiProperty() totalBurnCount: number;
+  @ApiProperty() allTimeUniqueBurners: number;
+  @ApiProperty() largestBurn: string;
+  @ApiProperty() largestBurnTx: string;
+
+  // Period stats
+  @ApiProperty({ type: PeriodStats }) stats24h: PeriodStats;
+  @ApiProperty({ type: PeriodStats }) stats7d: PeriodStats;
+  @ApiProperty({ type: PeriodStats }) stats30d: PeriodStats;
+
+  // Current period stats
+  @ApiProperty() periodVolume: string;
+  @ApiProperty() periodBurnCount: number;
+  @ApiProperty() periodUniqueBurners: number;
+  @ApiProperty() averageBurnAmount: string;
+  @ApiProperty() burnFrequencyPerDay: number;
+
+  // Comparison vs previous period
+  @ApiProperty() volumeChangePercent: number;
+  @ApiProperty() countChangePercent: number;
+
+  // Chart data
+  @ApiProperty({ type: [TimeSeriesDataPoint] }) timeSeries: TimeSeriesDataPoint[];
+
+  // Distribution
+  @ApiProperty({ type: BurnTypeDistribution }) burnTypeDistribution: BurnTypeDistribution;
+}

--- a/backend/src/token-analytics/analytics.e2e.spec.ts
+++ b/backend/src/token-analytics/analytics.e2e.spec.ts
@@ -1,0 +1,171 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import * as request from 'supertest';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { DataSource } from 'typeorm';
+import { AnalyticsModule } from './analytics.module';
+import { BurnEvent, BurnType } from './entities/burn-event.entity';
+import { TimePeriod } from './dto/analytics.dto';
+
+// ─── Stubs ────────────────────────────────────────────────────────────────────
+
+const TOKEN = '0xe2d3a739effcd3a99387d015e260eefac72ebea1';
+
+function buildDataSourceStub() {
+  let callIndex = 0;
+  const data = [
+    [{ totalVolume: '2000000', totalCount: 20, uniqueBurners: 8 }],
+    [{ volume: '500000', count: 5, uniqueBurners: 3 }],
+    [{ volume: '400000', count: 4, uniqueBurners: 2 }],
+    [{ volume: '200000', count: 2, uniqueBurners: 1 }],
+    [{ volume: '350000', count: 3, uniqueBurners: 2 }],
+    [{ volume: '450000', count: 4, uniqueBurners: 3 }],
+    [
+      {
+        ts: new Date(Date.now() - 86_400_000).toISOString(),
+        value: '100000',
+        count: 1,
+      },
+    ],
+    [
+      { burn_type: BurnType.SELF, volume: '350000', cnt: 3 },
+      { burn_type: BurnType.ADMIN, volume: '150000', cnt: 2 },
+    ],
+  ];
+  return {
+    query: jest.fn().mockImplementation(() => {
+      const result = data[callIndex] ?? [];
+      callIndex++;
+      return Promise.resolve(result);
+    }),
+  };
+}
+
+// ─── Suite ────────────────────────────────────────────────────────────────────
+
+describe('Analytics E2E', () => {
+  let app: INestApplication;
+  let dataSourceStub: ReturnType<typeof buildDataSourceStub>;
+  const repoStub = {
+    count: jest.fn().mockResolvedValue(20),
+    findOne: jest.fn().mockResolvedValue({ amount: '900000', txHash: '0xabc' }),
+  };
+  const cacheStub = { get: jest.fn(), set: jest.fn(), del: jest.fn() };
+
+  beforeAll(async () => {
+    dataSourceStub = buildDataSourceStub();
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AnalyticsModule],
+    })
+      .overrideProvider(getRepositoryToken(BurnEvent))
+      .useValue(repoStub)
+      .overrideProvider(DataSource)
+      .useValue(dataSourceStub)
+      .overrideProvider(CACHE_MANAGER)
+      .useValue(cacheStub)
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(new ValidationPipe({ transform: true, whitelist: true }));
+    await app.init();
+  });
+
+  afterAll(() => app.close());
+
+  // ── 200 responses ────────────────────────────────────────────────────────
+
+  it('GET /api/analytics/:address → 200 with default period', async () => {
+    const res = await request(app.getHttpServer())
+      .get(`/api/analytics/${TOKEN}`)
+      .expect(200);
+
+    expect(res.body.tokenAddress).toBe(TOKEN);
+    expect(res.body.period).toBe(TimePeriod.D7);
+    expect(Array.isArray(res.body.timeSeries)).toBe(true);
+    expect(res.body.burnTypeDistribution).toBeDefined();
+    expect(res.body.stats24h).toBeDefined();
+  });
+
+  it('GET /api/analytics/:address?period=24h → 200', async () => {
+    // Re-create stub for fresh call counts
+    const module = await Test.createTestingModule({
+      imports: [AnalyticsModule],
+    })
+      .overrideProvider(getRepositoryToken(BurnEvent))
+      .useValue({ ...repoStub })
+      .overrideProvider(DataSource)
+      .useValue(buildDataSourceStub())
+      .overrideProvider(CACHE_MANAGER)
+      .useValue(cacheStub)
+      .compile();
+
+    const localApp = module.createNestApplication();
+    localApp.useGlobalPipes(
+      new ValidationPipe({ transform: true, whitelist: true }),
+    );
+    await localApp.init();
+
+    const res = await request(localApp.getHttpServer())
+      .get(`/api/analytics/${TOKEN}?period=24h`)
+      .expect(200);
+
+    expect(res.body.period).toBe(TimePeriod.H24);
+    await localApp.close();
+  });
+
+  // ── 404 response ─────────────────────────────────────────────────────────
+
+  it('GET /api/analytics/:address → 404 when no burns exist', async () => {
+    const module = await Test.createTestingModule({
+      imports: [AnalyticsModule],
+    })
+      .overrideProvider(getRepositoryToken(BurnEvent))
+      .useValue({ count: jest.fn().mockResolvedValue(0), findOne: jest.fn() })
+      .overrideProvider(DataSource)
+      .useValue(buildDataSourceStub())
+      .overrideProvider(CACHE_MANAGER)
+      .useValue(cacheStub)
+      .compile();
+
+    const localApp = module.createNestApplication();
+    localApp.useGlobalPipes(
+      new ValidationPipe({ transform: true, whitelist: true }),
+    );
+    await localApp.init();
+
+    await request(localApp.getHttpServer())
+      .get('/api/analytics/0xunknown')
+      .expect(404);
+
+    await localApp.close();
+  });
+
+  // ── Validation ────────────────────────────────────────────────────────────
+
+  it('GET /api/analytics/:address?period=invalid → 400', async () => {
+    const module = await Test.createTestingModule({
+      imports: [AnalyticsModule],
+    })
+      .overrideProvider(getRepositoryToken(BurnEvent))
+      .useValue(repoStub)
+      .overrideProvider(DataSource)
+      .useValue(buildDataSourceStub())
+      .overrideProvider(CACHE_MANAGER)
+      .useValue(cacheStub)
+      .compile();
+
+    const localApp = module.createNestApplication();
+    localApp.useGlobalPipes(
+      new ValidationPipe({ transform: true, whitelist: true }),
+    );
+    await localApp.init();
+
+    await request(localApp.getHttpServer())
+      .get(`/api/analytics/${TOKEN}?period=bad_value`)
+      .expect(400);
+
+    await localApp.close();
+  });
+});

--- a/backend/src/token-analytics/analytics.module.ts
+++ b/backend/src/token-analytics/analytics.module.ts
@@ -1,0 +1,20 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { CacheModule } from '@nestjs/cache-manager';
+import { AnalyticsController } from './analytics.controller';
+import { AnalyticsService } from './analytics.service';
+import { BurnEvent } from './entities/burn-event.entity';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([BurnEvent]),
+    CacheModule.register({
+      ttl: 300, // 5 minutes default
+      max: 100,
+    }),
+  ],
+  controllers: [AnalyticsController],
+  providers: [AnalyticsService],
+  exports: [AnalyticsService],
+})
+export class AnalyticsModule {}

--- a/backend/src/token-analytics/analytics.service.spec.ts
+++ b/backend/src/token-analytics/analytics.service.spec.ts
@@ -1,0 +1,258 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { NotFoundException } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import { AnalyticsService } from './analytics.service';
+import { BurnEvent, BurnType } from './entities/burn-event.entity';
+import { TimePeriod } from './dto/analytics.dto';
+
+// ─── Shared fixtures ─────────────────────────────────────────────────────────
+
+const TOKEN = '0xtoken123';
+
+const makeAllTimeRow = (overrides = {}) => ({
+  totalVolume: '1000000',
+  totalCount: 10,
+  uniqueBurners: 5,
+  ...overrides,
+});
+
+const makePeriodRow = (overrides = {}) => ({
+  volume: '500000',
+  count: 5,
+  uniqueBurners: 3,
+  ...overrides,
+});
+
+const makeBurnTypeRows = () => [
+  { burn_type: BurnType.SELF, volume: '700000', cnt: 7 },
+  { burn_type: BurnType.ADMIN, volume: '300000', cnt: 3 },
+];
+
+const makeTimeSeriesRows = () => [
+  {
+    ts: '2024-01-01 00:00:00+00',
+    value: '100000',
+    count: 1,
+  },
+];
+
+const makeLargestBurn = (): Partial<BurnEvent> => ({
+  amount: '900000',
+  txHash: '0xabc',
+});
+
+// ─── Test helpers ─────────────────────────────────────────────────────────────
+
+function buildQueryMock(
+  overrides: Partial<Record<number, unknown[]>> = {},
+): jest.Mock {
+  // The service calls dataSource.query multiple times; we match by call order.
+  let callIndex = 0;
+  const defaults: unknown[][] = [
+    [makeAllTimeRow()],          // 0 – getAllTimeStats
+    [makePeriodRow()],            // 1 – getPeriodStats (current)
+    [makePeriodRow({ volume: '400000', count: 4, uniqueBurners: 2 })], // 2 – getPeriodStats (prev)
+    [makePeriodRow({ volume: '200000', count: 2 })],  // 3 – stats24h
+    [makePeriodRow({ volume: '350000', count: 3 })],  // 4 – stats7d
+    [makePeriodRow({ volume: '450000', count: 4 })],  // 5 – stats30d
+    makeTimeSeriesRows(),                              // 6 – timeSeries
+    makeBurnTypeRows(),                                // 7 – burnTypeDistribution
+  ];
+
+  return jest.fn().mockImplementation(() => {
+    const result = overrides[callIndex] ?? defaults[callIndex] ?? [];
+    callIndex++;
+    return Promise.resolve(result);
+  });
+}
+
+// ─── Suite ───────────────────────────────────────────────────────────────────
+
+describe('AnalyticsService', () => {
+  let service: AnalyticsService;
+  let queryMock: jest.Mock;
+
+  const mockRepo = {
+    count: jest.fn(),
+    findOne: jest.fn(),
+  };
+
+  const mockDataSource = {
+    query: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    queryMock = buildQueryMock();
+    mockDataSource.query = queryMock;
+    mockRepo.count.mockResolvedValue(10);
+    mockRepo.findOne.mockResolvedValue(makeLargestBurn());
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AnalyticsService,
+        { provide: getRepositoryToken(BurnEvent), useValue: mockRepo },
+        { provide: DataSource, useValue: mockDataSource },
+      ],
+    }).compile();
+
+    service = module.get<AnalyticsService>(AnalyticsService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // ── Existence check ─────────────────────────────────────────────────────
+
+  it('throws NotFoundException when no burns exist for token', async () => {
+    mockRepo.count.mockResolvedValueOnce(0);
+    await expect(
+      service.getTokenAnalytics(TOKEN, TimePeriod.D7),
+    ).rejects.toThrow(NotFoundException);
+  });
+
+  // ── Happy-path shape ────────────────────────────────────────────────────
+
+  it('returns a well-shaped analytics response for 7d period', async () => {
+    const result = await service.getTokenAnalytics(TOKEN, TimePeriod.D7);
+
+    expect(result.tokenAddress).toBe(TOKEN);
+    expect(result.period).toBe(TimePeriod.D7);
+    expect(result.totalBurned).toBe('1000000');
+    expect(result.totalBurnCount).toBe(10);
+    expect(result.allTimeUniqueBurners).toBe(5);
+    expect(result.largestBurn).toBe('900000');
+    expect(result.largestBurnTx).toBe('0xabc');
+    expect(result.periodVolume).toBe('500000');
+    expect(result.periodBurnCount).toBe(5);
+    expect(result.periodUniqueBurners).toBe(3);
+    expect(result.averageBurnAmount).toBe('100000');
+    expect(typeof result.burnFrequencyPerDay).toBe('number');
+    expect(Array.isArray(result.timeSeries)).toBe(true);
+    expect(result.generatedAt).toBeTruthy();
+  });
+
+  // ── Period variations ───────────────────────────────────────────────────
+
+  it.each([
+    TimePeriod.H24,
+    TimePeriod.D7,
+    TimePeriod.D30,
+    TimePeriod.D90,
+    TimePeriod.ALL,
+  ])('resolves without error for period %s', async (period) => {
+    queryMock = buildQueryMock();
+    mockDataSource.query = queryMock;
+    await expect(
+      service.getTokenAnalytics(TOKEN, period),
+    ).resolves.toBeDefined();
+  });
+
+  // ── Comparison metrics ──────────────────────────────────────────────────
+
+  it('calculates positive volumeChangePercent when current > previous', async () => {
+    // current=500000, prev=400000 → +25 %
+    const result = await service.getTokenAnalytics(TOKEN, TimePeriod.D7);
+    expect(result.volumeChangePercent).toBeCloseTo(25, 1);
+  });
+
+  it('returns 100 volumeChangePercent when previous period has zero volume', async () => {
+    mockDataSource.query = buildQueryMock({
+      2: [{ volume: '0', count: 0, uniqueBurners: 0 }],
+    });
+    const result = await service.getTokenAnalytics(TOKEN, TimePeriod.D7);
+    expect(result.volumeChangePercent).toBe(100);
+  });
+
+  it('returns 0 changePercent when both periods are zero', async () => {
+    mockDataSource.query = buildQueryMock({
+      1: [{ volume: '0', count: 0, uniqueBurners: 0 }],
+      2: [{ volume: '0', count: 0, uniqueBurners: 0 }],
+    });
+    const result = await service.getTokenAnalytics(TOKEN, TimePeriod.D7);
+    expect(result.volumeChangePercent).toBe(0);
+  });
+
+  // ── averageBurnAmount ───────────────────────────────────────────────────
+
+  it('returns 0 for averageBurnAmount when count is zero', async () => {
+    mockDataSource.query = buildQueryMock({
+      1: [{ volume: '0', count: 0, uniqueBurners: 0 }],
+    });
+    const result = await service.getTokenAnalytics(TOKEN, TimePeriod.D7);
+    expect(result.averageBurnAmount).toBe('0');
+  });
+
+  // ── Burn-type distribution ──────────────────────────────────────────────
+
+  it('calculates burn type distribution percentages correctly', async () => {
+    const result = await service.getTokenAnalytics(TOKEN, TimePeriod.D7);
+    const dist = result.burnTypeDistribution;
+
+    expect(dist.self).toBe('700000');
+    expect(dist.admin).toBe('300000');
+    expect(dist.selfPercentage).toBe(70);
+    expect(dist.adminPercentage).toBe(30);
+    expect(dist.selfPercentage + dist.adminPercentage).toBe(100);
+  });
+
+  it('handles zero total volume in burn type distribution', async () => {
+    mockDataSource.query = buildQueryMock({
+      7: [
+        { burn_type: BurnType.SELF, volume: '0', cnt: 0 },
+        { burn_type: BurnType.ADMIN, volume: '0', cnt: 0 },
+      ],
+    });
+    const result = await service.getTokenAnalytics(TOKEN, TimePeriod.D7);
+    expect(result.burnTypeDistribution.selfPercentage).toBe(0);
+    expect(result.burnTypeDistribution.adminPercentage).toBe(0);
+  });
+
+  it('handles missing burn types gracefully (only self burns exist)', async () => {
+    mockDataSource.query = buildQueryMock({
+      7: [{ burn_type: BurnType.SELF, volume: '500000', cnt: 5 }],
+    });
+    const result = await service.getTokenAnalytics(TOKEN, TimePeriod.D7);
+    expect(result.burnTypeDistribution.admin).toBe('0');
+    expect(result.burnTypeDistribution.adminPercentage).toBe(0);
+  });
+
+  // ── Time series ─────────────────────────────────────────────────────────
+
+  it('returns timeSeries as an array of TimeSeriesDataPoint objects', async () => {
+    const result = await service.getTokenAnalytics(TOKEN, TimePeriod.D7);
+    expect(result.timeSeries.length).toBeGreaterThan(0);
+    for (const point of result.timeSeries) {
+      expect(point).toHaveProperty('timestamp');
+      expect(point).toHaveProperty('value');
+      expect(point).toHaveProperty('count');
+    }
+  });
+
+  it('fills zero-value gaps in time series', async () => {
+    // Return only 1 data point for a 7d window (should have 7 points)
+    mockDataSource.query = buildQueryMock({
+      6: makeTimeSeriesRows(),
+    });
+    const result = await service.getTokenAnalytics(TOKEN, TimePeriod.D7);
+    const zeros = result.timeSeries.filter((p) => p.value === '0');
+    expect(zeros.length).toBeGreaterThan(0);
+  });
+
+  // ── Address normalisation ───────────────────────────────────────────────
+
+  it('normalises the token address to lowercase before querying', async () => {
+    const upper = '0xTOKEN123';
+    await service.getTokenAnalytics(upper, TimePeriod.D7);
+    const firstQueryArgs = mockRepo.count.mock.calls[0][0];
+    expect(firstQueryArgs.where.tokenAddress).toBe(upper.toLowerCase());
+  });
+
+  // ── Fixed-window stats ──────────────────────────────────────────────────
+
+  it('returns stats24h, stats7d, stats30d on the response', async () => {
+    const result = await service.getTokenAnalytics(TOKEN, TimePeriod.D7);
+    expect(result.stats24h).toHaveProperty('volume');
+    expect(result.stats7d).toHaveProperty('count');
+    expect(result.stats30d).toHaveProperty('uniqueBurners');
+  });
+});

--- a/backend/src/token-analytics/analytics.service.ts
+++ b/backend/src/token-analytics/analytics.service.ts
@@ -1,0 +1,370 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, DataSource } from 'typeorm';
+import { BurnEvent, BurnType } from './entities/burn-event.entity';
+import {
+  TimePeriod,
+  TokenAnalyticsResponseDto,
+  TimeSeriesDataPoint,
+  PeriodStats,
+} from './dto/analytics.dto';
+
+interface PeriodWindow {
+  start: Date;
+  end: Date;
+  granularity: 'hour' | 'day' | 'week' | 'month';
+  intervalCount: number;
+}
+
+@Injectable()
+export class AnalyticsService {
+  constructor(
+    @InjectRepository(BurnEvent)
+    private readonly burnRepo: Repository<BurnEvent>,
+    private readonly dataSource: DataSource,
+  ) {}
+
+  // ──────────────────────────────────────────────
+  // Public API
+  // ──────────────────────────────────────────────
+
+  async getTokenAnalytics(
+    tokenAddress: string,
+    period: TimePeriod,
+  ): Promise<TokenAnalyticsResponseDto> {
+    const normalizedAddress = tokenAddress.toLowerCase();
+
+    // Verify token has any burns at all
+    const exists = await this.burnRepo.count({
+      where: { tokenAddress: normalizedAddress },
+    });
+    if (exists === 0) {
+      throw new NotFoundException(
+        `No burn data found for token ${tokenAddress}`,
+      );
+    }
+
+    const window = this.getPeriodWindow(period);
+    const prevWindow = this.getPreviousWindow(window);
+
+    const [
+      allTimeStats,
+      periodBurns,
+      prevPeriodBurns,
+      stats24h,
+      stats7d,
+      stats30d,
+      timeSeries,
+      burnTypeDistribution,
+      largestBurnRow,
+    ] = await Promise.all([
+      this.getAllTimeStats(normalizedAddress),
+      this.getPeriodStats(normalizedAddress, window.start, window.end),
+      this.getPeriodStats(normalizedAddress, prevWindow.start, prevWindow.end),
+      this.getPeriodStats(
+        normalizedAddress,
+        this.hoursAgo(24),
+        new Date(),
+      ),
+      this.getPeriodStats(
+        normalizedAddress,
+        this.daysAgo(7),
+        new Date(),
+      ),
+      this.getPeriodStats(
+        normalizedAddress,
+        this.daysAgo(30),
+        new Date(),
+      ),
+      this.buildTimeSeries(normalizedAddress, window),
+      this.getBurnTypeDistribution(normalizedAddress, window.start, window.end),
+      this.getLargestBurn(normalizedAddress),
+    ]);
+
+    const volumeChangePercent = this.calcChangePercent(
+      BigInt(prevPeriodBurns.volume),
+      BigInt(periodBurns.volume),
+    );
+    const countChangePercent = this.calcChangePercent(
+      BigInt(prevPeriodBurns.count),
+      BigInt(periodBurns.count),
+    );
+
+    const durationDays = this.windowDurationDays(window);
+    const burnFrequencyPerDay =
+      durationDays > 0
+        ? Math.round((periodBurns.count / durationDays) * 100) / 100
+        : 0;
+
+    const averageBurnAmount =
+      periodBurns.count > 0
+        ? (BigInt(periodBurns.volume) / BigInt(periodBurns.count)).toString()
+        : '0';
+
+    return {
+      tokenAddress,
+      period,
+      generatedAt: new Date().toISOString(),
+
+      // All-time
+      totalBurned: allTimeStats.totalVolume,
+      totalBurnCount: allTimeStats.totalCount,
+      allTimeUniqueBurners: allTimeStats.uniqueBurners,
+      largestBurn: largestBurnRow?.amount ?? '0',
+      largestBurnTx: largestBurnRow?.txHash ?? '',
+
+      // Fixed-window stats
+      stats24h,
+      stats7d,
+      stats30d,
+
+      // Current period
+      periodVolume: periodBurns.volume,
+      periodBurnCount: periodBurns.count,
+      periodUniqueBurners: periodBurns.uniqueBurners,
+      averageBurnAmount,
+      burnFrequencyPerDay,
+
+      // Comparison
+      volumeChangePercent,
+      countChangePercent,
+
+      // Chart
+      timeSeries,
+      burnTypeDistribution,
+    };
+  }
+
+  // ──────────────────────────────────────────────
+  // Query helpers
+  // ──────────────────────────────────────────────
+
+  private async getAllTimeStats(tokenAddress: string) {
+    const row = await this.dataSource.query(
+      `SELECT
+         COALESCE(SUM(amount::numeric), 0)::text AS "totalVolume",
+         COUNT(*)::int                           AS "totalCount",
+         COUNT(DISTINCT burner_address)::int     AS "uniqueBurners"
+       FROM burn_events
+       WHERE token_address = $1`,
+      [tokenAddress],
+    );
+    return row[0] as {
+      totalVolume: string;
+      totalCount: number;
+      uniqueBurners: number;
+    };
+  }
+
+  private async getPeriodStats(
+    tokenAddress: string,
+    start: Date,
+    end: Date,
+  ): Promise<PeriodStats> {
+    const row = await this.dataSource.query(
+      `SELECT
+         COALESCE(SUM(amount::numeric), 0)::text AS volume,
+         COUNT(*)::int                           AS count,
+         COUNT(DISTINCT burner_address)::int     AS "uniqueBurners"
+       FROM burn_events
+       WHERE token_address = $1
+         AND burned_at >= $2
+         AND burned_at < $3`,
+      [tokenAddress, start, end],
+    );
+    return row[0] as PeriodStats;
+  }
+
+  private async getLargestBurn(
+    tokenAddress: string,
+  ): Promise<BurnEvent | null> {
+    return this.burnRepo.findOne({
+      where: { tokenAddress },
+      order: { amount: 'DESC' } as any,
+    });
+  }
+
+  private async getBurnTypeDistribution(
+    tokenAddress: string,
+    start: Date,
+    end: Date,
+  ) {
+    const rows: { burn_type: BurnType; volume: string; cnt: number }[] =
+      await this.dataSource.query(
+        `SELECT
+           burn_type,
+           COALESCE(SUM(amount::numeric), 0)::text AS volume,
+           COUNT(*)::int AS cnt
+         FROM burn_events
+         WHERE token_address = $1
+           AND burned_at >= $2
+           AND burned_at < $3
+         GROUP BY burn_type`,
+        [tokenAddress, start, end],
+      );
+
+    const byType = (type: BurnType) =>
+      rows.find((r) => r.burn_type === type) ?? { volume: '0', cnt: 0 };
+
+    const selfRow = byType(BurnType.SELF);
+    const adminRow = byType(BurnType.ADMIN);
+
+    const totalVolume =
+      BigInt(selfRow.volume) + BigInt(adminRow.volume);
+
+    const pct = (v: bigint) =>
+      totalVolume === 0n
+        ? 0
+        : Math.round(Number((v * 10000n) / totalVolume) / 100);
+
+    return {
+      self: selfRow.volume,
+      admin: adminRow.volume,
+      selfPercentage: pct(BigInt(selfRow.volume)),
+      adminPercentage: pct(BigInt(adminRow.volume)),
+    };
+  }
+
+  private async buildTimeSeries(
+    tokenAddress: string,
+    window: PeriodWindow,
+  ): Promise<TimeSeriesDataPoint[]> {
+    const pgTrunc = {
+      hour: 'hour',
+      day: 'day',
+      week: 'week',
+      month: 'month',
+    }[window.granularity];
+
+    const rows: { ts: string; value: string; count: number }[] =
+      await this.dataSource.query(
+        `SELECT
+           DATE_TRUNC('${pgTrunc}', burned_at)::text AS ts,
+           COALESCE(SUM(amount::numeric), 0)::text   AS value,
+           COUNT(*)::int                             AS count
+         FROM burn_events
+         WHERE token_address = $1
+           AND burned_at >= $2
+           AND burned_at < $3
+         GROUP BY DATE_TRUNC('${pgTrunc}', burned_at)
+         ORDER BY ts ASC`,
+        [tokenAddress, window.start, window.end],
+      );
+
+    // Fill gaps so the chart has a complete series
+    return this.fillTimeSeriesGaps(rows, window);
+  }
+
+  private fillTimeSeriesGaps(
+    rows: { ts: string; value: string; count: number }[],
+    window: PeriodWindow,
+  ): TimeSeriesDataPoint[] {
+    const map = new Map(rows.map((r) => [r.ts.slice(0, 16), r]));
+    const result: TimeSeriesDataPoint[] = [];
+
+    const cursor = new Date(window.start);
+    while (cursor < window.end) {
+      const key = cursor.toISOString().slice(0, 16);
+      const row = map.get(key);
+      result.push({
+        timestamp: cursor.toISOString(),
+        value: row?.value ?? '0',
+        count: row?.count ?? 0,
+      });
+      this.advanceCursor(cursor, window.granularity);
+    }
+
+    return result;
+  }
+
+  // ──────────────────────────────────────────────
+  // Time-window utilities
+  // ──────────────────────────────────────────────
+
+  private getPeriodWindow(period: TimePeriod): PeriodWindow {
+    const now = new Date();
+    switch (period) {
+      case TimePeriod.H24:
+        return {
+          start: this.hoursAgo(24),
+          end: now,
+          granularity: 'hour',
+          intervalCount: 24,
+        };
+      case TimePeriod.D7:
+        return {
+          start: this.daysAgo(7),
+          end: now,
+          granularity: 'day',
+          intervalCount: 7,
+        };
+      case TimePeriod.D30:
+        return {
+          start: this.daysAgo(30),
+          end: now,
+          granularity: 'day',
+          intervalCount: 30,
+        };
+      case TimePeriod.D90:
+        return {
+          start: this.daysAgo(90),
+          end: now,
+          granularity: 'week',
+          intervalCount: 13,
+        };
+      case TimePeriod.ALL:
+      default:
+        return {
+          start: new Date('2020-01-01'),
+          end: now,
+          granularity: 'month',
+          intervalCount: 0,
+        };
+    }
+  }
+
+  private getPreviousWindow(window: PeriodWindow): PeriodWindow {
+    const duration = window.end.getTime() - window.start.getTime();
+    return {
+      start: new Date(window.start.getTime() - duration),
+      end: window.start,
+      granularity: window.granularity,
+      intervalCount: window.intervalCount,
+    };
+  }
+
+  private windowDurationDays(window: PeriodWindow): number {
+    return (window.end.getTime() - window.start.getTime()) / 86_400_000;
+  }
+
+  private hoursAgo(h: number): Date {
+    return new Date(Date.now() - h * 3_600_000);
+  }
+
+  private daysAgo(d: number): Date {
+    return new Date(Date.now() - d * 86_400_000);
+  }
+
+  private advanceCursor(d: Date, granularity: PeriodWindow['granularity']) {
+    switch (granularity) {
+      case 'hour':
+        d.setHours(d.getHours() + 1);
+        break;
+      case 'day':
+        d.setDate(d.getDate() + 1);
+        break;
+      case 'week':
+        d.setDate(d.getDate() + 7);
+        break;
+      case 'month':
+        d.setMonth(d.getMonth() + 1);
+        break;
+    }
+  }
+
+  private calcChangePercent(prev: bigint, curr: bigint): number {
+    if (prev === 0n) return curr > 0n ? 100 : 0;
+    const change = Number(((curr - prev) * 10000n) / prev) / 100;
+    return Math.round(change * 100) / 100;
+  }
+}

--- a/backend/src/token-analytics/burn-event.entity.ts
+++ b/backend/src/token-analytics/burn-event.entity.ts
@@ -1,0 +1,47 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+
+export enum BurnType {
+  SELF = 'self',
+  ADMIN = 'admin',
+}
+
+@Entity('burn_events')
+@Index(['tokenAddress', 'burnedAt'])
+@Index(['tokenAddress', 'burner'])
+export class BurnEvent {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'token_address' })
+  @Index()
+  tokenAddress: string;
+
+  @Column({ name: 'burner_address' })
+  burner: string;
+
+  @Column({ type: 'numeric', precision: 78, scale: 0, name: 'amount' })
+  amount: string;
+
+  @Column({
+    type: 'enum',
+    enum: BurnType,
+    default: BurnType.SELF,
+    name: 'burn_type',
+  })
+  burnType: BurnType;
+
+  @Column({ name: 'transaction_hash', nullable: true })
+  txHash: string;
+
+  @Column({ name: 'block_number', type: 'bigint', nullable: true })
+  blockNumber: string;
+
+  @CreateDateColumn({ name: 'burned_at' })
+  burnedAt: Date;
+}


### PR DESCRIPTION
- Create migration for burn_events table and associated enum type.
- Add AnalyticsController to handle token burn analytics requests.
- Implement AnalyticsService to process analytics data for tokens.
- Define DTOs for analytics response and query parameters.
- Create unit and end-to-end tests for analytics functionality.
- Add caching to improve performance of analytics queries.
- Implement burn event entity with necessary fields and indexes.
-
Closes #176 