### PR TITLE
feat: Implement Batch Claim API

### DIFF
--- a/contracts/token-factory/src/batch_claim_test.rs
+++ b/contracts/token-factory/src/batch_claim_test.rs
@@ -1,0 +1,230 @@
+#![cfg(test)]
+
+use crate::{TokenFactory, TokenFactoryClient};
+use crate::test_helpers::{set_time};
+use soroban_sdk::{testutils::Address as _, vec, Address, Env, Vec};
+
+fn setup() -> (Env, TokenFactoryClient, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    
+    let contract_id = env.register_contract(None, TokenFactory);
+    let client = TokenFactoryClient::new(&env, &contract_id);
+    
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    
+    client.initialize(&admin, &treasury, &1_000_000, &500_000);
+    
+    (env, client, admin, treasury)
+}
+
+#[test]
+fn test_batch_claim_happy_path() {
+    let (env, client, _admin, _treasury) = setup();
+    
+    let creator = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token = Address::generate(&env);
+    
+    let stream_id1 = client.create_stream(
+        &creator,
+        &recipient,
+        &token,
+        &1000_0000000,
+        &100,
+        &200,
+        &300,
+        &None,
+    );
+    
+    let stream_id2 = client.create_stream(
+        &creator,
+        &recipient,
+        &token,
+        &2000_0000000,
+        &100,
+        &200,
+        &300,
+        &None,
+    );
+    
+    // Set time to end of streams (100% completion)
+    set_time(&env, 400);
+    
+    let stream_ids: Vec<u64> = vec![&env, stream_id1, stream_id2];
+    
+    let claimed_amounts = client.batch_claim(&recipient, &stream_ids);
+    
+    assert_eq!(claimed_amounts.len(), 2);
+    assert_eq!(claimed_amounts.get(0).unwrap(), 1000_0000000);
+    assert_eq!(claimed_amounts.get(1).unwrap(), 2000_0000000);
+    
+    // Verify stream objects updated
+    let stream1 = client.get_stream(&stream_id1).unwrap();
+    assert_eq!(stream1.claimed, 1000_0000000);
+    
+    let stream2 = client.get_stream(&stream_id2).unwrap();
+    assert_eq!(stream2.claimed, 2000_0000000);
+}
+
+#[test]
+fn test_batch_claim_mixed_claimable() {
+    let (env, client, _admin, _treasury) = setup();
+    
+    let creator = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token = Address::generate(&env);
+    
+    // Eligible stream
+    let stream_id1 = client.create_stream(
+        &creator,
+        &recipient,
+        &token,
+        &1000_0000000,
+        &100,
+        &200,
+        &300,
+        &None,
+    );
+    
+    // Not eligible yet (cliff hasn't hit)
+    let stream_id2 = client.create_stream(
+        &creator,
+        &recipient,
+        &token,
+        &2000_0000000,
+        &400,
+        &450,
+        &500,
+        &None,
+    );
+    
+    // Set time to end of first stream, but before second stream's cliff
+    set_time(&env, 350);
+    
+    let stream_ids: Vec<u64> = vec![&env, stream_id1, stream_id2];
+    
+    let claimed_amounts = client.batch_claim(&recipient, &stream_ids);
+    
+    assert_eq!(claimed_amounts.len(), 2);
+    assert_eq!(claimed_amounts.get(0).unwrap(), 1000_0000000);
+    assert_eq!(claimed_amounts.get(1).unwrap(), 0);
+    
+    // Verify stream objects updated correctly
+    let stream1 = client.get_stream(&stream_id1).unwrap();
+    assert_eq!(stream1.claimed, 1000_0000000);
+    
+    let stream2 = client.get_stream(&stream_id2).unwrap();
+    assert_eq!(stream2.claimed, 0);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #2)")]
+fn test_batch_claim_unauthorized() {
+    let (env, client, _admin, _treasury) = setup();
+    
+    let creator = Address::generate(&env);
+    let recipient1 = Address::generate(&env);
+    let recipient2 = Address::generate(&env);
+    let token = Address::generate(&env);
+    
+    let stream_id1 = client.create_stream(
+        &creator,
+        &recipient1,
+        &token,
+        &1000_0000000,
+        &100,
+        &200,
+        &300,
+        &None,
+    );
+    
+    let stream_id2 = client.create_stream(
+        &creator,
+        &recipient2,  // Different recipient
+        &token,
+        &2000_0000000,
+        &100,
+        &200,
+        &300,
+        &None,
+    );
+    
+    set_time(&env, 400);
+    
+    let stream_ids: Vec<u64> = vec![&env, stream_id1, stream_id2];
+    
+    // Attempting to claim a batch where one stream belongs to someone else should fail
+    client.batch_claim(&recipient1, &stream_ids);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #4)")]
+fn test_batch_claim_token_not_found() {
+    let (env, client, _admin, _treasury) = setup();
+    
+    let creator = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token = Address::generate(&env);
+    
+    let stream_id1 = client.create_stream(
+        &creator,
+        &recipient,
+        &token,
+        &1000_0000000,
+        &100,
+        &200,
+        &300,
+        &None,
+    );
+    
+    set_time(&env, 400);
+    
+    // stream ID 999 does not exist
+    let stream_ids: Vec<u64> = vec![&env, stream_id1, 999];
+    
+    client.batch_claim(&recipient, &stream_ids);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3)")]
+fn test_batch_claim_cancelled_stream() {
+    let (env, client, _admin, _treasury) = setup();
+    
+    let creator = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token = Address::generate(&env);
+    
+    let stream_id1 = client.create_stream(
+        &creator,
+        &recipient,
+        &token,
+        &1000_0000000,
+        &100,
+        &200,
+        &300,
+        &None,
+    );
+    
+    let stream_id2 = client.create_stream(
+        &creator,
+        &recipient,
+        &token,
+        &2000_0000000,
+        &100,
+        &200,
+        &300,
+        &None,
+    );
+    
+    // Cancel stream_id2
+    client.cancel_stream(&creator, &stream_id2);
+    
+    set_time(&env, 400);
+    
+    let stream_ids: Vec<u64> = vec![&env, stream_id1, stream_id2];
+    
+    // Calling batch_claim with a cancelled stream should fail
+    client.batch_claim(&recipient, &stream_ids);
+}

--- a/contracts/token-factory/src/lib.rs
+++ b/contracts/token-factory/src/lib.rs
@@ -1607,6 +1607,38 @@ impl TokenFactory {
         streaming::claim_stream(&env, &recipient, stream_id)
     }
 
+    /// Batch claim vested tokens from multiple streams
+    ///
+    /// Allows recipient to claim tokens that have vested according to schedule
+    /// from multiple streams in a single transaction. Streams that cannot be
+    /// claimed (e.g. before cliff or zero remaining) are skipped without error.
+    ///
+    /// # Arguments
+    /// * `env` - The contract environment
+    /// * `recipient` - Address claiming tokens (must authorize)
+    /// * `stream_ids` - Vector of stream IDs to claim from
+    ///
+    /// # Returns
+    /// Returns a vector of claimed amounts matching the input order
+    ///
+    /// # Errors
+    /// * `Error::Unauthorized` - Caller is not the recipient for one of the streams
+    /// * `Error::TokenNotFound` - Stream not found
+    /// * `Error::InvalidParameters` - Stream cancelled
+    ///
+    /// # Examples
+    /// ```
+    /// let stream_ids = vec![&env, stream_id1, stream_id2];
+    /// let claimed_amounts = factory.batch_claim(&env, recipient, stream_ids)?;
+    /// ```
+    pub fn batch_claim(
+        env: Env,
+        recipient: Address,
+        stream_ids: Vec<u64>,
+    ) -> Result<Vec<i128>, Error> {
+        streaming::batch_claim(&env, &recipient, &stream_ids)
+    }
+
     /// Cancel a stream
     ///
     /// Allows creator to cancel a stream. Recipient can still claim vested amount.
@@ -1775,3 +1807,6 @@ mod stateful_model_test;
 
 #[cfg(test)]
 mod stateful_model_based_test;
+
+#[cfg(test)]
+mod batch_claim_test;

--- a/contracts/token-factory/src/streaming.rs
+++ b/contracts/token-factory/src/streaming.rs
@@ -236,6 +236,74 @@ pub fn claim_stream(
     Ok(claimable)
 }
 
+/// Batch claim vested tokens from multiple streams
+///
+/// Allows recipient to claim tokens that have vested according to schedule
+/// from multiple streams in a single transaction. Streams that cannot be
+/// claimed (e.g. before cliff or zero remaining) are skipped without error.
+///
+/// # Arguments
+/// * `env` - The contract environment
+/// * `recipient` - Address claiming tokens (must authorize)
+/// * `stream_ids` - Vector of stream IDs to claim from
+///
+/// # Returns
+/// Returns a vector of claimed amounts matching the input order
+///
+/// # Errors
+/// * `Error::Unauthorized` - Caller is not the recipient for one of the streams
+/// * `Error::TokenNotFound` - Stream not found
+/// * `Error::InvalidParameters` - Stream cancelled
+pub fn batch_claim(
+    env: &Env,
+    recipient: &Address,
+    stream_ids: &Vec<u64>,
+) -> Result<Vec<i128>, Error> {
+    recipient.require_auth();
+    
+    // First pass: validate all streams
+    for stream_id in stream_ids.iter() {
+        let stream = storage::get_stream(env, stream_id)
+            .ok_or(Error::TokenNotFound)?;
+            
+        // Verify recipient
+        if stream.recipient != *recipient {
+            return Err(Error::Unauthorized);
+        }
+        
+        // Check if cancelled
+        if stream.cancelled {
+            return Err(Error::InvalidParameters);
+        }
+    }
+    
+    // Second pass: claim from all eligible streams
+    let mut claimed_amounts = Vec::new(env);
+    
+    for stream_id in stream_ids.iter() {
+        let mut stream = storage::get_stream(env, stream_id).unwrap();
+        
+        // Calculate claimable amount
+        let claimable = calculate_claimable(env, &stream)?;
+        
+        if claimable > 0 {
+            // Update claimed amount
+            stream.claimed_amount = stream.claimed_amount
+                .checked_add(claimable)
+                .ok_or(Error::ArithmeticError)?;
+                
+            storage::set_stream(env, stream_id, &stream);
+            
+            // Emit event
+            events::emit_stream_claimed(env, stream_id, recipient, claimable);
+        }
+        
+        claimed_amounts.push_back(claimable);
+    }
+    
+    Ok(claimed_amounts)
+}
+
 /// Calculate claimable amount for a stream
 ///
 /// Calculates how much can be claimed based on vesting schedule.


### PR DESCRIPTION


This PR introduces the ability for beneficiaries to claim tokens from **multiple vesting streams in a single transaction** using the new `batch_claim` function.

This significantly reduces **transaction friction** and **gas overhead** for users who have multiple streams.

---

# Changes Made

## . Added `batch_claim` to `streaming.rs`

Implemented a **two-pass approach** to ensure **atomic and predictable behavior**.

### Validation Pass
Validates all provided `stream_ids` to ensure:

- The stream exists
- The caller is the **authorized recipient**
- The stream is **not cancelled**

If **any validation fails**, the **entire batch transaction reverts**.

### Claim Pass
- Calculates the **claimable amount** for each stream.

### Graceful Skipping
If a stream has **0 claimable amount** (for example):

- The **cliff has not been reached**
- The stream is **already fully claimed**

The function **skips it instead of failing the batch**.

This allows batches with **mixed claimable and non-claimable streams**.


closes #358 