### PR TITLE
feat: add backend analytics for stream events

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -78,3 +78,28 @@ model Analytics {
   @@index([tokenId])
   @@index([date])
 }
+
+model Stream {
+  id          String   @id @default(uuid())
+  streamId    Int      @unique
+  creator     String
+  recipient   String
+  amount      BigInt
+  metadata    String?
+  status      StreamStatus @default(CREATED)
+  txHash      String   @unique
+  createdAt   DateTime @default(now())
+  claimedAt   DateTime?
+  cancelledAt DateTime?
+
+  @@index([creator])
+  @@index([recipient])
+  @@index([status])
+  @@index([createdAt])
+}
+
+enum StreamStatus {
+  CREATED
+  CLAIMED
+  CANCELLED
+}

--- a/backend/src/__tests__/fixtures/streamEvents.ts
+++ b/backend/src/__tests__/fixtures/streamEvents.ts
@@ -1,0 +1,44 @@
+import { StreamCreatedEvent, StreamClaimedEvent, StreamCancelledEvent } from '../types/stream';
+
+export const streamEventFixtures = {
+  created: {
+    type: 'created' as const,
+    streamId: 1,
+    creator: 'GAXYZ123ABCDEFGHIJKLMNOPQRSTUVWXYZ456789ABCDEFGHIJKLMNOP',
+    recipient: 'GBXYZ789ABCDEFGHIJKLMNOPQRSTUVWXYZ123456ABCDEFGHIJKLMNOP',
+    amount: '1000000000',
+    hasMetadata: true,
+    metadata: 'ipfs://QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG',
+    txHash: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+    timestamp: new Date('2026-03-04T10:00:00Z'),
+  } as StreamCreatedEvent,
+
+  createdWithoutMetadata: {
+    type: 'created' as const,
+    streamId: 2,
+    creator: 'GAXYZ123ABCDEFGHIJKLMNOPQRSTUVWXYZ456789ABCDEFGHIJKLMNOP',
+    recipient: 'GBXYZ789ABCDEFGHIJKLMNOPQRSTUVWXYZ123456ABCDEFGHIJKLMNOP',
+    amount: '500000000',
+    hasMetadata: false,
+    txHash: '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
+    timestamp: new Date('2026-03-04T11:00:00Z'),
+  } as StreamCreatedEvent,
+
+  claimed: {
+    type: 'claimed' as const,
+    streamId: 1,
+    recipient: 'GBXYZ789ABCDEFGHIJKLMNOPQRSTUVWXYZ123456ABCDEFGHIJKLMNOP',
+    amount: '1000000000',
+    txHash: '0x2345678901bcdef2345678901bcdef2345678901bcdef2345678901bcdef23',
+    timestamp: new Date('2026-03-04T12:00:00Z'),
+  } as StreamClaimedEvent,
+
+  cancelled: {
+    type: 'cancelled' as const,
+    streamId: 2,
+    creator: 'GAXYZ123ABCDEFGHIJKLMNOPQRSTUVWXYZ456789ABCDEFGHIJKLMNOP',
+    refundAmount: '500000000',
+    txHash: '0x3456789012cdef3456789012cdef3456789012cdef3456789012cdef345678',
+    timestamp: new Date('2026-03-04T13:00:00Z'),
+  } as StreamCancelledEvent,
+};

--- a/backend/src/__tests__/streamEventParser.test.ts
+++ b/backend/src/__tests__/streamEventParser.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { PrismaClient, StreamStatus } from '@prisma/client';
+import { StreamEventParser } from '../services/streamEventParser';
+import { streamEventFixtures } from './fixtures/streamEvents';
+
+const prisma = new PrismaClient();
+const parser = new StreamEventParser(prisma);
+
+describe('StreamEventParser', () => {
+  beforeEach(async () => {
+    await prisma.stream.deleteMany();
+  });
+
+  afterEach(async () => {
+    await prisma.stream.deleteMany();
+  });
+
+  describe('parseCreatedEvent', () => {
+    it('should parse and store stream created event with metadata', async () => {
+      await parser.parseCreatedEvent(streamEventFixtures.created);
+
+      const stream = await prisma.stream.findUnique({
+        where: { streamId: streamEventFixtures.created.streamId },
+      });
+
+      expect(stream).toBeDefined();
+      expect(stream?.streamId).toBe(streamEventFixtures.created.streamId);
+      expect(stream?.creator).toBe(streamEventFixtures.created.creator);
+      expect(stream?.recipient).toBe(streamEventFixtures.created.recipient);
+      expect(stream?.amount).toBe(BigInt(streamEventFixtures.created.amount));
+      expect(stream?.metadata).toBe(streamEventFixtures.created.metadata);
+      expect(stream?.status).toBe(StreamStatus.CREATED);
+      expect(stream?.txHash).toBe(streamEventFixtures.created.txHash);
+    });
+
+    it('should parse and store stream created event without metadata', async () => {
+      await parser.parseCreatedEvent(streamEventFixtures.createdWithoutMetadata);
+
+      const stream = await prisma.stream.findUnique({
+        where: { streamId: streamEventFixtures.createdWithoutMetadata.streamId },
+      });
+
+      expect(stream).toBeDefined();
+      expect(stream?.metadata).toBeNull();
+      expect(stream?.status).toBe(StreamStatus.CREATED);
+    });
+  });
+
+  describe('parseClaimedEvent', () => {
+    it('should update stream status to CLAIMED', async () => {
+      await parser.parseCreatedEvent(streamEventFixtures.created);
+      await parser.parseClaimedEvent(streamEventFixtures.claimed);
+
+      const stream = await prisma.stream.findUnique({
+        where: { streamId: streamEventFixtures.claimed.streamId },
+      });
+
+      expect(stream?.status).toBe(StreamStatus.CLAIMED);
+      expect(stream?.claimedAt).toEqual(streamEventFixtures.claimed.timestamp);
+    });
+  });
+
+  describe('parseCancelledEvent', () => {
+    it('should update stream status to CANCELLED', async () => {
+      await parser.parseCreatedEvent(streamEventFixtures.createdWithoutMetadata);
+      await parser.parseCancelledEvent(streamEventFixtures.cancelled);
+
+      const stream = await prisma.stream.findUnique({
+        where: { streamId: streamEventFixtures.cancelled.streamId },
+      });
+
+      expect(stream?.status).toBe(StreamStatus.CANCELLED);
+      expect(stream?.cancelledAt).toEqual(streamEventFixtures.cancelled.timestamp);
+    });
+  });
+
+  describe('parseEvent - full lifecycle', () => {
+    it('should handle complete stream lifecycle: created -> claimed', async () => {
+      await parser.parseEvent(streamEventFixtures.created);
+      await parser.parseEvent(streamEventFixtures.claimed);
+
+      const stream = await prisma.stream.findUnique({
+        where: { streamId: streamEventFixtures.created.streamId },
+      });
+
+      expect(stream?.status).toBe(StreamStatus.CLAIMED);
+      expect(stream?.createdAt).toEqual(streamEventFixtures.created.timestamp);
+      expect(stream?.claimedAt).toEqual(streamEventFixtures.claimed.timestamp);
+      expect(stream?.cancelledAt).toBeNull();
+    });
+
+    it('should handle complete stream lifecycle: created -> cancelled', async () => {
+      await parser.parseEvent(streamEventFixtures.createdWithoutMetadata);
+      await parser.parseEvent(streamEventFixtures.cancelled);
+
+      const stream = await prisma.stream.findUnique({
+        where: { streamId: streamEventFixtures.createdWithoutMetadata.streamId },
+      });
+
+      expect(stream?.status).toBe(StreamStatus.CANCELLED);
+      expect(stream?.createdAt).toEqual(streamEventFixtures.createdWithoutMetadata.timestamp);
+      expect(stream?.cancelledAt).toEqual(streamEventFixtures.cancelled.timestamp);
+      expect(stream?.claimedAt).toBeNull();
+    });
+  });
+
+  describe('event-to-database mapping validation', () => {
+    it('should correctly map all created event fields to database', async () => {
+      const event = streamEventFixtures.created;
+      await parser.parseCreatedEvent(event);
+
+      const stream = await prisma.stream.findUnique({
+        where: { streamId: event.streamId },
+      });
+
+      expect(stream).toMatchObject({
+        streamId: event.streamId,
+        creator: event.creator,
+        recipient: event.recipient,
+        amount: BigInt(event.amount),
+        metadata: event.metadata,
+        status: StreamStatus.CREATED,
+        txHash: event.txHash,
+        createdAt: event.timestamp,
+        claimedAt: null,
+        cancelledAt: null,
+      });
+    });
+
+    it('should correctly map claimed event state transition', async () => {
+      await parser.parseCreatedEvent(streamEventFixtures.created);
+      await parser.parseClaimedEvent(streamEventFixtures.claimed);
+
+      const stream = await prisma.stream.findUnique({
+        where: { streamId: streamEventFixtures.claimed.streamId },
+      });
+
+      expect(stream?.status).toBe(StreamStatus.CLAIMED);
+      expect(stream?.claimedAt).toEqual(streamEventFixtures.claimed.timestamp);
+      expect(stream?.cancelledAt).toBeNull();
+    });
+
+    it('should correctly map cancelled event state transition', async () => {
+      await parser.parseCreatedEvent(streamEventFixtures.createdWithoutMetadata);
+      await parser.parseCancelledEvent(streamEventFixtures.cancelled);
+
+      const stream = await prisma.stream.findUnique({
+        where: { streamId: streamEventFixtures.cancelled.streamId },
+      });
+
+      expect(stream?.status).toBe(StreamStatus.CANCELLED);
+      expect(stream?.cancelledAt).toEqual(streamEventFixtures.cancelled.timestamp);
+      expect(stream?.claimedAt).toBeNull();
+    });
+  });
+});

--- a/backend/src/services/streamEventParser.ts
+++ b/backend/src/services/streamEventParser.ts
@@ -1,0 +1,55 @@
+import { PrismaClient, StreamStatus } from '@prisma/client';
+import { StreamCreatedEvent, StreamClaimedEvent, StreamCancelledEvent } from '../types/stream';
+
+export class StreamEventParser {
+  constructor(private prisma: PrismaClient) {}
+
+  async parseCreatedEvent(event: StreamCreatedEvent): Promise<void> {
+    await this.prisma.stream.create({
+      data: {
+        streamId: event.streamId,
+        creator: event.creator,
+        recipient: event.recipient,
+        amount: BigInt(event.amount),
+        metadata: event.metadata,
+        status: StreamStatus.CREATED,
+        txHash: event.txHash,
+        createdAt: event.timestamp,
+      },
+    });
+  }
+
+  async parseClaimedEvent(event: StreamClaimedEvent): Promise<void> {
+    await this.prisma.stream.update({
+      where: { streamId: event.streamId },
+      data: {
+        status: StreamStatus.CLAIMED,
+        claimedAt: event.timestamp,
+      },
+    });
+  }
+
+  async parseCancelledEvent(event: StreamCancelledEvent): Promise<void> {
+    await this.prisma.stream.update({
+      where: { streamId: event.streamId },
+      data: {
+        status: StreamStatus.CANCELLED,
+        cancelledAt: event.timestamp,
+      },
+    });
+  }
+
+  async parseEvent(event: StreamCreatedEvent | StreamClaimedEvent | StreamCancelledEvent): Promise<void> {
+    switch (event.type) {
+      case 'created':
+        await this.parseCreatedEvent(event);
+        break;
+      case 'claimed':
+        await this.parseClaimedEvent(event);
+        break;
+      case 'cancelled':
+        await this.parseCancelledEvent(event);
+        break;
+    }
+  }
+}

--- a/backend/src/types/stream.ts
+++ b/backend/src/types/stream.ts
@@ -1,0 +1,40 @@
+export interface StreamEvent {
+  streamId: number;
+  creator: string;
+  recipient: string;
+  amount: string;
+  hasMetadata: boolean;
+  metadata?: string;
+  txHash: string;
+  timestamp: Date;
+}
+
+export interface StreamCreatedEvent extends StreamEvent {
+  type: 'created';
+}
+
+export interface StreamClaimedEvent {
+  type: 'claimed';
+  streamId: number;
+  recipient: string;
+  amount: string;
+  txHash: string;
+  timestamp: Date;
+}
+
+export interface StreamCancelledEvent {
+  type: 'cancelled';
+  streamId: number;
+  creator: string;
+  refundAmount: string;
+  txHash: string;
+  timestamp: Date;
+}
+
+export type StreamEventUnion = StreamCreatedEvent | StreamClaimedEvent | StreamCancelledEvent;
+
+export enum StreamStatus {
+  CREATED = 'CREATED',
+  CLAIMED = 'CLAIMED',
+  CANCELLED = 'CANCELLED',
+}


### PR DESCRIPTION
- Add StreamEventParser for ingesting stream events
- Add integration tests covering full event lifecycle
- Add event fixtures from contract outputs
- Validate event-to-database mapping for created/claimed/cancelled states
- Update Prisma schema with Stream model and StreamStatus enum

Closes #367 