### PR TITLE
feat(burn-history): implement burn transaction history feature with D…

### DIFF
--- a/backend/src/burn-history/1700000000000-CreateBurnTransactions.ts
+++ b/backend/src/burn-history/1700000000000-CreateBurnTransactions.ts
@@ -1,0 +1,101 @@
+import { MigrationInterface, QueryRunner, Table, TableIndex } from 'typeorm';
+
+export class CreateBurnTransactions1700000000000 implements MigrationInterface {
+  name = 'CreateBurnTransactions1700000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TYPE "burn_transactions_type_enum" AS ENUM ('self', 'admin')
+    `);
+
+    await queryRunner.createTable(
+      new Table({
+        name: 'burn_transactions',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'uuid_generate_v4()',
+          },
+          {
+            name: 'token_address',
+            type: 'varchar',
+            length: '100',
+          },
+          {
+            name: 'amount',
+            type: 'decimal',
+            precision: 36,
+            scale: 18,
+          },
+          {
+            name: 'from',
+            type: 'varchar',
+            length: '100',
+          },
+          {
+            name: 'type',
+            type: 'enum',
+            enum: ['self', 'admin'],
+            default: "'self'",
+          },
+          {
+            name: 'transaction_hash',
+            type: 'varchar',
+            length: '100',
+            isUnique: true,
+          },
+          {
+            name: 'block_number',
+            type: 'bigint',
+            isNullable: true,
+          },
+          {
+            name: 'timestamp',
+            type: 'timestamp with time zone',
+          },
+          {
+            name: 'created_at',
+            type: 'timestamp with time zone',
+            default: 'now()',
+          },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createIndex(
+      'burn_transactions',
+      new TableIndex({
+        name: 'IDX_BURN_TOKEN_TIMESTAMP',
+        columnNames: ['token_address', 'timestamp'],
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'burn_transactions',
+      new TableIndex({
+        name: 'IDX_BURN_TOKEN_TYPE',
+        columnNames: ['token_address', 'type'],
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'burn_transactions',
+      new TableIndex({
+        name: 'IDX_BURN_TIMESTAMP',
+        columnNames: ['timestamp'],
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropIndex('burn_transactions', 'IDX_BURN_TOKEN_TIMESTAMP');
+    await queryRunner.dropIndex('burn_transactions', 'IDX_BURN_TOKEN_TYPE');
+    await queryRunner.dropIndex('burn_transactions', 'IDX_BURN_TIMESTAMP');
+    await queryRunner.dropTable('burn_transactions');
+    await queryRunner.query(`DROP TYPE "burn_transactions_type_enum"`);
+  }
+}

--- a/backend/src/burn-history/burn-history-query.dto.spec.ts
+++ b/backend/src/burn-history/burn-history-query.dto.spec.ts
@@ -1,0 +1,111 @@
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import { BurnHistoryQueryDto, BurnType, SortBy, SortOrder } from './dto/burn-history-query.dto';
+
+async function validateDto(plain: Record<string, unknown>) {
+  const dto = plainToInstance(BurnHistoryQueryDto, plain);
+  return validate(dto);
+}
+
+describe('BurnHistoryQueryDto', () => {
+  it('should pass validation with no params (all optional)', async () => {
+    const errors = await validateDto({});
+    expect(errors).toHaveLength(0);
+  });
+
+  it('should pass with valid tokenAddress', async () => {
+    const errors = await validateDto({ tokenAddress: '0xabc123' });
+    expect(errors).toHaveLength(0);
+  });
+
+  it('should pass with valid type values', async () => {
+    for (const type of [BurnType.ALL, BurnType.SELF, BurnType.ADMIN]) {
+      const errors = await validateDto({ type });
+      expect(errors).toHaveLength(0);
+    }
+  });
+
+  it('should fail with invalid type', async () => {
+    const errors = await validateDto({ type: 'invalid' });
+    expect(errors.some((e) => e.property === 'type')).toBe(true);
+  });
+
+  it('should pass with valid ISO date strings', async () => {
+    const errors = await validateDto({
+      startDate: '2024-01-01T00:00:00Z',
+      endDate: '2024-12-31T23:59:59Z',
+    });
+    expect(errors).toHaveLength(0);
+  });
+
+  it('should fail with invalid date format', async () => {
+    const errors = await validateDto({ startDate: 'not-a-date' });
+    expect(errors.some((e) => e.property === 'startDate')).toBe(true);
+  });
+
+  it('should pass with valid page and limit', async () => {
+    const errors = await validateDto({ page: '2', limit: '20' });
+    expect(errors).toHaveLength(0);
+  });
+
+  it('should fail with page < 1', async () => {
+    const errors = await validateDto({ page: '0' });
+    expect(errors.some((e) => e.property === 'page')).toBe(true);
+  });
+
+  it('should fail with limit > 100', async () => {
+    const errors = await validateDto({ limit: '101' });
+    expect(errors.some((e) => e.property === 'limit')).toBe(true);
+  });
+
+  it('should fail with limit < 1', async () => {
+    const errors = await validateDto({ limit: '0' });
+    expect(errors.some((e) => e.property === 'limit')).toBe(true);
+  });
+
+  it('should pass with valid sortBy values', async () => {
+    for (const sortBy of [SortBy.TIMESTAMP, SortBy.AMOUNT, SortBy.FROM]) {
+      const errors = await validateDto({ sortBy });
+      expect(errors).toHaveLength(0);
+    }
+  });
+
+  it('should fail with invalid sortBy', async () => {
+    const errors = await validateDto({ sortBy: 'invalid' });
+    expect(errors.some((e) => e.property === 'sortBy')).toBe(true);
+  });
+
+  it('should pass with valid sortOrder values', async () => {
+    for (const sortOrder of [SortOrder.ASC, SortOrder.DESC]) {
+      const errors = await validateDto({ sortOrder });
+      expect(errors).toHaveLength(0);
+    }
+  });
+
+  it('should fail with invalid sortOrder', async () => {
+    const errors = await validateDto({ sortOrder: 'random' });
+    expect(errors.some((e) => e.property === 'sortOrder')).toBe(true);
+  });
+
+  it('should transform page and limit to numbers via @Type', async () => {
+    const dto = plainToInstance(BurnHistoryQueryDto, { page: '3', limit: '25' });
+    expect(typeof dto.page).toBe('number');
+    expect(typeof dto.limit).toBe('number');
+    expect(dto.page).toBe(3);
+    expect(dto.limit).toBe(25);
+  });
+
+  it('should pass full valid query', async () => {
+    const errors = await validateDto({
+      tokenAddress: '0xAbcDef1234567890',
+      type: BurnType.ADMIN,
+      startDate: '2024-01-01T00:00:00.000Z',
+      endDate: '2024-06-30T23:59:59.999Z',
+      page: '1',
+      limit: '50',
+      sortBy: SortBy.AMOUNT,
+      sortOrder: SortOrder.ASC,
+    });
+    expect(errors).toHaveLength(0);
+  });
+});

--- a/backend/src/burn-history/burn-history-query.dto.ts
+++ b/backend/src/burn-history/burn-history-query.dto.ts
@@ -1,0 +1,58 @@
+import { IsOptional, IsString, IsEnum, IsDateString, IsInt, Min, Max } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export enum BurnType {
+  ALL = 'all',
+  SELF = 'self',
+  ADMIN = 'admin',
+}
+
+export enum SortBy {
+  TIMESTAMP = 'timestamp',
+  AMOUNT = 'amount',
+  FROM = 'from',
+}
+
+export enum SortOrder {
+  ASC = 'asc',
+  DESC = 'desc',
+}
+
+export class BurnHistoryQueryDto {
+  @IsOptional()
+  @IsString()
+  tokenAddress?: string;
+
+  @IsOptional()
+  @IsEnum(BurnType)
+  type?: BurnType = BurnType.ALL;
+
+  @IsOptional()
+  @IsDateString()
+  startDate?: string;
+
+  @IsOptional()
+  @IsDateString()
+  endDate?: string;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 10;
+
+  @IsOptional()
+  @IsEnum(SortBy)
+  sortBy?: SortBy = SortBy.TIMESTAMP;
+
+  @IsOptional()
+  @IsEnum(SortOrder)
+  sortOrder?: SortOrder = SortOrder.DESC;
+}

--- a/backend/src/burn-history/burn-history.controller.spec.ts
+++ b/backend/src/burn-history/burn-history.controller.spec.ts
@@ -1,0 +1,104 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BurnHistoryController } from './burn-history.controller';
+import { BurnHistoryService } from './burn-history.service';
+import { BurnHistoryQueryDto, BurnType, SortBy, SortOrder } from './dto/burn-history-query.dto';
+import { BurnHistoryResponse } from './interfaces/burn-history.interface';
+
+const mockResponse: BurnHistoryResponse = {
+  success: true,
+  data: [
+    {
+      id: 'uuid-1',
+      tokenAddress: '0xToken',
+      amount: '1000',
+      from: '0xFrom',
+      type: 'self',
+      transactionHash: '0xHash',
+      blockNumber: '100',
+      timestamp: new Date('2024-01-15T10:00:00Z'),
+    },
+  ],
+  pagination: { page: 1, limit: 10, total: 1, totalPages: 1 },
+  filters: { sortBy: 'timestamp', sortOrder: 'desc' },
+};
+
+describe('BurnHistoryController', () => {
+  let controller: BurnHistoryController;
+  let service: jest.Mocked<BurnHistoryService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [BurnHistoryController],
+      providers: [
+        {
+          provide: BurnHistoryService,
+          useValue: {
+            getHistory: jest.fn().mockResolvedValue(mockResponse),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<BurnHistoryController>(BurnHistoryController);
+    service = module.get(BurnHistoryService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  describe('getBurnHistory', () => {
+    it('should call service with query params', async () => {
+      const query: BurnHistoryQueryDto = {
+        tokenAddress: '0xToken',
+        type: BurnType.SELF,
+        page: 1,
+        limit: 10,
+        sortBy: SortBy.TIMESTAMP,
+        sortOrder: SortOrder.DESC,
+      };
+
+      const result = await controller.getBurnHistory(query);
+
+      expect(service.getHistory).toHaveBeenCalledWith(query);
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('should return response with success = true', async () => {
+      const result = await controller.getBurnHistory({});
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should return data array', async () => {
+      const result = await controller.getBurnHistory({});
+
+      expect(Array.isArray(result.data)).toBe(true);
+    });
+
+    it('should return pagination metadata', async () => {
+      const result = await controller.getBurnHistory({});
+
+      expect(result.pagination).toBeDefined();
+      expect(result.pagination).toHaveProperty('page');
+      expect(result.pagination).toHaveProperty('limit');
+      expect(result.pagination).toHaveProperty('total');
+      expect(result.pagination).toHaveProperty('totalPages');
+    });
+
+    it('should return filters object', async () => {
+      const result = await controller.getBurnHistory({});
+
+      expect(result.filters).toBeDefined();
+    });
+
+    it('should pass empty query without error', async () => {
+      await expect(controller.getBurnHistory({})).resolves.not.toThrow();
+      expect(service.getHistory).toHaveBeenCalledWith({});
+    });
+
+    it('should propagate service errors', async () => {
+      service.getHistory.mockRejectedValueOnce(new Error('DB connection failed'));
+
+      await expect(controller.getBurnHistory({})).rejects.toThrow('DB connection failed');
+    });
+  });
+});

--- a/backend/src/burn-history/burn-history.controller.ts
+++ b/backend/src/burn-history/burn-history.controller.ts
@@ -1,0 +1,81 @@
+import {
+  Controller,
+  Get,
+  Query,
+  HttpCode,
+  HttpStatus,
+  UseInterceptors,
+  Logger,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiQuery,
+} from '@nestjs/swagger';
+import { CacheInterceptor, CacheTTL } from '@nestjs/cache-manager';
+import { BurnHistoryService } from './burn-history.service';
+import {
+  BurnHistoryQueryDto,
+  BurnType,
+  SortBy,
+  SortOrder,
+} from './dto/burn-history-query.dto';
+import { BurnHistoryResponse } from './interfaces/burn-history.interface';
+
+@ApiTags('Burn')
+@Controller('api/burn')
+export class BurnHistoryController {
+  private readonly logger = new Logger(BurnHistoryController.name);
+
+  constructor(private readonly burnHistoryService: BurnHistoryService) {}
+
+  @Get('history')
+  @HttpCode(HttpStatus.OK)
+  @UseInterceptors(CacheInterceptor)
+  @CacheTTL(60_000)
+  @ApiOperation({
+    summary: 'Get burn transaction history',
+    description:
+      'Returns paginated burn transaction history with support for filtering by token address, type, and date range, plus sorting options.',
+  })
+  @ApiQuery({ name: 'tokenAddress', required: false, description: 'Filter by token contract address' })
+  @ApiQuery({ name: 'type', required: false, enum: BurnType, description: 'Filter by burn type' })
+  @ApiQuery({ name: 'startDate', required: false, description: 'ISO date string for range start' })
+  @ApiQuery({ name: 'endDate', required: false, description: 'ISO date string for range end' })
+  @ApiQuery({ name: 'page', required: false, description: 'Page number (default: 1)' })
+  @ApiQuery({ name: 'limit', required: false, description: 'Records per page (default: 10, max: 100)' })
+  @ApiQuery({ name: 'sortBy', required: false, enum: SortBy, description: 'Sort field' })
+  @ApiQuery({ name: 'sortOrder', required: false, enum: SortOrder, description: 'Sort direction' })
+  @ApiResponse({
+    status: 200,
+    description: 'Burn history retrieved successfully',
+    schema: {
+      example: {
+        success: true,
+        data: [
+          {
+            id: 'uuid',
+            tokenAddress: '0xabc...',
+            amount: '1000000000000000000',
+            from: '0xdef...',
+            type: 'self',
+            transactionHash: '0x123...',
+            blockNumber: '12345678',
+            timestamp: '2024-01-01T00:00:00.000Z',
+          },
+        ],
+        pagination: { page: 1, limit: 10, total: 100, totalPages: 10 },
+        filters: { tokenAddress: '0xabc...', sortBy: 'timestamp', sortOrder: 'desc' },
+      },
+    },
+  })
+  @ApiResponse({ status: 400, description: 'Invalid query parameters' })
+  @ApiResponse({ status: 500, description: 'Internal server error' })
+  async getBurnHistory(
+    @Query() query: BurnHistoryQueryDto,
+  ): Promise<BurnHistoryResponse> {
+    this.logger.log(`Fetching burn history with params: ${JSON.stringify(query)}`);
+    return this.burnHistoryService.getHistory(query);
+  }
+}

--- a/backend/src/burn-history/burn-history.e2e.spec.ts
+++ b/backend/src/burn-history/burn-history.e2e.spec.ts
@@ -1,0 +1,201 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import * as request from 'supertest';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { BurnHistoryModule } from './burn-history.module';
+import { BurnTransaction, BurnTransactionType } from './entities/burn-transaction.entity';
+
+const mockTransactions: BurnTransaction[] = [
+  {
+    id: 'uuid-1',
+    tokenAddress: '0xToken1',
+    amount: '1000000000000000000',
+    from: '0xUser1',
+    type: BurnTransactionType.SELF,
+    transactionHash: '0xHash1',
+    blockNumber: '100',
+    timestamp: new Date('2024-01-15T10:00:00Z'),
+    createdAt: new Date(),
+  },
+  {
+    id: 'uuid-2',
+    tokenAddress: '0xToken1',
+    amount: '2000000000000000000',
+    from: '0xAdmin',
+    type: BurnTransactionType.ADMIN,
+    transactionHash: '0xHash2',
+    blockNumber: '101',
+    timestamp: new Date('2024-01-16T12:00:00Z'),
+    createdAt: new Date(),
+  },
+];
+
+describe('BurnHistory E2E', () => {
+  let app: INestApplication;
+
+  const mockQb = {
+    select: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    skip: jest.fn().mockReturnThis(),
+    take: jest.fn().mockReturnThis(),
+    getCount: jest.fn().mockResolvedValue(2),
+    getMany: jest.fn().mockResolvedValue(mockTransactions),
+  };
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [BurnHistoryModule],
+    })
+      .overrideProvider(getRepositoryToken(BurnTransaction))
+      .useValue({ createQueryBuilder: jest.fn().mockReturnValue(mockQb) })
+      .overrideProvider(CACHE_MANAGER)
+      .useValue({ get: jest.fn().mockResolvedValue(null), set: jest.fn() })
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({
+        transform: true,
+        whitelist: true,
+        forbidNonWhitelisted: false,
+      }),
+    );
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    mockQb.getCount.mockResolvedValue(2);
+    mockQb.getMany.mockResolvedValue(mockTransactions);
+  });
+
+  describe('GET /api/burn/history', () => {
+    it('should return 200 with default params', async () => {
+      const res = await request(app.getHttpServer())
+        .get('/api/burn/history')
+        .expect(200);
+
+      expect(res.body.success).toBe(true);
+      expect(Array.isArray(res.body.data)).toBe(true);
+      expect(res.body.pagination).toBeDefined();
+      expect(res.body.filters).toBeDefined();
+    });
+
+    it('should return valid pagination structure', async () => {
+      const res = await request(app.getHttpServer())
+        .get('/api/burn/history')
+        .expect(200);
+
+      const { pagination } = res.body;
+      expect(pagination).toMatchObject({
+        page: 1,
+        limit: 10,
+        total: 2,
+        totalPages: 1,
+      });
+    });
+
+    it('should filter by tokenAddress', async () => {
+      const res = await request(app.getHttpServer())
+        .get('/api/burn/history?tokenAddress=0xToken1')
+        .expect(200);
+
+      expect(res.body.success).toBe(true);
+      expect(mockQb.andWhere).toHaveBeenCalledWith(
+        'bt.tokenAddress = :tokenAddress',
+        { tokenAddress: '0xToken1' },
+      );
+    });
+
+    it('should filter by type=self', async () => {
+      const res = await request(app.getHttpServer())
+        .get('/api/burn/history?type=self')
+        .expect(200);
+
+      expect(res.body.success).toBe(true);
+      expect(mockQb.andWhere).toHaveBeenCalledWith('bt.type = :type', { type: 'self' });
+    });
+
+    it('should return 400 for invalid type param', async () => {
+      await request(app.getHttpServer())
+        .get('/api/burn/history?type=invalid')
+        .expect(400);
+    });
+
+    it('should return 400 for invalid sortBy param', async () => {
+      await request(app.getHttpServer())
+        .get('/api/burn/history?sortBy=invalid')
+        .expect(400);
+    });
+
+    it('should return 400 for limit > 100', async () => {
+      await request(app.getHttpServer())
+        .get('/api/burn/history?limit=101')
+        .expect(400);
+    });
+
+    it('should return 400 for page < 1', async () => {
+      await request(app.getHttpServer())
+        .get('/api/burn/history?page=0')
+        .expect(400);
+    });
+
+    it('should return 400 for invalid startDate', async () => {
+      await request(app.getHttpServer())
+        .get('/api/burn/history?startDate=not-a-date')
+        .expect(400);
+    });
+
+    it('should accept full valid query', async () => {
+      const res = await request(app.getHttpServer())
+        .get(
+          '/api/burn/history?tokenAddress=0xToken1&type=admin&startDate=2024-01-01T00:00:00Z&endDate=2024-12-31T23:59:59Z&page=1&limit=20&sortBy=amount&sortOrder=asc',
+        )
+        .expect(200);
+
+      expect(res.body.success).toBe(true);
+      expect(res.body.filters).toMatchObject({
+        tokenAddress: '0xToken1',
+        type: 'admin',
+        startDate: '2024-01-01T00:00:00Z',
+        endDate: '2024-12-31T23:59:59Z',
+        sortBy: 'amount',
+        sortOrder: 'asc',
+      });
+    });
+
+    it('should paginate correctly on page 2', async () => {
+      mockQb.getCount.mockResolvedValueOnce(25);
+
+      const res = await request(app.getHttpServer())
+        .get('/api/burn/history?page=2&limit=10')
+        .expect(200);
+
+      expect(mockQb.skip).toHaveBeenCalledWith(10);
+      expect(mockQb.take).toHaveBeenCalledWith(10);
+      expect(res.body.pagination.page).toBe(2);
+    });
+
+    it('should sort by amount ascending', async () => {
+      await request(app.getHttpServer())
+        .get('/api/burn/history?sortBy=amount&sortOrder=asc')
+        .expect(200);
+
+      expect(mockQb.orderBy).toHaveBeenCalledWith('bt.amount', 'ASC');
+    });
+
+    it('should sort by from descending', async () => {
+      await request(app.getHttpServer())
+        .get('/api/burn/history?sortBy=from&sortOrder=desc')
+        .expect(200);
+
+      expect(mockQb.orderBy).toHaveBeenCalledWith('bt.from', 'DESC');
+    });
+  });
+});

--- a/backend/src/burn-history/burn-history.interface.ts
+++ b/backend/src/burn-history/burn-history.interface.ts
@@ -1,0 +1,33 @@
+export interface BurnRecord {
+  id: string;
+  tokenAddress: string;
+  amount: string;
+  from: string;
+  type: 'self' | 'admin';
+  transactionHash: string;
+  blockNumber: string | null;
+  timestamp: Date;
+}
+
+export interface PaginationMeta {
+  page: number;
+  limit: number;
+  total: number;
+  totalPages: number;
+}
+
+export interface AppliedFilters {
+  tokenAddress?: string;
+  type?: string;
+  startDate?: string;
+  endDate?: string;
+  sortBy: string;
+  sortOrder: string;
+}
+
+export interface BurnHistoryResponse {
+  success: boolean;
+  data: BurnRecord[];
+  pagination: PaginationMeta;
+  filters: AppliedFilters;
+}

--- a/backend/src/burn-history/burn-history.module.ts
+++ b/backend/src/burn-history/burn-history.module.ts
@@ -1,0 +1,20 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { CacheModule } from '@nestjs/cache-manager';
+import { BurnHistoryController } from './burn-history.controller';
+import { BurnHistoryService } from './burn-history.service';
+import { BurnTransaction } from './entities/burn-transaction.entity';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([BurnTransaction]),
+    CacheModule.register({
+      ttl: 60_000, // 60 seconds default
+      max: 500,    // max cached items
+    }),
+  ],
+  controllers: [BurnHistoryController],
+  providers: [BurnHistoryService],
+  exports: [BurnHistoryService],
+})
+export class BurnHistoryModule {}

--- a/backend/src/burn-history/burn-history.service.spec.ts
+++ b/backend/src/burn-history/burn-history.service.spec.ts
@@ -1,0 +1,286 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { Repository, SelectQueryBuilder } from 'typeorm';
+import { BurnHistoryService } from './burn-history.service';
+import { BurnTransaction, BurnTransactionType } from './entities/burn-transaction.entity';
+import { BurnHistoryQueryDto, BurnType, SortBy, SortOrder } from './dto/burn-history-query.dto';
+
+const mockBurnTransactions: BurnTransaction[] = [
+  {
+    id: 'uuid-1',
+    tokenAddress: '0xTokenAddress1',
+    amount: '1000000000000000000',
+    from: '0xFromAddress1',
+    type: BurnTransactionType.SELF,
+    transactionHash: '0xHash1',
+    blockNumber: '12345678',
+    timestamp: new Date('2024-01-15T10:00:00Z'),
+    createdAt: new Date('2024-01-15T10:00:00Z'),
+  },
+  {
+    id: 'uuid-2',
+    tokenAddress: '0xTokenAddress1',
+    amount: '500000000000000000',
+    from: '0xAdminAddress',
+    type: BurnTransactionType.ADMIN,
+    transactionHash: '0xHash2',
+    blockNumber: '12345679',
+    timestamp: new Date('2024-01-16T12:00:00Z'),
+    createdAt: new Date('2024-01-16T12:00:00Z'),
+  },
+];
+
+describe('BurnHistoryService', () => {
+  let service: BurnHistoryService;
+  let repository: jest.Mocked<Repository<BurnTransaction>>;
+  let cacheManager: jest.Mocked<{ get: jest.Mock; set: jest.Mock }>;
+  let mockQueryBuilder: Partial<SelectQueryBuilder<BurnTransaction>>;
+
+  beforeEach(async () => {
+    mockQueryBuilder = {
+      select: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      skip: jest.fn().mockReturnThis(),
+      take: jest.fn().mockReturnThis(),
+      getCount: jest.fn().mockResolvedValue(2),
+      getMany: jest.fn().mockResolvedValue(mockBurnTransactions),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        BurnHistoryService,
+        {
+          provide: getRepositoryToken(BurnTransaction),
+          useValue: {
+            createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder),
+          },
+        },
+        {
+          provide: CACHE_MANAGER,
+          useValue: {
+            get: jest.fn().mockResolvedValue(null),
+            set: jest.fn().mockResolvedValue(undefined),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<BurnHistoryService>(BurnHistoryService);
+    repository = module.get(getRepositoryToken(BurnTransaction));
+    cacheManager = module.get(CACHE_MANAGER);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  describe('getHistory', () => {
+    it('should return paginated burn history with default params', async () => {
+      const query: BurnHistoryQueryDto = {};
+
+      const result = await service.getHistory(query);
+
+      expect(result.success).toBe(true);
+      expect(result.data).toHaveLength(2);
+      expect(result.pagination).toEqual({
+        page: 1,
+        limit: 10,
+        total: 2,
+        totalPages: 1,
+      });
+      expect(result.filters).toEqual({
+        sortBy: SortBy.TIMESTAMP,
+        sortOrder: SortOrder.DESC,
+      });
+    });
+
+    it('should return cached response if available', async () => {
+      const cachedResponse = {
+        success: true,
+        data: [],
+        pagination: { page: 1, limit: 10, total: 0, totalPages: 0 },
+        filters: { sortBy: 'timestamp', sortOrder: 'desc' },
+      };
+      (cacheManager.get as jest.Mock).mockResolvedValueOnce(cachedResponse);
+
+      const result = await service.getHistory({});
+
+      expect(result).toEqual(cachedResponse);
+      expect(repository.createQueryBuilder).not.toHaveBeenCalled();
+    });
+
+    it('should filter by tokenAddress', async () => {
+      const query: BurnHistoryQueryDto = { tokenAddress: '0xTokenAddress1' };
+
+      await service.getHistory(query);
+
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        'bt.tokenAddress = :tokenAddress',
+        { tokenAddress: '0xTokenAddress1' },
+      );
+    });
+
+    it('should filter by type = self', async () => {
+      const query: BurnHistoryQueryDto = { type: BurnType.SELF };
+
+      await service.getHistory(query);
+
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        'bt.type = :type',
+        { type: BurnType.SELF },
+      );
+    });
+
+    it('should NOT add type filter when type = all', async () => {
+      const query: BurnHistoryQueryDto = { type: BurnType.ALL };
+
+      await service.getHistory(query);
+
+      const andWhereCalls = (mockQueryBuilder.andWhere as jest.Mock).mock.calls;
+      const typeFilterCalled = andWhereCalls.some((call) =>
+        call[0].includes('bt.type'),
+      );
+      expect(typeFilterCalled).toBe(false);
+    });
+
+    it('should filter by date range', async () => {
+      const query: BurnHistoryQueryDto = {
+        startDate: '2024-01-01T00:00:00Z',
+        endDate: '2024-01-31T23:59:59Z',
+      };
+
+      await service.getHistory(query);
+
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        'bt.timestamp >= :startDate',
+        { startDate: new Date('2024-01-01T00:00:00Z') },
+      );
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        'bt.timestamp <= :endDate',
+        { endDate: new Date('2024-01-31T23:59:59Z') },
+      );
+    });
+
+    it('should apply pagination correctly', async () => {
+      const query: BurnHistoryQueryDto = { page: 2, limit: 5 };
+
+      await service.getHistory(query);
+
+      expect(mockQueryBuilder.skip).toHaveBeenCalledWith(5); // (page-1) * limit
+      expect(mockQueryBuilder.take).toHaveBeenCalledWith(5);
+    });
+
+    it('should calculate totalPages correctly', async () => {
+      (mockQueryBuilder.getCount as jest.Mock).mockResolvedValueOnce(25);
+
+      const result = await service.getHistory({ page: 1, limit: 10 });
+
+      expect(result.pagination.totalPages).toBe(3);
+      expect(result.pagination.total).toBe(25);
+    });
+
+    it('should apply sortBy and sortOrder', async () => {
+      const query: BurnHistoryQueryDto = {
+        sortBy: SortBy.AMOUNT,
+        sortOrder: SortOrder.ASC,
+      };
+
+      await service.getHistory(query);
+
+      expect(mockQueryBuilder.orderBy).toHaveBeenCalledWith('bt.amount', 'ASC');
+    });
+
+    it('should sort by timestamp descending by default', async () => {
+      await service.getHistory({});
+
+      expect(mockQueryBuilder.orderBy).toHaveBeenCalledWith('bt.timestamp', 'DESC');
+    });
+
+    it('should include only applied filters in response', async () => {
+      const query: BurnHistoryQueryDto = {
+        tokenAddress: '0xToken',
+        type: BurnType.ADMIN,
+        startDate: '2024-01-01T00:00:00Z',
+        sortBy: SortBy.FROM,
+        sortOrder: SortOrder.ASC,
+      };
+
+      const result = await service.getHistory(query);
+
+      expect(result.filters).toEqual({
+        tokenAddress: '0xToken',
+        type: BurnType.ADMIN,
+        startDate: '2024-01-01T00:00:00Z',
+        sortBy: SortBy.FROM,
+        sortOrder: SortOrder.ASC,
+      });
+      expect(result.filters).not.toHaveProperty('endDate');
+    });
+
+    it('should cache result after fetching from DB', async () => {
+      await service.getHistory({ tokenAddress: '0xToken' });
+
+      expect(cacheManager.set).toHaveBeenCalledTimes(1);
+      const [key, value, ttl] = (cacheManager.set as jest.Mock).mock.calls[0];
+      expect(key).toContain('burn_history');
+      expect(value.success).toBe(true);
+      expect(ttl).toBe(60_000);
+    });
+
+    it('should map entity fields to response correctly', async () => {
+      const result = await service.getHistory({});
+
+      expect(result.data[0]).toMatchObject({
+        id: 'uuid-1',
+        tokenAddress: '0xTokenAddress1',
+        amount: '1000000000000000000',
+        from: '0xFromAddress1',
+        type: 'self',
+        transactionHash: '0xHash1',
+        blockNumber: '12345678',
+      });
+    });
+
+    it('should handle empty result set gracefully', async () => {
+      (mockQueryBuilder.getCount as jest.Mock).mockResolvedValueOnce(0);
+      (mockQueryBuilder.getMany as jest.Mock).mockResolvedValueOnce([]);
+
+      const result = await service.getHistory({});
+
+      expect(result.success).toBe(true);
+      expect(result.data).toHaveLength(0);
+      expect(result.pagination.total).toBe(0);
+      expect(result.pagination.totalPages).toBe(0);
+    });
+
+    it('should combine multiple filters', async () => {
+      const query: BurnHistoryQueryDto = {
+        tokenAddress: '0xToken',
+        type: BurnType.SELF,
+        startDate: '2024-01-01T00:00:00Z',
+        endDate: '2024-01-31T23:59:59Z',
+        page: 2,
+        limit: 20,
+        sortBy: SortBy.AMOUNT,
+        sortOrder: SortOrder.ASC,
+      };
+
+      await service.getHistory(query);
+
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledTimes(4);
+      expect(mockQueryBuilder.skip).toHaveBeenCalledWith(20);
+      expect(mockQueryBuilder.take).toHaveBeenCalledWith(20);
+      expect(mockQueryBuilder.orderBy).toHaveBeenCalledWith('bt.amount', 'ASC');
+    });
+  });
+
+  describe('invalidateCache', () => {
+    it('should not throw when called', async () => {
+      await expect(service.invalidateCache('0xToken')).resolves.not.toThrow();
+    });
+
+    it('should not throw when called without tokenAddress', async () => {
+      await expect(service.invalidateCache()).resolves.not.toThrow();
+    });
+  });
+});

--- a/backend/src/burn-history/burn-history.service.ts
+++ b/backend/src/burn-history/burn-history.service.ts
@@ -1,0 +1,181 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, SelectQueryBuilder } from 'typeorm';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { Inject } from '@nestjs/common';
+import { Cache } from 'cache-manager';
+import { BurnTransaction } from './entities/burn-transaction.entity';
+import {
+  BurnHistoryQueryDto,
+  BurnType,
+  SortBy,
+  SortOrder,
+} from './dto/burn-history-query.dto';
+import {
+  BurnHistoryResponse,
+  AppliedFilters,
+} from './interfaces/burn-history.interface';
+
+@Injectable()
+export class BurnHistoryService {
+  private readonly logger = new Logger(BurnHistoryService.name);
+  private readonly CACHE_TTL = 60; // seconds
+  private readonly CACHE_PREFIX = 'burn_history';
+
+  constructor(
+    @InjectRepository(BurnTransaction)
+    private readonly burnRepository: Repository<BurnTransaction>,
+    @Inject(CACHE_MANAGER)
+    private readonly cacheManager: Cache,
+  ) {}
+
+  async getHistory(query: BurnHistoryQueryDto): Promise<BurnHistoryResponse> {
+    const cacheKey = this.buildCacheKey(query);
+
+    const cached = await this.cacheManager.get<BurnHistoryResponse>(cacheKey);
+    if (cached) {
+      this.logger.debug(`Cache hit for key: ${cacheKey}`);
+      return cached;
+    }
+
+    const {
+      tokenAddress,
+      type = BurnType.ALL,
+      startDate,
+      endDate,
+      page = 1,
+      limit = 10,
+      sortBy = SortBy.TIMESTAMP,
+      sortOrder = SortOrder.DESC,
+    } = query;
+
+    const qb = this.buildQuery({
+      tokenAddress,
+      type,
+      startDate,
+      endDate,
+      sortBy,
+      sortOrder,
+    });
+
+    const total = await qb.getCount();
+    const totalPages = Math.ceil(total / limit);
+
+    const data = await qb
+      .skip((page - 1) * limit)
+      .take(limit)
+      .getMany();
+
+    const appliedFilters: AppliedFilters = {
+      ...(tokenAddress && { tokenAddress }),
+      ...(type !== BurnType.ALL && { type }),
+      ...(startDate && { startDate }),
+      ...(endDate && { endDate }),
+      sortBy,
+      sortOrder,
+    };
+
+    const response: BurnHistoryResponse = {
+      success: true,
+      data: data.map((tx) => ({
+        id: tx.id,
+        tokenAddress: tx.tokenAddress,
+        amount: tx.amount,
+        from: tx.from,
+        type: tx.type,
+        transactionHash: tx.transactionHash,
+        blockNumber: tx.blockNumber,
+        timestamp: tx.timestamp,
+      })),
+      pagination: {
+        page,
+        limit,
+        total,
+        totalPages,
+      },
+      filters: appliedFilters,
+    };
+
+    await this.cacheManager.set(cacheKey, response, this.CACHE_TTL * 1000);
+    this.logger.debug(`Cached result for key: ${cacheKey}`);
+
+    return response;
+  }
+
+  private buildQuery(params: {
+    tokenAddress?: string;
+    type: BurnType;
+    startDate?: string;
+    endDate?: string;
+    sortBy: SortBy;
+    sortOrder: SortOrder;
+  }): SelectQueryBuilder<BurnTransaction> {
+    const { tokenAddress, type, startDate, endDate, sortBy, sortOrder } = params;
+
+    const qb = this.burnRepository
+      .createQueryBuilder('bt')
+      .select([
+        'bt.id',
+        'bt.tokenAddress',
+        'bt.amount',
+        'bt.from',
+        'bt.type',
+        'bt.transactionHash',
+        'bt.blockNumber',
+        'bt.timestamp',
+      ]);
+
+    if (tokenAddress) {
+      qb.andWhere('bt.tokenAddress = :tokenAddress', { tokenAddress });
+    }
+
+    if (type !== BurnType.ALL) {
+      qb.andWhere('bt.type = :type', { type });
+    }
+
+    if (startDate) {
+      qb.andWhere('bt.timestamp >= :startDate', { startDate: new Date(startDate) });
+    }
+
+    if (endDate) {
+      qb.andWhere('bt.timestamp <= :endDate', { endDate: new Date(endDate) });
+    }
+
+    const sortColumn = this.resolveSortColumn(sortBy);
+    qb.orderBy(sortColumn, sortOrder.toUpperCase() as 'ASC' | 'DESC');
+
+    return qb;
+  }
+
+  private resolveSortColumn(sortBy: SortBy): string {
+    const map: Record<SortBy, string> = {
+      [SortBy.TIMESTAMP]: 'bt.timestamp',
+      [SortBy.AMOUNT]: 'bt.amount',
+      [SortBy.FROM]: 'bt.from',
+    };
+    return map[sortBy] ?? 'bt.timestamp';
+  }
+
+  private buildCacheKey(query: BurnHistoryQueryDto): string {
+    const parts = [
+      this.CACHE_PREFIX,
+      query.tokenAddress ?? 'all',
+      query.type ?? BurnType.ALL,
+      query.startDate ?? 'none',
+      query.endDate ?? 'none',
+      query.page ?? 1,
+      query.limit ?? 10,
+      query.sortBy ?? SortBy.TIMESTAMP,
+      query.sortOrder ?? SortOrder.DESC,
+    ];
+    return parts.join(':');
+  }
+
+  async invalidateCache(tokenAddress?: string): Promise<void> {
+    // Pattern-based invalidation if your cache manager supports it
+    // For simple implementations, log the intent
+    this.logger.log(
+      `Cache invalidation triggered${tokenAddress ? ` for token: ${tokenAddress}` : ''}`,
+    );
+  }
+}

--- a/backend/src/burn-history/burn-transaction.entity.ts
+++ b/backend/src/burn-history/burn-transaction.entity.ts
@@ -1,0 +1,50 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+
+export enum BurnTransactionType {
+  SELF = 'self',
+  ADMIN = 'admin',
+}
+
+@Entity('burn_transactions')
+@Index(['tokenAddress', 'timestamp'])
+@Index(['tokenAddress', 'type'])
+export class BurnTransaction {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'token_address', length: 100 })
+  @Index()
+  tokenAddress: string;
+
+  @Column({ type: 'decimal', precision: 36, scale: 18 })
+  amount: string;
+
+  @Column({ name: 'from_address', length: 100 })
+  from: string;
+
+  @Column({
+    type: 'enum',
+    enum: BurnTransactionType,
+    default: BurnTransactionType.SELF,
+  })
+  type: BurnTransactionType;
+
+  @Column({ name: 'transaction_hash', length: 100, unique: true })
+  transactionHash: string;
+
+  @Column({ name: 'block_number', type: 'bigint', nullable: true })
+  blockNumber: string | null;
+
+  @Column({ type: 'timestamp with time zone' })
+  @Index()
+  timestamp: Date;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+}

--- a/backend/src/burn-history/index.ts
+++ b/backend/src/burn-history/index.ts
@@ -1,0 +1,6 @@
+export * from './burn-history.module';
+export * from './burn-history.service';
+export * from './burn-history.controller';
+export * from './entities/burn-transaction.entity';
+export * from './dto/burn-history-query.dto';
+export * from './interfaces/burn-history.interface';


### PR DESCRIPTION
…TOs, service, controller, and E2E tests

- Create migration for burn_transactions table and enum type
- Add BurnHistoryQueryDto for query parameter validation
- Implement BurnHistoryService for fetching and caching burn transaction data
- Develop BurnHistoryController to handle API requests for burn history
- Create unit and E2E tests for service and controller
- Define BurnTransaction entity with necessary fields and indexes
- Update index file to export new modules and entities

closes #175 