### PR TITLE
feat(integration): persist token projections from contract events

### DIFF
--- a/backend/src/__tests__/tokenEventParser.integration.test.ts
+++ b/backend/src/__tests__/tokenEventParser.integration.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { PrismaClient } from "@prisma/client";
+import { TokenEventParser, RawTokenEvent } from "../services/tokenEventParser";
+
+const TOKEN_ADDRESS = "CTOKEN_TEST_PROJECTION_001";
+const CREATOR = "GCREATOR_TEST_001";
+const TX_CREATE = "tx-token-create-001";
+const TX_BURN_1 = "tx-burn-self-001";
+const TX_BURN_ADMIN = "tx-burn-admin-001";
+
+const tokenCreatedEvent: RawTokenEvent = {
+  type: "tok_reg",
+  tokenAddress: TOKEN_ADDRESS,
+  transactionHash: TX_CREATE,
+  ledger: 1000,
+  creator: CREATOR,
+  name: "Test Token",
+  symbol: "TTK",
+  decimals: 7,
+  initialSupply: "1000000000000",
+};
+
+const selfBurnEvent: RawTokenEvent = {
+  type: "tok_burn",
+  tokenAddress: TOKEN_ADDRESS,
+  transactionHash: TX_BURN_1,
+  ledger: 1001,
+  from: "GUSER_001",
+  amount: "100000000",
+  burner: "GUSER_001",
+};
+
+const adminBurnEvent: RawTokenEvent = {
+  type: "adm_burn",
+  tokenAddress: TOKEN_ADDRESS,
+  transactionHash: TX_BURN_ADMIN,
+  ledger: 1002,
+  from: "GUSER_002",
+  amount: "200000000",
+  admin: CREATOR,
+};
+
+const metadataEvent: RawTokenEvent = {
+  type: "tok_meta",
+  tokenAddress: TOKEN_ADDRESS,
+  transactionHash: "tx-meta-001",
+  ledger: 1003,
+  metadataUri: "ipfs://QmTest123",
+  updatedBy: CREATOR,
+};
+
+describe("TokenEventParser integration", () => {
+  let prisma: PrismaClient;
+  let parser: TokenEventParser;
+
+  beforeEach(async () => {
+    prisma = new PrismaClient();
+    parser = new TokenEventParser(prisma);
+
+    // Clean up in dependency order
+    await prisma.burnRecord.deleteMany({ where: { token: { address: TOKEN_ADDRESS } } });
+    await prisma.token.deleteMany({ where: { address: TOKEN_ADDRESS } });
+  });
+
+  afterEach(async () => {
+    await prisma.$disconnect();
+  });
+
+  it("inserts a token row on tok_reg event", async () => {
+    await parser.parseEvent(tokenCreatedEvent);
+
+    const token = await prisma.token.findUnique({ where: { address: TOKEN_ADDRESS } });
+    expect(token).not.toBeNull();
+    expect(token?.creator).toBe(CREATOR);
+    expect(token?.name).toBe("Test Token");
+    expect(token?.symbol).toBe("TTK");
+    expect(token?.decimals).toBe(7);
+    expect(token?.initialSupply).toBe(BigInt("1000000000000"));
+    expect(token?.totalSupply).toBe(BigInt("1000000000000"));
+    expect(token?.totalBurned).toBe(BigInt(0));
+    expect(token?.burnCount).toBe(0);
+  });
+
+  it("increments totalBurned and burnCount on self-burn", async () => {
+    await parser.parseEvent(tokenCreatedEvent);
+    await parser.parseEvent(selfBurnEvent);
+
+    const token = await prisma.token.findUnique({ where: { address: TOKEN_ADDRESS } });
+    expect(token?.totalBurned).toBe(BigInt("100000000"));
+    expect(token?.burnCount).toBe(1);
+    expect(token?.totalSupply).toBe(BigInt("1000000000000") - BigInt("100000000"));
+
+    const record = await prisma.burnRecord.findUnique({ where: { txHash: TX_BURN_1 } });
+    expect(record).not.toBeNull();
+    expect(record?.isAdminBurn).toBe(false);
+    expect(record?.from).toBe("GUSER_001");
+  });
+
+  it("increments totalBurned and burnCount on admin-burn", async () => {
+    await parser.parseEvent(tokenCreatedEvent);
+    await parser.parseEvent(adminBurnEvent);
+
+    const token = await prisma.token.findUnique({ where: { address: TOKEN_ADDRESS } });
+    expect(token?.totalBurned).toBe(BigInt("200000000"));
+    expect(token?.burnCount).toBe(1);
+
+    const record = await prisma.burnRecord.findUnique({ where: { txHash: TX_BURN_ADMIN } });
+    expect(record?.isAdminBurn).toBe(true);
+    expect(record?.burnedBy).toBe(CREATOR);
+  });
+
+  it("updates metadataUri on tok_meta event", async () => {
+    await parser.parseEvent(tokenCreatedEvent);
+    await parser.parseEvent(metadataEvent);
+
+    const token = await prisma.token.findUnique({ where: { address: TOKEN_ADDRESS } });
+    expect(token?.metadataUri).toBe("ipfs://QmTest123");
+  });
+
+  it("replaying tok_reg does not double-apply (idempotent)", async () => {
+    await parser.parseEvent(tokenCreatedEvent);
+    await parser.parseEvent(tokenCreatedEvent); // replay
+
+    const count = await prisma.token.count({ where: { address: TOKEN_ADDRESS } });
+    expect(count).toBe(1);
+  });
+
+  it("replaying a burn event does not double-apply (idempotent)", async () => {
+    await parser.parseEvent(tokenCreatedEvent);
+    await parser.parseEvent(selfBurnEvent);
+    await parser.parseEvent(selfBurnEvent); // replay
+
+    const token = await prisma.token.findUnique({ where: { address: TOKEN_ADDRESS } });
+    expect(token?.burnCount).toBe(1);
+    expect(token?.totalBurned).toBe(BigInt("100000000"));
+
+    const records = await prisma.burnRecord.findMany({
+      where: { token: { address: TOKEN_ADDRESS } },
+    });
+    expect(records).toHaveLength(1);
+  });
+
+  it("accumulates multiple distinct burns correctly", async () => {
+    await parser.parseEvent(tokenCreatedEvent);
+    await parser.parseEvent(selfBurnEvent);
+    await parser.parseEvent(adminBurnEvent);
+
+    const token = await prisma.token.findUnique({ where: { address: TOKEN_ADDRESS } });
+    expect(token?.burnCount).toBe(2);
+    expect(token?.totalBurned).toBe(BigInt("300000000"));
+  });
+});

--- a/backend/src/services/stellarEventListener.ts
+++ b/backend/src/services/stellarEventListener.ts
@@ -4,6 +4,7 @@ import webhookDeliveryService from "./webhookDeliveryService";
 import { PrismaClient } from "@prisma/client";
 import { GovernanceEventParser } from "./governanceEventParser";
 import governanceEventMapper from "./governanceEventMapper";
+import { TokenEventParser, RawTokenEvent } from "./tokenEventParser";
 
 const HORIZON_URL =
   process.env.STELLAR_HORIZON_URL || "https://horizon-testnet.stellar.org";
@@ -28,10 +29,12 @@ export class StellarEventListener {
   private lastCursor: string | null = null;
   private prisma: PrismaClient;
   private governanceParser: GovernanceEventParser;
+  private tokenEventParser: TokenEventParser;
 
   constructor() {
     this.prisma = new PrismaClient();
     this.governanceParser = new GovernanceEventParser(this.prisma);
+    this.tokenEventParser = new TokenEventParser(this.prisma);
   }
 
   /**
@@ -130,6 +133,12 @@ export class StellarEventListener {
 
       if (!eventData) {
         return;
+      }
+
+      // Persist token projection (idempotent)
+      const rawTokenEvent = this.toRawTokenEvent(event);
+      if (rawTokenEvent) {
+        await this.tokenEventParser.parseEvent(rawTokenEvent);
       }
 
       // Trigger webhooks only if we have a webhook event type
@@ -233,6 +242,60 @@ export class StellarEventListener {
 
       default:
         return baseData;
+    }
+  }
+
+  /**
+   * Map a StellarEvent to a RawTokenEvent for projection, or null if not a token event.
+   */
+  private toRawTokenEvent(event: StellarEvent): RawTokenEvent | null {
+    const topic0 = event.topic[0];
+    const tokenAddress = event.topic[1] || "";
+
+    switch (topic0) {
+      case "tok_reg":
+        return {
+          type: "tok_reg",
+          tokenAddress,
+          transactionHash: event.transaction_hash,
+          ledger: event.ledger,
+          creator: event.value?.creator || "",
+          name: event.value?.name || "",
+          symbol: event.value?.symbol || "",
+          decimals: event.value?.decimals ?? 7,
+          initialSupply: event.value?.initial_supply?.toString() || "0",
+        };
+      case "tok_burn":
+        return {
+          type: "tok_burn",
+          tokenAddress,
+          transactionHash: event.transaction_hash,
+          ledger: event.ledger,
+          from: event.value?.from || "",
+          amount: event.value?.amount?.toString() || "0",
+          burner: event.value?.burner || event.value?.from || "",
+        };
+      case "adm_burn":
+        return {
+          type: "adm_burn",
+          tokenAddress,
+          transactionHash: event.transaction_hash,
+          ledger: event.ledger,
+          from: event.value?.from || "",
+          amount: event.value?.amount?.toString() || "0",
+          admin: event.value?.admin || "",
+        };
+      case "tok_meta":
+        return {
+          type: "tok_meta",
+          tokenAddress,
+          transactionHash: event.transaction_hash,
+          ledger: event.ledger,
+          metadataUri: event.value?.metadata_uri || "",
+          updatedBy: event.value?.updated_by || "",
+        };
+      default:
+        return null;
     }
   }
 

--- a/backend/src/services/tokenEventParser.ts
+++ b/backend/src/services/tokenEventParser.ts
@@ -1,0 +1,114 @@
+import { PrismaClient } from "@prisma/client";
+
+export interface RawTokenEvent {
+  type: "tok_reg" | "tok_burn" | "adm_burn" | "tok_meta";
+  tokenAddress: string;
+  transactionHash: string;
+  ledger: number;
+  // tok_reg fields
+  creator?: string;
+  name?: string;
+  symbol?: string;
+  decimals?: number;
+  initialSupply?: string;
+  // burn fields
+  from?: string;
+  amount?: string;
+  burner?: string;
+  admin?: string;
+  // metadata fields
+  metadataUri?: string;
+  updatedBy?: string;
+}
+
+export class TokenEventParser {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async parseEvent(event: RawTokenEvent): Promise<void> {
+    switch (event.type) {
+      case "tok_reg":
+        await this.handleTokenCreated(event);
+        break;
+      case "tok_burn":
+        await this.handleBurn(event, false);
+        break;
+      case "adm_burn":
+        await this.handleBurn(event, true);
+        break;
+      case "tok_meta":
+        await this.handleMetadataUpdate(event);
+        break;
+    }
+  }
+
+  private async handleTokenCreated(event: RawTokenEvent): Promise<void> {
+    const initialSupply = BigInt(event.initialSupply ?? "0");
+
+    await this.prisma.token.upsert({
+      where: { address: event.tokenAddress },
+      create: {
+        address: event.tokenAddress,
+        creator: event.creator ?? "",
+        name: event.name ?? "",
+        symbol: event.symbol ?? "",
+        decimals: event.decimals ?? 7,
+        totalSupply: initialSupply,
+        initialSupply,
+      },
+      update: {}, // idempotent — do not overwrite on replay
+    });
+  }
+
+  private async handleBurn(
+    event: RawTokenEvent,
+    isAdminBurn: boolean
+  ): Promise<void> {
+    // Idempotency: txHash is unique on BurnRecord
+    const existing = await this.prisma.burnRecord.findUnique({
+      where: { txHash: event.transactionHash },
+    });
+    if (existing) return;
+
+    const token = await this.prisma.token.findUnique({
+      where: { address: event.tokenAddress },
+    });
+    if (!token) {
+      console.warn(
+        `TokenEventParser: burn for unknown token ${event.tokenAddress}, skipping`
+      );
+      return;
+    }
+
+    const amount = BigInt(event.amount ?? "0");
+
+    await this.prisma.$transaction([
+      this.prisma.burnRecord.create({
+        data: {
+          tokenId: token.id,
+          from: event.from ?? "",
+          amount,
+          burnedBy: isAdminBurn
+            ? (event.admin ?? event.from ?? "")
+            : (event.burner ?? event.from ?? ""),
+          isAdminBurn,
+          txHash: event.transactionHash,
+        },
+      }),
+      this.prisma.token.update({
+        where: { id: token.id },
+        data: {
+          totalBurned: { increment: amount },
+          burnCount: { increment: 1 },
+          totalSupply: { decrement: amount },
+        },
+      }),
+    ]);
+  }
+
+  private async handleMetadataUpdate(event: RawTokenEvent): Promise<void> {
+    await this.prisma.token.updateMany({
+      where: { address: event.tokenAddress },
+      data: { metadataUri: event.metadataUri ?? null },
+    });
+  }
+}


### PR DESCRIPTION
Closes #604

What
Persist tok_reg, tok_burn, adm_burn, and tok_meta contract events into Prisma Token and BurnRecord tables.

Changes
- tokenEventParser.ts — new service handling all 4 event types with idempotent upserts
- stellarEventListener.ts — routes token events to the parser before webhook delivery
- tokenEventParser.integration.test.ts — 7 tests covering creation, burns, metadata, and replay safety

Idempotency
- Token creation: upsert with empty update block
- Burns: early-exit if txHash already exists in BurnRecord