### PR TITLE
feat(token-factory): add vault cancellation policy and guards (#513)

### DIFF
--- a/contracts/token-factory/src/events.rs
+++ b/contracts/token-factory/src/events.rs
@@ -522,6 +522,29 @@ pub fn emit_vault_created(
     );
 }
 
+/// Emit vault claimed event
+///
+/// Published when a vault owner claims unlocked tokens.
+pub fn emit_vault_claimed(env: &Env, vault_id: u64, owner: &Address, amount: i128) {
+    env.events()
+        .publish((symbol_short!("vlt_clm"), vault_id), (owner.clone(), amount));
+}
+
+/// Emit vault cancelled event
+///
+/// Published when a vault is cancelled by an authorized actor.
+pub fn emit_vault_cancelled(
+    env: &Env,
+    vault_id: u64,
+    actor: &Address,
+    remaining_amount: i128,
+) {
+    env.events().publish(
+        (symbol_short!("vlt_cnl"), vault_id),
+        (actor.clone(), remaining_amount),
+    );
+}
+
 /// Emit metadata set event
 /// 
 /// Published when metadata is set for a token

--- a/contracts/token-factory/src/lib.rs
+++ b/contracts/token-factory/src/lib.rs
@@ -1489,6 +1489,93 @@ impl TokenFactory {
         storage::get_vault(&env, vault_id).ok_or(Error::TokenNotFound)
     }
 
+    /// Claim unlocked tokens from an active vault.
+    pub fn claim_vault(env: Env, vault_id: u64, actor: Address) -> Result<i128, Error> {
+        actor.require_auth();
+
+        if storage::is_paused(&env) {
+            return Err(Error::ContractPaused);
+        }
+
+        let mut vault = storage::get_vault(&env, vault_id).ok_or(Error::TokenNotFound)?;
+
+        if actor != vault.owner {
+            return Err(Error::Unauthorized);
+        }
+
+        if vault.status == VaultStatus::Cancelled {
+            return Err(Error::InvalidParameters);
+        }
+
+        if vault.status == VaultStatus::Claimed || vault.claimed_amount >= vault.total_amount {
+            return Err(Error::NothingToClaim);
+        }
+
+        if vault.unlock_time > 0 && env.ledger().timestamp() < vault.unlock_time {
+            return Err(Error::InvalidParameters);
+        }
+
+        let claimable = vault
+            .total_amount
+            .checked_sub(vault.claimed_amount)
+            .ok_or(Error::ArithmeticError)?;
+
+        if claimable <= 0 {
+            return Err(Error::NothingToClaim);
+        }
+
+        vault.claimed_amount = vault
+            .claimed_amount
+            .checked_add(claimable)
+            .ok_or(Error::ArithmeticError)?;
+        vault.status = VaultStatus::Claimed;
+        storage::set_vault(&env, &vault)?;
+
+        events::emit_vault_claimed(&env, vault_id, &actor, claimable);
+        Ok(claimable)
+    }
+
+    /// Cancel an active vault using policy checks.
+    ///
+    /// Policy:
+    /// - `actor` must authorize.
+    /// - `actor` must be the vault creator or contract admin.
+    /// - Already claimed/cancelled vaults cannot be cancelled.
+    ///
+    /// Partially claimed behavior:
+    /// - Cancellation is allowed.
+    /// - `claimed_amount` remains unchanged.
+    /// - Remaining amount is permanently unclaimable.
+    pub fn cancel_vault(env: Env, vault_id: u64, actor: Address) -> Result<(), Error> {
+        actor.require_auth();
+
+        if storage::is_paused(&env) {
+            return Err(Error::ContractPaused);
+        }
+
+        let mut vault = storage::get_vault(&env, vault_id).ok_or(Error::TokenNotFound)?;
+        let admin = storage::get_admin(&env);
+        if actor != vault.creator && actor != admin {
+            return Err(Error::Unauthorized);
+        }
+
+        if vault.status != VaultStatus::Active {
+            return Err(Error::InvalidParameters);
+        }
+
+        let remaining_amount = vault
+            .total_amount
+            .checked_sub(vault.claimed_amount)
+            .ok_or(Error::ArithmeticError)?
+            .max(0);
+
+        vault.status = VaultStatus::Cancelled;
+        storage::set_vault(&env, &vault)?;
+        events::emit_vault_cancelled(&env, vault_id, &actor, remaining_amount);
+
+        Ok(())
+    }
+
     /// Update stream metadata (creator/admin only)
     ///
     /// Allows the stream creator or admin to update the metadata associated with
@@ -1782,6 +1869,9 @@ mod event_replay_test;
 
 #[cfg(test)]
 mod batch_token_creation_test;
+
+#[cfg(test)]
+mod vault_cancellation_test;
 
 // Vault/Stream Security and Fuzz Tests
 // Temporarily disabled - requires fixing timelock/freeze dependencies

--- a/contracts/token-factory/src/vault_cancellation_test.rs
+++ b/contracts/token-factory/src/vault_cancellation_test.rs
@@ -1,0 +1,119 @@
+#![cfg(test)]
+
+use crate::{
+    types::{DataKey, TokenInfo, VaultStatus},
+    TokenFactory, TokenFactoryClient,
+};
+use soroban_sdk::{
+    testutils::{Address as _, Events},
+    Address, BytesN, Env, String,
+};
+
+fn setup() -> (Env, Address, Address, Address, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, TokenFactory);
+    let client = TokenFactoryClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    client.initialize(&admin, &treasury, &1_000_000, &500_000);
+
+    let creator = Address::generate(&env);
+    let owner = Address::generate(&env);
+    let token = Address::generate(&env);
+    let token_info = TokenInfo {
+        address: token.clone(),
+        creator: creator.clone(),
+        name: String::from_str(&env, "Vault Token"),
+        symbol: String::from_str(&env, "VLT"),
+        decimals: 7,
+        total_supply: 1_000_000_000,
+        initial_supply: 1_000_000_000,
+        max_supply: None,
+        total_burned: 0,
+        burn_count: 0,
+        metadata_uri: None,
+        created_at: 0,
+        is_paused: false,
+        clawback_enabled: false,
+        freeze_enabled: false,
+    };
+
+    env.as_contract(&contract_id, || {
+        crate::storage::set_token_info_by_address(&env, &token, &token_info);
+    });
+
+    (env, contract_id, admin, creator, owner, token)
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #2)")]
+fn test_cancel_vault_rejects_unauthorized_actor() {
+    let (env, contract_id, _admin, creator, owner, token) = setup();
+    let client = TokenFactoryClient::new(&env, &contract_id);
+    let attacker = Address::generate(&env);
+    let no_milestone = BytesN::from_array(&env, &[0u8; 32]);
+
+    let vault_id = client.create_vault(&creator, &token, &owner, &500_000, &1, &no_milestone);
+    let _ = client.cancel_vault(&vault_id, &attacker);
+}
+
+#[test]
+fn test_cancel_vault_emits_event_and_marks_cancelled() {
+    let (env, contract_id, _admin, creator, owner, token) = setup();
+    let client = TokenFactoryClient::new(&env, &contract_id);
+    let no_milestone = BytesN::from_array(&env, &[0u8; 32]);
+
+    let vault_id = client.create_vault(&creator, &token, &owner, &500_000, &1, &no_milestone);
+    let before = env.events().all().len();
+    client.cancel_vault(&vault_id, &creator);
+
+    let vault = client.get_vault(&vault_id);
+    assert_eq!(vault.status, VaultStatus::Cancelled);
+
+    let events = env.events().all();
+    assert_eq!(events.len(), before + 1);
+    let last = events.get(events.len() - 1).unwrap();
+    let topics = last.1;
+    let first_topic: soroban_sdk::Symbol =
+        soroban_sdk::FromVal::from_val(&env, &topics.get(0).unwrap());
+    assert_eq!(first_topic, soroban_sdk::symbol_short!("vlt_cnl"));
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3)")]
+fn test_claim_rejected_after_cancel() {
+    let (env, contract_id, _admin, creator, owner, token) = setup();
+    let client = TokenFactoryClient::new(&env, &contract_id);
+    let no_milestone = BytesN::from_array(&env, &[0u8; 32]);
+
+    let vault_id = client.create_vault(&creator, &token, &owner, &500_000, &1, &no_milestone);
+    client.cancel_vault(&vault_id, &creator);
+
+    let _ = client.claim_vault(&vault_id, &owner);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3)")]
+fn test_cancel_partially_claimed_vault_preserves_claimed_amount() {
+    let (env, contract_id, _admin, creator, owner, token) = setup();
+    let client = TokenFactoryClient::new(&env, &contract_id);
+    let no_milestone = BytesN::from_array(&env, &[0u8; 32]);
+
+    let vault_id = client.create_vault(&creator, &token, &owner, &500_000, &1, &no_milestone);
+    let mut vault = client.get_vault(&vault_id);
+    vault.claimed_amount = 200_000;
+
+    env.as_contract(&contract_id, || {
+        env.storage().persistent().set(&DataKey::Vault(vault_id), &vault);
+    });
+
+    client.cancel_vault(&vault_id, &creator);
+    let cancelled = client.get_vault(&vault_id);
+    assert_eq!(cancelled.status, VaultStatus::Cancelled);
+    assert_eq!(cancelled.claimed_amount, 200_000);
+
+    let _ = client.claim_vault(&vault_id, &owner);
+}


### PR DESCRIPTION
Closes #513

## Changes
- Added `cancel_vault(vault_id, actor)` entrypoint with policy checks:
  - `actor` must authorize
  - only vault creator or contract admin can cancel
  - only `Active` vaults can be cancelled
- Added `claim_vault(vault_id, actor)` entrypoint and enforced post-cancel claim rejection.
- Defined and implemented partially claimed vault cancellation behavior:
  - cancellation is allowed
  - `claimed_amount` is preserved
  - remaining amount is emitted in cancellation event and becomes unclaimable
- Added `vault_cancelled` event emission (`vlt_cnl`).
- Added vault-specific tests for:
  - unauthorized cancellation
  - cancel event emission + status transition
  - post-cancel claim rejection
  - partial-claim cancellation behavior

## Testing
- Command run:
  - `cd contracts && cargo test -p token-factory vault_cancellation_test -- --nocapture`
- Result:
  - blocked by pre-existing compile errors in the crate unrelated to this issue (duplicate module/event defs, missing types/errors in other modules).
- New vault-cancellation logic and tests are isolated to:
  - `contracts/token-factory/src/lib.rs`
  - `contracts/token-factory/src/events.rs`
  - `contracts/token-factory/src/vault_cancellation_test.rs`
