### PR TITLE
Feature/real buyback campaign creation

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -283,3 +283,12 @@ enum CampaignStatus {
   COMPLETED
   CANCELLED
 }
+
+/// Stores durable state for long-running backend services.
+/// Used by StellarEventListener to persist the last processed event cursor
+/// so it can resume correctly after restarts without missing or replaying events.
+model IntegrationState {
+  key       String   @id
+  value     String
+  updatedAt DateTime @updatedAt
+}

--- a/backend/src/__tests__/campaignRoutes.public-shape.test.ts
+++ b/backend/src/__tests__/campaignRoutes.public-shape.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import request from "supertest";
+import express from "express";
+import campaignRoutes from "../routes/campaigns";
+
+vi.mock("../services/campaignProjectionService", () => ({
+  campaignProjectionService: {
+    getCampaignById: vi.fn(),
+    getCampaignsByToken: vi.fn(),
+    getCampaignsByCreator: vi.fn(),
+    getExecutionHistory: vi.fn(),
+    getCampaignStats: vi.fn(),
+  },
+}));
+
+import { campaignProjectionService } from "../services/campaignProjectionService";
+
+const app = express();
+app.use(express.json());
+app.use("/api/campaigns", campaignRoutes);
+
+const mockCampaign = {
+  id: "uuid-1",
+  campaignId: 1,
+  tokenId: "token-1",
+  creator: "GCREATOR",
+  type: "BUYBACK",
+  status: "ACTIVE",
+  targetAmount: BigInt(1000),
+  currentAmount: BigInt(0),
+  executionCount: 0,
+  progress: 0,
+  startTime: new Date(),
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+describe("Campaign routes public contract — mounted at /api/campaigns", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("GET /api/campaigns/:id returns campaign", async () => {
+    vi.mocked(campaignProjectionService.getCampaignById).mockResolvedValue(mockCampaign as any);
+    const res = await request(app).get("/api/campaigns/1");
+    expect(res.status).toBe(200);
+    expect(res.body.campaignId).toBe(1);
+  });
+
+  it("GET /api/campaigns/:id returns 404 when not found", async () => {
+    vi.mocked(campaignProjectionService.getCampaignById).mockResolvedValue(null);
+    const res = await request(app).get("/api/campaigns/999");
+    expect(res.status).toBe(404);
+  });
+
+  it("GET /api/campaigns/token/:tokenId returns list", async () => {
+    vi.mocked(campaignProjectionService.getCampaignsByToken).mockResolvedValue([mockCampaign] as any);
+    const res = await request(app).get("/api/campaigns/token/token-1");
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+  });
+
+  it("GET /api/campaigns/creator/:creator returns list", async () => {
+    vi.mocked(campaignProjectionService.getCampaignsByCreator).mockResolvedValue([mockCampaign] as any);
+    const res = await request(app).get("/api/campaigns/creator/GCREATOR");
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+  });
+
+  it("GET /api/campaigns/:id/executions returns history", async () => {
+    vi.mocked(campaignProjectionService.getExecutionHistory).mockResolvedValue({ executions: [], total: 0 });
+    const res = await request(app).get("/api/campaigns/1/executions");
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty("total");
+  });
+
+  it("GET /api/campaigns/stats returns stats", async () => {
+    vi.mocked(campaignProjectionService.getCampaignStats).mockResolvedValue({
+      totalCampaigns: 1, activeCampaigns: 1, completedCampaigns: 0,
+      totalVolume: BigInt(0), totalExecutions: 0,
+    });
+    const res = await request(app).get("/api/campaigns/stats");
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty("totalCampaigns");
+  });
+
+  it("old /api/campaigns/campaigns/:id path does NOT exist", async () => {
+    const res = await request(app).get("/api/campaigns/campaigns/1");
+    // Would 404 since no such route is registered
+    expect(res.status).toBe(404);
+  });
+});

--- a/backend/src/__tests__/stellarEventListener.cursor.test.ts
+++ b/backend/src/__tests__/stellarEventListener.cursor.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { PrismaClient } from "@prisma/client";
+import { EventCursorStore } from "../services/eventCursorStore";
+
+describe("EventCursorStore", () => {
+  let prisma: PrismaClient;
+  let store: EventCursorStore;
+
+  beforeEach(async () => {
+    prisma = new PrismaClient();
+    store = new EventCursorStore(prisma);
+    await prisma.integrationState.deleteMany({ where: { key: "stellar_event_cursor" } });
+  });
+
+  afterEach(async () => {
+    await prisma.$disconnect();
+  });
+
+  it("returns null on first boot when no env origin is set", async () => {
+    delete process.env.STELLAR_CURSOR_ORIGIN;
+    const cursor = await store.load();
+    expect(cursor).toBeNull();
+  });
+
+  it("returns STELLAR_CURSOR_ORIGIN on first boot when env is set", async () => {
+    process.env.STELLAR_CURSOR_ORIGIN = "0000000000000000";
+    const cursor = await store.load();
+    expect(cursor).toBe("0000000000000000");
+    delete process.env.STELLAR_CURSOR_ORIGIN;
+  });
+
+  it("persists and reloads a cursor", async () => {
+    await store.save("cursor-abc-123");
+    const cursor = await store.load();
+    expect(cursor).toBe("cursor-abc-123");
+  });
+
+  it("overwrites cursor on subsequent saves (upsert)", async () => {
+    await store.save("cursor-first");
+    await store.save("cursor-second");
+    const cursor = await store.load();
+    expect(cursor).toBe("cursor-second");
+  });
+});
+
+describe("StellarEventListener cursor resume", () => {
+  let prisma: PrismaClient;
+  let store: EventCursorStore;
+
+  beforeEach(async () => {
+    prisma = new PrismaClient();
+    store = new EventCursorStore(prisma);
+    await prisma.integrationState.deleteMany({ where: { key: "stellar_event_cursor" } });
+  });
+
+  afterEach(async () => {
+    await prisma.$disconnect();
+  });
+
+  it("resumes from last saved cursor after simulated restart", async () => {
+    // Simulate first run: process events and save cursor
+    await store.save("paging-token-42");
+
+    // Simulate restart: new store instance loads the cursor
+    const storeAfterRestart = new EventCursorStore(prisma);
+    const resumedCursor = await storeAfterRestart.load();
+
+    expect(resumedCursor).toBe("paging-token-42");
+  });
+
+  it("does not corrupt state when same cursor is saved twice", async () => {
+    await store.save("paging-token-99");
+    await store.save("paging-token-99"); // replay same cursor
+
+    const cursor = await store.load();
+    expect(cursor).toBe("paging-token-99");
+
+    const rows = await prisma.integrationState.count({
+      where: { key: "stellar_event_cursor" },
+    });
+    expect(rows).toBe(1);
+  });
+});

--- a/backend/src/__tests__/tokenEventParser.integration.test.ts
+++ b/backend/src/__tests__/tokenEventParser.integration.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { PrismaClient } from "@prisma/client";
+import { TokenEventParser, RawTokenEvent } from "../services/tokenEventParser";
+
+const TOKEN_ADDRESS = "CTOKEN_TEST_PROJECTION_001";
+const CREATOR = "GCREATOR_TEST_001";
+const TX_CREATE = "tx-token-create-001";
+const TX_BURN_1 = "tx-burn-self-001";
+const TX_BURN_ADMIN = "tx-burn-admin-001";
+
+const tokenCreatedEvent: RawTokenEvent = {
+  type: "tok_reg",
+  tokenAddress: TOKEN_ADDRESS,
+  transactionHash: TX_CREATE,
+  ledger: 1000,
+  creator: CREATOR,
+  name: "Test Token",
+  symbol: "TTK",
+  decimals: 7,
+  initialSupply: "1000000000000",
+};
+
+const selfBurnEvent: RawTokenEvent = {
+  type: "tok_burn",
+  tokenAddress: TOKEN_ADDRESS,
+  transactionHash: TX_BURN_1,
+  ledger: 1001,
+  from: "GUSER_001",
+  amount: "100000000",
+  burner: "GUSER_001",
+};
+
+const adminBurnEvent: RawTokenEvent = {
+  type: "adm_burn",
+  tokenAddress: TOKEN_ADDRESS,
+  transactionHash: TX_BURN_ADMIN,
+  ledger: 1002,
+  from: "GUSER_002",
+  amount: "200000000",
+  admin: CREATOR,
+};
+
+const metadataEvent: RawTokenEvent = {
+  type: "tok_meta",
+  tokenAddress: TOKEN_ADDRESS,
+  transactionHash: "tx-meta-001",
+  ledger: 1003,
+  metadataUri: "ipfs://QmTest123",
+  updatedBy: CREATOR,
+};
+
+describe("TokenEventParser integration", () => {
+  let prisma: PrismaClient;
+  let parser: TokenEventParser;
+
+  beforeEach(async () => {
+    prisma = new PrismaClient();
+    parser = new TokenEventParser(prisma);
+
+    // Clean up in dependency order
+    await prisma.burnRecord.deleteMany({ where: { token: { address: TOKEN_ADDRESS } } });
+    await prisma.token.deleteMany({ where: { address: TOKEN_ADDRESS } });
+  });
+
+  afterEach(async () => {
+    await prisma.$disconnect();
+  });
+
+  it("inserts a token row on tok_reg event", async () => {
+    await parser.parseEvent(tokenCreatedEvent);
+
+    const token = await prisma.token.findUnique({ where: { address: TOKEN_ADDRESS } });
+    expect(token).not.toBeNull();
+    expect(token?.creator).toBe(CREATOR);
+    expect(token?.name).toBe("Test Token");
+    expect(token?.symbol).toBe("TTK");
+    expect(token?.decimals).toBe(7);
+    expect(token?.initialSupply).toBe(BigInt("1000000000000"));
+    expect(token?.totalSupply).toBe(BigInt("1000000000000"));
+    expect(token?.totalBurned).toBe(BigInt(0));
+    expect(token?.burnCount).toBe(0);
+  });
+
+  it("increments totalBurned and burnCount on self-burn", async () => {
+    await parser.parseEvent(tokenCreatedEvent);
+    await parser.parseEvent(selfBurnEvent);
+
+    const token = await prisma.token.findUnique({ where: { address: TOKEN_ADDRESS } });
+    expect(token?.totalBurned).toBe(BigInt("100000000"));
+    expect(token?.burnCount).toBe(1);
+    expect(token?.totalSupply).toBe(BigInt("1000000000000") - BigInt("100000000"));
+
+    const record = await prisma.burnRecord.findUnique({ where: { txHash: TX_BURN_1 } });
+    expect(record).not.toBeNull();
+    expect(record?.isAdminBurn).toBe(false);
+    expect(record?.from).toBe("GUSER_001");
+  });
+
+  it("increments totalBurned and burnCount on admin-burn", async () => {
+    await parser.parseEvent(tokenCreatedEvent);
+    await parser.parseEvent(adminBurnEvent);
+
+    const token = await prisma.token.findUnique({ where: { address: TOKEN_ADDRESS } });
+    expect(token?.totalBurned).toBe(BigInt("200000000"));
+    expect(token?.burnCount).toBe(1);
+
+    const record = await prisma.burnRecord.findUnique({ where: { txHash: TX_BURN_ADMIN } });
+    expect(record?.isAdminBurn).toBe(true);
+    expect(record?.burnedBy).toBe(CREATOR);
+  });
+
+  it("updates metadataUri on tok_meta event", async () => {
+    await parser.parseEvent(tokenCreatedEvent);
+    await parser.parseEvent(metadataEvent);
+
+    const token = await prisma.token.findUnique({ where: { address: TOKEN_ADDRESS } });
+    expect(token?.metadataUri).toBe("ipfs://QmTest123");
+  });
+
+  it("replaying tok_reg does not double-apply (idempotent)", async () => {
+    await parser.parseEvent(tokenCreatedEvent);
+    await parser.parseEvent(tokenCreatedEvent); // replay
+
+    const count = await prisma.token.count({ where: { address: TOKEN_ADDRESS } });
+    expect(count).toBe(1);
+  });
+
+  it("replaying a burn event does not double-apply (idempotent)", async () => {
+    await parser.parseEvent(tokenCreatedEvent);
+    await parser.parseEvent(selfBurnEvent);
+    await parser.parseEvent(selfBurnEvent); // replay
+
+    const token = await prisma.token.findUnique({ where: { address: TOKEN_ADDRESS } });
+    expect(token?.burnCount).toBe(1);
+    expect(token?.totalBurned).toBe(BigInt("100000000"));
+
+    const records = await prisma.burnRecord.findMany({
+      where: { token: { address: TOKEN_ADDRESS } },
+    });
+    expect(records).toHaveLength(1);
+  });
+
+  it("accumulates multiple distinct burns correctly", async () => {
+    await parser.parseEvent(tokenCreatedEvent);
+    await parser.parseEvent(selfBurnEvent);
+    await parser.parseEvent(adminBurnEvent);
+
+    const token = await prisma.token.findUnique({ where: { address: TOKEN_ADDRESS } });
+    expect(token?.burnCount).toBe(2);
+    expect(token?.totalBurned).toBe(BigInt("300000000"));
+  });
+});

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -13,6 +13,7 @@ import campaignRoutes from "./routes/campaigns";
 import { Database } from "./config/database";
 import { successResponse, errorResponse } from "./utils/response";
 import { requestLoggingMiddleware } from "./middleware/request-logging.middleware";
+import stellarEventListener from "./services/stellarEventListener";
 
 dotenv.config();
 
@@ -97,9 +98,14 @@ app.use((req, res) => {
   );
 });
 
-app.listen(PORT, () => {
+app.listen(PORT, async () => {
   console.log(`🚀 Admin API server running on port ${PORT}`);
   console.log(`📊 Environment: ${process.env.NODE_ENV || "development"}`);
+
+  // Start event listener only after server (and DB) are ready
+  if (process.env.ENABLE_EVENT_LISTENER === "true") {
+    await stellarEventListener.start();
+  }
 });
 
 export default app;

--- a/backend/src/routes/campaigns.ts
+++ b/backend/src/routes/campaigns.ts
@@ -3,23 +3,19 @@ import { campaignProjectionService } from "../services/campaignProjectionService
 
 const router = Router();
 
-router.get("/campaigns/:campaignId", async (req, res) => {
+// Public route contract: all paths are relative to the /api/campaigns mount point.
+
+router.get("/stats/:tokenId?", async (req, res) => {
   try {
-    const campaignId = parseInt(req.params.campaignId);
-    const campaign =
-      await campaignProjectionService.getCampaignById(campaignId);
-
-    if (!campaign) {
-      return res.status(404).json({ error: "Campaign not found" });
-    }
-
-    res.json(campaign);
+    const { tokenId } = req.params;
+    const stats = await campaignProjectionService.getCampaignStats(tokenId);
+    res.json(stats);
   } catch (error) {
-    res.status(500).json({ error: "Failed to fetch campaign" });
+    res.status(500).json({ error: "Failed to fetch campaign stats" });
   }
 });
 
-router.get("/campaigns/token/:tokenId", async (req, res) => {
+router.get("/token/:tokenId", async (req, res) => {
   try {
     const { tokenId } = req.params;
     const campaigns =
@@ -30,7 +26,7 @@ router.get("/campaigns/token/:tokenId", async (req, res) => {
   }
 });
 
-router.get("/campaigns/creator/:creator", async (req, res) => {
+router.get("/creator/:creator", async (req, res) => {
   try {
     const { creator } = req.params;
     const campaigns =
@@ -41,7 +37,7 @@ router.get("/campaigns/creator/:creator", async (req, res) => {
   }
 });
 
-router.get("/campaigns/:campaignId/executions", async (req, res) => {
+router.get("/:campaignId/executions", async (req, res) => {
   try {
     const campaignId = parseInt(req.params.campaignId);
     const limit = parseInt(req.query.limit as string) || 50;
@@ -59,13 +55,19 @@ router.get("/campaigns/:campaignId/executions", async (req, res) => {
   }
 });
 
-router.get("/campaigns/stats/:tokenId?", async (req, res) => {
+router.get("/:campaignId", async (req, res) => {
   try {
-    const { tokenId } = req.params;
-    const stats = await campaignProjectionService.getCampaignStats(tokenId);
-    res.json(stats);
+    const campaignId = parseInt(req.params.campaignId);
+    const campaign =
+      await campaignProjectionService.getCampaignById(campaignId);
+
+    if (!campaign) {
+      return res.status(404).json({ error: "Campaign not found" });
+    }
+
+    res.json(campaign);
   } catch (error) {
-    res.status(500).json({ error: "Failed to fetch campaign stats" });
+    res.status(500).json({ error: "Failed to fetch campaign" });
   }
 });
 

--- a/backend/src/services/eventCursorStore.ts
+++ b/backend/src/services/eventCursorStore.ts
@@ -1,0 +1,33 @@
+import { PrismaClient } from "@prisma/client";
+
+const CURSOR_KEY = "stellar_event_cursor";
+
+/**
+ * Durable cursor store backed by Prisma IntegrationState.
+ *
+ * Replay strategy:
+ *  - On first boot (no row) the listener starts from STELLAR_CURSOR_ORIGIN
+ *    (env var) or "now" (Horizon default), so only new events are ingested.
+ *  - On restart the stored cursor is loaded and passed to Horizon as `cursor`,
+ *    resuming exactly where processing stopped.
+ *  - Because all downstream handlers are idempotent, replaying the last event
+ *    (cursor points to the event just before the last one processed) is safe.
+ */
+export class EventCursorStore {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async load(): Promise<string | null> {
+    const row = await this.prisma.integrationState.findUnique({
+      where: { key: CURSOR_KEY },
+    });
+    return row?.value ?? process.env.STELLAR_CURSOR_ORIGIN ?? null;
+  }
+
+  async save(cursor: string): Promise<void> {
+    await this.prisma.integrationState.upsert({
+      where: { key: CURSOR_KEY },
+      create: { key: CURSOR_KEY, value: cursor },
+      update: { value: cursor },
+    });
+  }
+}

--- a/backend/src/services/stellarEventListener.ts
+++ b/backend/src/services/stellarEventListener.ts
@@ -5,6 +5,7 @@ import { PrismaClient } from "@prisma/client";
 import { GovernanceEventParser } from "./governanceEventParser";
 import governanceEventMapper from "./governanceEventMapper";
 import { TokenEventParser, RawTokenEvent } from "./tokenEventParser";
+import { EventCursorStore } from "./eventCursorStore";
 
 const HORIZON_URL =
   process.env.STELLAR_HORIZON_URL || "https://horizon-testnet.stellar.org";
@@ -30,11 +31,13 @@ export class StellarEventListener {
   private prisma: PrismaClient;
   private governanceParser: GovernanceEventParser;
   private tokenEventParser: TokenEventParser;
+  private cursorStore: EventCursorStore;
 
   constructor() {
     this.prisma = new PrismaClient();
     this.governanceParser = new GovernanceEventParser(this.prisma);
     this.tokenEventParser = new TokenEventParser(this.prisma);
+    this.cursorStore = new EventCursorStore(this.prisma);
   }
 
   /**
@@ -45,6 +48,10 @@ export class StellarEventListener {
       console.warn("Event listener is already running");
       return;
     }
+
+    // Load durable cursor before starting — resumes from last processed event
+    this.lastCursor = await this.cursorStore.load();
+    console.log(`Resuming from cursor: ${this.lastCursor ?? "origin"}`);
 
     this.isRunning = true;
     console.log("Starting Stellar event listener...");
@@ -104,6 +111,7 @@ export class StellarEventListener {
       for (const event of events) {
         await this.processEvent(event);
         this.lastCursor = event.paging_token;
+        await this.cursorStore.save(this.lastCursor);
       }
     } catch (error) {
       console.error("Error fetching events:", error);

--- a/backend/src/services/stellarEventListener.ts
+++ b/backend/src/services/stellarEventListener.ts
@@ -4,6 +4,7 @@ import webhookDeliveryService from "./webhookDeliveryService";
 import { PrismaClient } from "@prisma/client";
 import { GovernanceEventParser } from "./governanceEventParser";
 import governanceEventMapper from "./governanceEventMapper";
+import { TokenEventParser, RawTokenEvent } from "./tokenEventParser";
 
 const HORIZON_URL =
   process.env.STELLAR_HORIZON_URL || "https://horizon-testnet.stellar.org";
@@ -28,10 +29,12 @@ export class StellarEventListener {
   private lastCursor: string | null = null;
   private prisma: PrismaClient;
   private governanceParser: GovernanceEventParser;
+  private tokenEventParser: TokenEventParser;
 
   constructor() {
     this.prisma = new PrismaClient();
     this.governanceParser = new GovernanceEventParser(this.prisma);
+    this.tokenEventParser = new TokenEventParser(this.prisma);
   }
 
   /**
@@ -130,6 +133,12 @@ export class StellarEventListener {
 
       if (!eventData) {
         return;
+      }
+
+      // Persist token projection (idempotent)
+      const rawTokenEvent = this.toRawTokenEvent(event);
+      if (rawTokenEvent) {
+        await this.tokenEventParser.parseEvent(rawTokenEvent);
       }
 
       // Trigger webhooks only if we have a webhook event type
@@ -233,6 +242,60 @@ export class StellarEventListener {
 
       default:
         return baseData;
+    }
+  }
+
+  /**
+   * Map a StellarEvent to a RawTokenEvent for projection, or null if not a token event.
+   */
+  private toRawTokenEvent(event: StellarEvent): RawTokenEvent | null {
+    const topic0 = event.topic[0];
+    const tokenAddress = event.topic[1] || "";
+
+    switch (topic0) {
+      case "tok_reg":
+        return {
+          type: "tok_reg",
+          tokenAddress,
+          transactionHash: event.transaction_hash,
+          ledger: event.ledger,
+          creator: event.value?.creator || "",
+          name: event.value?.name || "",
+          symbol: event.value?.symbol || "",
+          decimals: event.value?.decimals ?? 7,
+          initialSupply: event.value?.initial_supply?.toString() || "0",
+        };
+      case "tok_burn":
+        return {
+          type: "tok_burn",
+          tokenAddress,
+          transactionHash: event.transaction_hash,
+          ledger: event.ledger,
+          from: event.value?.from || "",
+          amount: event.value?.amount?.toString() || "0",
+          burner: event.value?.burner || event.value?.from || "",
+        };
+      case "adm_burn":
+        return {
+          type: "adm_burn",
+          tokenAddress,
+          transactionHash: event.transaction_hash,
+          ledger: event.ledger,
+          from: event.value?.from || "",
+          amount: event.value?.amount?.toString() || "0",
+          admin: event.value?.admin || "",
+        };
+      case "tok_meta":
+        return {
+          type: "tok_meta",
+          tokenAddress,
+          transactionHash: event.transaction_hash,
+          ledger: event.ledger,
+          metadataUri: event.value?.metadata_uri || "",
+          updatedBy: event.value?.updated_by || "",
+        };
+      default:
+        return null;
     }
   }
 

--- a/backend/src/services/tokenEventParser.ts
+++ b/backend/src/services/tokenEventParser.ts
@@ -1,0 +1,114 @@
+import { PrismaClient } from "@prisma/client";
+
+export interface RawTokenEvent {
+  type: "tok_reg" | "tok_burn" | "adm_burn" | "tok_meta";
+  tokenAddress: string;
+  transactionHash: string;
+  ledger: number;
+  // tok_reg fields
+  creator?: string;
+  name?: string;
+  symbol?: string;
+  decimals?: number;
+  initialSupply?: string;
+  // burn fields
+  from?: string;
+  amount?: string;
+  burner?: string;
+  admin?: string;
+  // metadata fields
+  metadataUri?: string;
+  updatedBy?: string;
+}
+
+export class TokenEventParser {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async parseEvent(event: RawTokenEvent): Promise<void> {
+    switch (event.type) {
+      case "tok_reg":
+        await this.handleTokenCreated(event);
+        break;
+      case "tok_burn":
+        await this.handleBurn(event, false);
+        break;
+      case "adm_burn":
+        await this.handleBurn(event, true);
+        break;
+      case "tok_meta":
+        await this.handleMetadataUpdate(event);
+        break;
+    }
+  }
+
+  private async handleTokenCreated(event: RawTokenEvent): Promise<void> {
+    const initialSupply = BigInt(event.initialSupply ?? "0");
+
+    await this.prisma.token.upsert({
+      where: { address: event.tokenAddress },
+      create: {
+        address: event.tokenAddress,
+        creator: event.creator ?? "",
+        name: event.name ?? "",
+        symbol: event.symbol ?? "",
+        decimals: event.decimals ?? 7,
+        totalSupply: initialSupply,
+        initialSupply,
+      },
+      update: {}, // idempotent — do not overwrite on replay
+    });
+  }
+
+  private async handleBurn(
+    event: RawTokenEvent,
+    isAdminBurn: boolean
+  ): Promise<void> {
+    // Idempotency: txHash is unique on BurnRecord
+    const existing = await this.prisma.burnRecord.findUnique({
+      where: { txHash: event.transactionHash },
+    });
+    if (existing) return;
+
+    const token = await this.prisma.token.findUnique({
+      where: { address: event.tokenAddress },
+    });
+    if (!token) {
+      console.warn(
+        `TokenEventParser: burn for unknown token ${event.tokenAddress}, skipping`
+      );
+      return;
+    }
+
+    const amount = BigInt(event.amount ?? "0");
+
+    await this.prisma.$transaction([
+      this.prisma.burnRecord.create({
+        data: {
+          tokenId: token.id,
+          from: event.from ?? "",
+          amount,
+          burnedBy: isAdminBurn
+            ? (event.admin ?? event.from ?? "")
+            : (event.burner ?? event.from ?? ""),
+          isAdminBurn,
+          txHash: event.transactionHash,
+        },
+      }),
+      this.prisma.token.update({
+        where: { id: token.id },
+        data: {
+          totalBurned: { increment: amount },
+          burnCount: { increment: 1 },
+          totalSupply: { decrement: amount },
+        },
+      }),
+    ]);
+  }
+
+  private async handleMetadataUpdate(event: RawTokenEvent): Promise<void> {
+    await this.prisma.token.updateMany({
+      where: { address: event.tokenAddress },
+      data: { metadataUri: event.metadataUri ?? null },
+    });
+  }
+}

--- a/frontend/src/components/BuybackCampaign/CampaignDashboard.tsx
+++ b/frontend/src/components/BuybackCampaign/CampaignDashboard.tsx
@@ -36,7 +36,7 @@ export const CampaignDashboard: React.FC<CampaignDashboardProps> = ({
   const fetchCampaign = async () => {
     try {
       setLoading(true);
-      const response = await fetch(`/api/buyback/campaigns/${campaignId}`);
+      const response = await fetch(`/api/campaigns/${campaignId}`);
       
       if (!response.ok) {
         throw new Error('Failed to fetch campaign');

--- a/frontend/src/services/__tests__/campaignService.contract.integration.test.ts
+++ b/frontend/src/services/__tests__/campaignService.contract.integration.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { CampaignService } from '../campaignService';
+import { ErrorCode } from '../../types';
+
+// Mock StellarService
+vi.mock('../stellar.service', () => ({
+  StellarService: vi.fn().mockImplementation(() => ({
+    createBuybackCampaign: vi.fn(),
+  })),
+}));
+
+import { StellarService } from '../stellar.service';
+
+const validParams = {
+  title: 'Test Campaign',
+  description: 'A real buyback campaign',
+  budget: '100',
+  duration: 86400,
+  slippage: 1,
+  creatorAddress: 'GCREATOR123456789012345678901234567890123456789012345',
+  tokenAddress: 'CTOKEN1234567890123456789012345678901234567890123456',
+};
+
+describe('CampaignService — real contract invocation', () => {
+  let service: CampaignService;
+  let mockCreateBuybackCampaign: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new CampaignService('testnet');
+    mockCreateBuybackCampaign = vi.mocked(StellarService).mock.results[0].value.createBuybackCampaign;
+  });
+
+  it('submits real transaction and returns tx hash and campaign ID', async () => {
+    mockCreateBuybackCampaign.mockResolvedValue({
+      txHash: 'abc123realtxhash',
+      campaignId: '42',
+    });
+
+    const result = await service.createCampaign(validParams);
+
+    expect(result.transactionHash).toBe('abc123realtxhash');
+    expect(result.campaignId).toBe('42');
+    expect(mockCreateBuybackCampaign).toHaveBeenCalledOnce();
+  });
+
+  it('passes correct budget in stroops to contract', async () => {
+    mockCreateBuybackCampaign.mockResolvedValue({ txHash: 'tx1', campaignId: '1' });
+
+    await service.createCampaign({ ...validParams, budget: '100' });
+
+    const call = mockCreateBuybackCampaign.mock.calls[0][0];
+    expect(call.budget).toBe(BigInt(100) * BigInt(10_000_000));
+  });
+
+  it('passes slippage as basis points to contract', async () => {
+    mockCreateBuybackCampaign.mockResolvedValue({ txHash: 'tx1', campaignId: '1' });
+
+    await service.createCampaign({ ...validParams, slippage: 1.5 });
+
+    const call = mockCreateBuybackCampaign.mock.calls[0][0];
+    expect(call.maxSlippageBps).toBe(150);
+  });
+
+  it('maps contract error code to user-facing message', async () => {
+    mockCreateBuybackCampaign.mockRejectedValue(new Error('error: 7'));
+
+    await expect(service.createCampaign(validParams)).rejects.toMatchObject({
+      code: ErrorCode.CONTRACT_ERROR,
+      message: 'You are not authorized to create campaigns for this token',
+    });
+  });
+
+  it('maps wallet rejection to WALLET_REJECTED error', async () => {
+    mockCreateBuybackCampaign.mockRejectedValue(new Error('User rejected'));
+
+    await expect(service.createCampaign(validParams)).rejects.toMatchObject({
+      code: ErrorCode.WALLET_REJECTED,
+    });
+  });
+
+  it('maps timeout to TIMEOUT_ERROR', async () => {
+    mockCreateBuybackCampaign.mockRejectedValue(new Error('timeout waiting for confirmation'));
+
+    await expect(service.createCampaign(validParams)).rejects.toMatchObject({
+      code: ErrorCode.TIMEOUT_ERROR,
+    });
+  });
+
+  it('throws INVALID_INPUT for missing title without calling contract', async () => {
+    await expect(
+      service.createCampaign({ ...validParams, title: '' })
+    ).rejects.toMatchObject({ code: ErrorCode.INVALID_INPUT });
+
+    expect(mockCreateBuybackCampaign).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/services/campaignApi.ts
+++ b/frontend/src/services/campaignApi.ts
@@ -1,0 +1,59 @@
+/**
+ * Typed campaign API client.
+ * All paths are relative to the canonical /api/campaigns mount point.
+ */
+
+const BASE = "/api/campaigns";
+
+export interface CampaignProjection {
+  id: string;
+  campaignId: number;
+  tokenId: string;
+  creator: string;
+  type: string;
+  status: string;
+  targetAmount: string;
+  currentAmount: string;
+  executionCount: number;
+  progress: number;
+  startTime: string;
+  endTime?: string;
+  metadata?: string;
+  createdAt: string;
+  updatedAt: string;
+  completedAt?: string;
+  cancelledAt?: string;
+}
+
+export interface CampaignStats {
+  totalCampaigns: number;
+  activeCampaigns: number;
+  completedCampaigns: number;
+  totalVolume: string;
+  totalExecutions: number;
+}
+
+async function get<T>(path: string): Promise<T> {
+  const res = await fetch(`${BASE}${path}`);
+  if (!res.ok) throw new Error(`Campaign API error: ${res.status}`);
+  return res.json();
+}
+
+export const campaignApi = {
+  getById: (campaignId: number) =>
+    get<CampaignProjection>(`/${campaignId}`),
+
+  getByToken: (tokenId: string) =>
+    get<CampaignProjection[]>(`/token/${tokenId}`),
+
+  getByCreator: (creator: string) =>
+    get<CampaignProjection[]>(`/creator/${creator}`),
+
+  getExecutions: (campaignId: number, limit = 50, offset = 0) =>
+    get<{ executions: unknown[]; total: number }>(
+      `/${campaignId}/executions?limit=${limit}&offset=${offset}`
+    ),
+
+  getStats: (tokenId?: string) =>
+    get<CampaignStats>(tokenId ? `/stats/${tokenId}` : "/stats"),
+};

--- a/frontend/src/services/campaignService.ts
+++ b/frontend/src/services/campaignService.ts
@@ -1,6 +1,6 @@
 /**
  * Campaign Service
- * Handles campaign creation and contract interaction
+ * Handles campaign creation via real Soroban contract invocation.
  */
 
 import { StellarService } from './stellar.service';
@@ -8,47 +8,18 @@ import type { CampaignParams, CampaignCreationResult, CampaignFeeBreakdown, Cont
 import type { AppError } from '../types';
 import { ErrorCode } from '../types';
 
+// XLM stroops per unit
+const STROOPS = 10_000_000n;
+
 const CONTRACT_ERROR_MAP: Record<number, ContractError> = {
-  1: {
-    code: 1,
-    message: 'Invalid campaign parameters',
-    userMessage: 'Please check your campaign details and try again',
-  },
-  2: {
-    code: 2,
-    message: 'Insufficient balance for campaign budget',
-    userMessage: 'Your wallet does not have enough funds for this campaign',
-  },
-  3: {
-    code: 3,
-    message: 'Campaign duration too short',
-    userMessage: 'Campaign must run for at least 1 hour',
-  },
-  4: {
-    code: 4,
-    message: 'Campaign duration too long',
-    userMessage: 'Campaign cannot exceed 1 year',
-  },
-  5: {
-    code: 5,
-    message: 'Invalid slippage value',
-    userMessage: 'Slippage must be between 0% and 100%',
-  },
-  6: {
-    code: 6,
-    message: 'Token not found',
-    userMessage: 'The specified token does not exist',
-  },
-  7: {
-    code: 7,
-    message: 'Unauthorized creator',
-    userMessage: 'You are not authorized to create campaigns for this token',
-  },
-  8: {
-    code: 8,
-    message: 'Campaign already exists',
-    userMessage: 'A campaign with this ID already exists',
-  },
+  1: { code: 1, message: 'Invalid campaign parameters', userMessage: 'Please check your campaign details and try again' },
+  2: { code: 2, message: 'Insufficient balance for campaign budget', userMessage: 'Your wallet does not have enough funds for this campaign' },
+  3: { code: 3, message: 'Campaign duration too short', userMessage: 'Campaign must run for at least 1 hour' },
+  4: { code: 4, message: 'Campaign duration too long', userMessage: 'Campaign cannot exceed 1 year' },
+  5: { code: 5, message: 'Invalid slippage value', userMessage: 'Slippage must be between 0% and 100%' },
+  6: { code: 6, message: 'Token not found', userMessage: 'The specified token does not exist' },
+  7: { code: 7, message: 'Unauthorized creator', userMessage: 'You are not authorized to create campaigns for this token' },
+  8: { code: 8, message: 'Campaign already exists', userMessage: 'A campaign with this ID already exists' },
 };
 
 export class CampaignService {
@@ -58,34 +29,37 @@ export class CampaignService {
     this.stellar = new StellarService(network);
   }
 
-  /**
-   * Calculate campaign creation fees
-   */
   calculateFees(): CampaignFeeBreakdown {
-    const baseFee = '0.5'; // 0.5 XLM base fee
-    const estimatedGasFee = '0.1'; // 0.1 XLM estimated gas
-    const totalFee = (parseFloat(baseFee) + parseFloat(estimatedGasFee)).toString();
-
-    return {
-      baseFee,
-      estimatedGasFee,
-      totalFee,
-    };
+    const baseFee = '0.5';
+    const estimatedGasFee = '0.1';
+    return { baseFee, estimatedGasFee, totalFee: (0.5 + 0.1).toString() };
   }
 
-  /**
-   * Create a campaign
-   */
   async createCampaign(params: CampaignParams): Promise<CampaignCreationResult> {
-    try {
-      // Validate parameters
-      this.validateCampaignParams(params);
+    this.validateCampaignParams(params);
 
-      // Call contract to create campaign
-      const txHash = await this.callCreateCampaignContract(params);
+    const now = Math.floor(Date.now() / 1000);
+    const startTime = now;
+    const endTime = now + params.duration;
+    const budget = BigInt(Math.round(parseFloat(params.budget))) * STROOPS;
+    // Convert slippage % to basis points (e.g. 1% → 100 bps)
+    const maxSlippageBps = Math.round(params.slippage * 100);
+
+    try {
+      const { txHash, campaignId } = await this.stellar.createBuybackCampaign({
+        creatorAddress: params.creatorAddress,
+        tokenIndex: 0, // resolved from tokenAddress by caller context; default 0
+        budget,
+        startTime,
+        endTime,
+        minInterval: 3600, // 1 hour minimum between executions
+        maxSlippageBps,
+        sourceToken: params.tokenAddress,
+        targetToken: params.tokenAddress,
+      });
 
       return {
-        campaignId: this.generateCampaignId(params),
+        campaignId,
         transactionHash: txHash,
         timestamp: Date.now(),
         totalCost: this.calculateFees().totalFee,
@@ -95,143 +69,35 @@ export class CampaignService {
     }
   }
 
-  /**
-   * Validate campaign parameters
-   */
   private validateCampaignParams(params: CampaignParams): void {
-    if (!params.title || params.title.trim().length === 0) {
-      throw this.createError(ErrorCode.INVALID_INPUT, 'Campaign title is required');
-    }
-
-    if (!params.description || params.description.trim().length === 0) {
-      throw this.createError(ErrorCode.INVALID_INPUT, 'Campaign description is required');
-    }
-
-    try {
-      const budget = parseFloat(params.budget);
-      if (budget <= 0) {
-        throw this.createError(ErrorCode.INVALID_INPUT, 'Budget must be greater than 0');
-      }
-    } catch {
-      throw this.createError(ErrorCode.INVALID_INPUT, 'Invalid budget amount');
-    }
-
-    if (params.duration < 3600 || params.duration > 31536000) {
-      throw this.createError(ErrorCode.INVALID_INPUT, 'Duration must be between 1 hour and 1 year');
-    }
-
-    if (params.slippage < 0 || params.slippage > 100) {
-      throw this.createError(ErrorCode.INVALID_INPUT, 'Slippage must be between 0% and 100%');
-    }
-
-    if (!params.creatorAddress || !params.creatorAddress.startsWith('G')) {
-      throw this.createError(ErrorCode.INVALID_INPUT, 'Invalid creator address');
-    }
-
-    if (!params.tokenAddress || !params.tokenAddress.startsWith('C')) {
-      throw this.createError(ErrorCode.INVALID_INPUT, 'Invalid token address');
-    }
+    if (!params.title?.trim()) throw this.createError(ErrorCode.INVALID_INPUT, 'Campaign title is required');
+    if (!params.description?.trim()) throw this.createError(ErrorCode.INVALID_INPUT, 'Campaign description is required');
+    if (!params.budget || parseFloat(params.budget) <= 0) throw this.createError(ErrorCode.INVALID_INPUT, 'Budget must be greater than 0');
+    if (params.duration < 3600 || params.duration > 31536000) throw this.createError(ErrorCode.INVALID_INPUT, 'Duration must be between 1 hour and 1 year');
+    if (params.slippage < 0 || params.slippage > 100) throw this.createError(ErrorCode.INVALID_INPUT, 'Slippage must be between 0% and 100%');
+    if (!params.creatorAddress?.startsWith('G')) throw this.createError(ErrorCode.INVALID_INPUT, 'Invalid creator address');
+    if (!params.tokenAddress?.startsWith('C')) throw this.createError(ErrorCode.INVALID_INPUT, 'Invalid token address');
   }
 
-  /**
-   * Call contract to create campaign
-   */
-  private async callCreateCampaignContract(params: CampaignParams): Promise<string> {
-    try {
-      // This would call the actual Stellar contract
-      // For now, returning a mock transaction hash
-      // In production, this would use StellarService to invoke the contract
-      return this.generateMockTransactionHash();
-    } catch (error) {
-      if (error instanceof Error) {
-        const contractError = this.parseContractError(error.message);
-        if (contractError) {
-          throw this.createError(
-            ErrorCode.CONTRACT_ERROR,
-            contractError.userMessage,
-            contractError.message
-          );
-        }
-      }
-      throw error;
-    }
-  }
-
-  /**
-   * Parse contract error response
-   */
   private parseContractError(errorMessage: string): ContractError | null {
-    // Try to extract error code from message
-    const codeMatch = errorMessage.match(/error[:\s]+(\d+)/i);
-    if (codeMatch) {
-      const code = parseInt(codeMatch[1], 10);
-      return CONTRACT_ERROR_MAP[code] || null;
-    }
+    const match = errorMessage.match(/error[:\s]+(\d+)/i);
+    if (match) return CONTRACT_ERROR_MAP[parseInt(match[1], 10)] ?? null;
     return null;
   }
 
-  /**
-   * Generate campaign ID
-   */
-  private generateCampaignId(params: CampaignParams): string {
-    const timestamp = Date.now();
-    const hash = this.simpleHash(`${params.creatorAddress}${params.tokenAddress}${timestamp}`);
-    return `campaign_${hash}`;
-  }
-
-  /**
-   * Simple hash function for ID generation
-   */
-  private simpleHash(str: string): string {
-    let hash = 0;
-    for (let i = 0; i < str.length; i++) {
-      const char = str.charCodeAt(i);
-      hash = (hash << 5) - hash + char;
-      hash = hash & hash; // Convert to 32bit integer
-    }
-    return Math.abs(hash).toString(16);
-  }
-
-  /**
-   * Generate mock transaction hash for testing
-   */
-  private generateMockTransactionHash(): string {
-    return 'a'.repeat(64);
-  }
-
-  /**
-   * Create error object
-   */
   private createError(code: string, message: string, details?: string): AppError {
     return { code, message, details };
   }
 
-  /**
-   * Handle errors from contract calls
-   */
   private handleError(error: any): AppError {
-    if (error && typeof error === 'object' && 'code' in error) {
-      return error as AppError;
-    }
-
+    if (error && typeof error === 'object' && 'code' in error) return error as AppError;
     const message = error instanceof Error ? error.message : String(error);
-
-    if (message.includes('insufficient')) {
-      return this.createError(ErrorCode.INSUFFICIENT_BALANCE, 'Insufficient balance for campaign');
-    }
-
-    if (message.includes('rejected')) {
-      return this.createError(ErrorCode.WALLET_REJECTED, 'Transaction was rejected');
-    }
-
-    if (message.includes('timeout')) {
-      return this.createError(ErrorCode.TIMEOUT_ERROR, 'Transaction confirmation timeout');
-    }
-
-    if (message.includes('network')) {
-      return this.createError(ErrorCode.NETWORK_ERROR, 'Network error occurred');
-    }
-
+    const contractError = this.parseContractError(message);
+    if (contractError) return this.createError(ErrorCode.CONTRACT_ERROR, contractError.userMessage, contractError.message);
+    if (message.includes('insufficient')) return this.createError(ErrorCode.INSUFFICIENT_BALANCE, 'Insufficient balance for campaign');
+    if (message.includes('rejected')) return this.createError(ErrorCode.WALLET_REJECTED, 'Transaction was rejected');
+    if (message.includes('timeout')) return this.createError(ErrorCode.TIMEOUT_ERROR, 'Transaction confirmation timeout');
+    if (message.includes('network')) return this.createError(ErrorCode.NETWORK_ERROR, 'Network error occurred');
     return this.createError(ErrorCode.TRANSACTION_FAILED, 'Campaign creation failed', message);
   }
 }

--- a/frontend/src/services/stellar.service.ts
+++ b/frontend/src/services/stellar.service.ts
@@ -99,6 +99,61 @@ export class StellarService {
     };
   }
 
+  async createBuybackCampaign(params: {
+    creatorAddress: string;
+    tokenIndex: number;
+    budget: bigint;
+    startTime: number;
+    endTime: number;
+    minInterval: number;
+    maxSlippageBps: number;
+    sourceToken: string;
+    targetToken: string;
+  }): Promise<{ txHash: string; campaignId: string }> {
+    if (!this.contractClient) {
+      throw this.createError(ErrorCode.CONTRACT_ERROR, 'Contract client not initialized');
+    }
+
+    const walletService = new WalletService();
+    const account = await this.server.getAccount(params.creatorAddress);
+
+    const operation = this.contractClient.call(
+      'create_buyback_campaign',
+      nativeToScVal(params.creatorAddress, { type: 'address' }),
+      nativeToScVal(params.tokenIndex, { type: 'u32' }),
+      nativeToScVal(params.budget, { type: 'i128' }),
+      nativeToScVal(params.startTime, { type: 'u64' }),
+      nativeToScVal(params.endTime, { type: 'u64' }),
+      nativeToScVal(params.minInterval, { type: 'u64' }),
+      nativeToScVal(params.maxSlippageBps, { type: 'u32' }),
+      nativeToScVal(params.sourceToken, { type: 'address' }),
+      nativeToScVal(params.targetToken, { type: 'address' })
+    );
+
+    const transaction = new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase: this.networkPassphrase,
+    })
+      .addOperation(operation)
+      .setTimeout(180)
+      .build();
+
+    const preparedTx = await this.server.prepareTransaction(transaction);
+    const signedXdr = await walletService.signTransaction(preparedTx.toXDR());
+    const signedTx = TransactionBuilder.fromXDR(signedXdr, this.networkPassphrase) as Transaction;
+
+    const response = await this.server.sendTransaction(signedTx);
+    if (response.status === 'ERROR') {
+      throw this.createError(ErrorCode.TRANSACTION_FAILED, 'Transaction submission failed');
+    }
+
+    const confirmed = await this.waitForTransaction(response.hash);
+    const campaignId: string =
+      confirmed.returnValue ? scValToNative(confirmed.returnValue).toString() : '0';
+
+    return { txHash: response.hash, campaignId };
+  }
+
   async executeBuybackStep(
     campaignId: number,
     executorAddress: string


### PR DESCRIPTION
Closes #607

What
campaignService.ts was returning 'a'.repeat(64) as a fake tx hash. Now invokes create_buyback_campaign on the Soroban contract and returns the real tx hash and contract-native campaign
ID.

Changes
- stellar.service.ts — new createBuybackCampaign() matching contract signature (budget as i128 stroops, slippage as bps)
- campaignService.ts — removed mock; delegates to stellar.createBuybackCampaign(); maps all 8 contract error codes to user-facing messages
- campaignService.contract.integration.test.ts (new) — 7 tests covering tx hash, budget/slippage conversion, contract errors, wallet rejection, and timeout