### PR TITLE
feat(integration): add typed buyback campaign read helpers

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -172,6 +172,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -563,6 +564,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -603,6 +605,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -2817,6 +2820,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -3222,6 +3226,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3232,6 +3237,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3322,6 +3328,7 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -3727,6 +3734,7 @@
       "integrity": "sha512-CGJ25bc8fRi8Lod/3GHSvXRKi7nBo3kxh0ApW4yCjmrWmRmlT53B5E08XRSZRliygG0aVNxLrBEqPYdz/KcCtQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.0.18",
         "fflate": "^0.8.2",
@@ -3787,6 +3795,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4173,16 +4182,6 @@
         }
       }
     },
-    "node_modules/bare-url": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.3.2.tgz",
-      "integrity": "sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "bare-path": "^3.0.0"
-      }
-    },
     "node_modules/base32.js": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/base32.js/-/base32.js-0.1.0.tgz",
@@ -4355,6 +4354,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5260,7 +5260,8 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1566079.tgz",
       "integrity": "sha512-MJfAEA1UfVhSs7fbSQOG4czavUp1ajfg6prlAN0+cmfa2zNjaIbvq8VneP7do1WAQQIvgNJWSMeP6UyI90gIlQ==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
@@ -5594,6 +5595,7 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6740,6 +6742,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4"
       },
@@ -7620,6 +7623,7 @@
       "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.31",
         "@asamuzakjp/dom-selector": "^6.8.1",
@@ -7914,7 +7918,8 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1211954.tgz",
       "integrity": "sha512-f6BRhngr9wpHN8omZOoSaEJFscTL+tjNhmeBqHHC3CZ3K2N75sDeKXZeTkAEkTCcrusDatfwjRRBh0uz4ov/sA==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/lighthouse/node_modules/lighthouse-logger": {
       "version": "2.0.2",
@@ -9181,6 +9186,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -9450,6 +9456,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9459,6 +9466,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -9505,6 +9513,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -9581,7 +9590,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -9695,6 +9705,7 @@
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -10516,6 +10527,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10783,6 +10795,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11022,6 +11035,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -11130,6 +11144,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11143,6 +11158,7 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -11533,6 +11549,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/components/BuybackCampaign/CampaignDashboard.tsx
+++ b/frontend/src/components/BuybackCampaign/CampaignDashboard.tsx
@@ -40,6 +40,8 @@ export const CampaignDashboard: React.FC<CampaignDashboardProps> = ({
 
   const handleStepError = (err: Error) => {
     console.error('Step execution failed:', err);
+    // Refresh to reconcile state from chain source of truth
+    fetchCampaign();
   };
 
   if (loading) {

--- a/frontend/src/components/BuybackCampaign/CampaignDashboard.tsx
+++ b/frontend/src/components/BuybackCampaign/CampaignDashboard.tsx
@@ -1,49 +1,28 @@
 import React, { useEffect, useState } from 'react';
 import { ExecuteStepButton } from './ExecuteStepButton';
-
-interface BuybackStep {
-  id: number;
-  stepNumber: number;
-  amount: string;
-  status: 'PENDING' | 'COMPLETED' | 'FAILED';
-  executedAt?: string;
-  txHash?: string;
-}
-
-interface BuybackCampaign {
-  id: number;
-  tokenAddress: string;
-  totalAmount: string;
-  executedAmount: string;
-  currentStep: number;
-  totalSteps: number;
-  status: 'ACTIVE' | 'COMPLETED' | 'CANCELLED';
-  createdAt: string;
-  steps: BuybackStep[];
-}
+import { StellarService } from '../../services/stellar.service';
+import { mapBuybackCampaign } from '../../services/mappers/buybackCampaignMapper';
+import type { BuybackCampaignModel } from '../../types/campaign';
 
 interface CampaignDashboardProps {
   campaignId: number;
+  network?: 'testnet' | 'mainnet';
 }
 
 export const CampaignDashboard: React.FC<CampaignDashboardProps> = ({
   campaignId,
+  network = 'testnet',
 }) => {
-  const [campaign, setCampaign] = useState<BuybackCampaign | null>(null);
+  const [campaign, setCampaign] = useState<BuybackCampaignModel | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   const fetchCampaign = async () => {
     try {
       setLoading(true);
-      const response = await fetch(`/api/buyback/campaigns/${campaignId}`);
-      
-      if (!response.ok) {
-        throw new Error('Failed to fetch campaign');
-      }
-
-      const data = await response.json();
-      setCampaign(data);
+      const service = new StellarService(network);
+      const raw = await service.getBuybackCampaign(campaignId);
+      setCampaign(mapBuybackCampaign(raw));
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Unknown error');
     } finally {
@@ -55,18 +34,22 @@ export const CampaignDashboard: React.FC<CampaignDashboardProps> = ({
     fetchCampaign();
   }, [campaignId]);
 
-  const handleStepSuccess = async (txHash: string) => {
+  const handleStepSuccess = async (_txHash: string) => {
     await fetchCampaign();
   };
 
-  const handleStepError = (error: Error) => {
-    console.error('Step execution failed:', error);
+  const handleStepError = (err: Error) => {
+    console.error('Step execution failed:', err);
   };
 
   if (loading) {
     return (
       <div className="flex items-center justify-center p-8">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-purple-600"></div>
+        <div
+          role="status"
+          aria-label="Loading"
+          className="animate-spin rounded-full h-12 w-12 border-b-2 border-purple-600"
+        />
       </div>
     );
   }
@@ -78,8 +61,6 @@ export const CampaignDashboard: React.FC<CampaignDashboardProps> = ({
       </div>
     );
   }
-
-  const progress = (campaign.currentStep / campaign.totalSteps) * 100;
 
   return (
     <div className="max-w-4xl mx-auto p-6 space-y-6">
@@ -126,24 +107,24 @@ export const CampaignDashboard: React.FC<CampaignDashboardProps> = ({
           <div className="flex items-center justify-between mb-2">
             <span className="text-sm font-medium text-gray-700">Progress</span>
             <span className="text-sm font-medium text-gray-700">
-              {progress.toFixed(0)}%
+              {campaign.progressPercent.toFixed(0)}%
             </span>
           </div>
           <div className="w-full bg-gray-200 rounded-full h-3">
             <div
               className="bg-purple-600 h-3 rounded-full transition-all duration-500"
-              style={{ width: `${progress}%` }}
+              style={{ width: `${campaign.progressPercent}%` }}
             />
           </div>
         </div>
 
-        {campaign.status === 'ACTIVE' && (
+        {campaign.isActive && (
           <div className="mb-6">
             <h3 className="text-lg font-semibold mb-4">Current Step</h3>
             <ExecuteStepButton
               campaignId={campaign.id}
               currentStep={campaign.currentStep}
-              stepAmount={campaign.steps[campaign.currentStep]?.amount || '0'}
+              stepAmount={campaign.steps[campaign.currentStep]?.amount ?? '0'}
               status={campaign.status}
               onSuccess={handleStepSuccess}
               onError={handleStepError}

--- a/frontend/src/components/BuybackCampaign/ExecuteStepButton.tsx
+++ b/frontend/src/components/BuybackCampaign/ExecuteStepButton.tsx
@@ -1,6 +1,7 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { useStellar } from '../../hooks/useStellar';
 import { useWallet } from '../../hooks/useWallet';
+import { TransactionMonitor } from '../../services/transactionMonitor';
 
 interface ExecuteStepButtonProps {
   campaignId: number;
@@ -11,7 +12,7 @@ interface ExecuteStepButtonProps {
   onError?: (error: Error) => void;
 }
 
-type TransactionState = 'idle' | 'pending' | 'success' | 'failure';
+type TxState = 'idle' | 'submitting' | 'confirming' | 'success' | 'failure';
 
 export const ExecuteStepButton: React.FC<ExecuteStepButtonProps> = ({
   campaignId,
@@ -23,104 +24,96 @@ export const ExecuteStepButton: React.FC<ExecuteStepButtonProps> = ({
 }) => {
   const { wallet } = useWallet();
   const { executeBuybackStep } = useStellar();
-  const [txState, setTxState] = useState<TransactionState>('idle');
+  const [txState, setTxState] = useState<TxState>('idle');
   const [txHash, setTxHash] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const inFlight = useRef(false);
 
-  const isDisabled =
-    !wallet ||
-    status !== 'ACTIVE' ||
-    txState === 'pending' ||
-    txState === 'success';
+  const isPending = txState === 'submitting' || txState === 'confirming';
+  const isDisabled = !wallet || status !== 'ACTIVE' || isPending || txState === 'success';
 
   const handleExecute = async () => {
-    if (!wallet) {
-      setError('Wallet not connected');
-      return;
-    }
+    if (inFlight.current || isDisabled || !wallet) return;
+    inFlight.current = true;
 
     try {
-      setTxState('pending');
+      setTxState('submitting');
       setError(null);
       setTxHash(null);
 
-      const result = await executeBuybackStep(campaignId, wallet.address);
+      const { txHash: hash } = await executeBuybackStep(campaignId, wallet.address);
+      setTxHash(hash);
+      setTxState('confirming');
 
-      setTxHash(result.txHash);
+      await new Promise<void>((resolve, reject) => {
+        const monitor = new TransactionMonitor();
+        monitor.startMonitoring(
+          hash,
+          (update) => {
+            if (update.status === 'success') {
+              monitor.stopMonitoring(hash);
+              resolve();
+            } else if (update.status === 'failed' || update.status === 'timeout') {
+              monitor.stopMonitoring(hash);
+              reject(new Error(`Transaction ${update.status}: ${update.error ?? ''}`));
+            }
+          },
+          (err) => {
+            monitor.stopMonitoring(hash);
+            reject(err);
+          }
+        );
+      });
+
       setTxState('success');
-
-      if (onSuccess) {
-        onSuccess(result.txHash);
-      }
+      onSuccess?.(hash);
     } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : 'Transaction failed';
-      setError(errorMessage);
+      const msg = err instanceof Error ? err.message : 'Transaction failed';
+      setError(msg);
       setTxState('failure');
-
-      if (onError && err instanceof Error) {
-        onError(err);
-      }
+      if (err instanceof Error) onError?.(err);
+    } finally {
+      inFlight.current = false;
     }
   };
 
-  const getButtonText = () => {
-    switch (txState) {
-      case 'pending':
-        return 'Executing...';
-      case 'success':
-        return 'Executed ✓';
-      case 'failure':
-        return 'Retry';
-      default:
-        return `Execute Step ${currentStep + 1}`;
-    }
-  };
+  const buttonLabel =
+    txState === 'submitting' ? 'Submitting...' :
+    txState === 'confirming' ? 'Confirming...' :
+    txState === 'success'    ? 'Executed ✓' :
+    txState === 'failure'    ? 'Retry' :
+    `Execute Step ${currentStep + 1}`;
 
-  const getButtonClass = () => {
-    const baseClass =
-      'px-6 py-3 rounded-lg font-semibold transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2';
-
-    if (isDisabled) {
-      return `${baseClass} bg-gray-300 text-gray-500 cursor-not-allowed`;
-    }
-
-    switch (txState) {
-      case 'pending':
-        return `${baseClass} bg-blue-500 text-white cursor-wait`;
-      case 'success':
-        return `${baseClass} bg-green-500 text-white`;
-      case 'failure':
-        return `${baseClass} bg-red-500 text-white hover:bg-red-600 focus:ring-red-500`;
-      default:
-        return `${baseClass} bg-purple-600 text-white hover:bg-purple-700 focus:ring-purple-500`;
-    }
-  };
+  const buttonClass = [
+    'px-6 py-3 rounded-lg font-semibold transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2',
+    isDisabled                ? 'bg-gray-300 text-gray-500 cursor-not-allowed' :
+    isPending                 ? 'bg-blue-500 text-white cursor-wait' :
+    txState === 'success'     ? 'bg-green-500 text-white' :
+    txState === 'failure'     ? 'bg-red-500 text-white hover:bg-red-600 focus:ring-red-500' :
+                                'bg-purple-600 text-white hover:bg-purple-700 focus:ring-purple-500',
+  ].join(' ');
 
   return (
     <div className="space-y-4">
       <button
         onClick={handleExecute}
         disabled={isDisabled}
-        className={getButtonClass()}
+        className={buttonClass}
         aria-label={`Execute buyback step ${currentStep + 1}`}
       >
-        {txState === 'pending' && (
-          <span className="inline-block mr-2 animate-spin">⏳</span>
-        )}
-        {getButtonText()}
+        {isPending && <span className="inline-block mr-2 animate-spin">⏳</span>}
+        {buttonLabel}
       </button>
 
-      {txState === 'pending' && (
-        <div className="flex items-center space-x-2 text-sm text-gray-600">
-          <div className="animate-pulse">Processing transaction...</div>
+      {isPending && (
+        <div className="text-sm text-gray-600 animate-pulse">
+          {txState === 'submitting' ? 'Submitting transaction...' : 'Processing transaction...'}
         </div>
       )}
 
       {txState === 'success' && txHash && (
         <div className="p-4 bg-green-50 border border-green-200 rounded-lg">
-          <p className="text-sm font-medium text-green-800 mb-2">
-            Transaction Successful!
-          </p>
+          <p className="text-sm font-medium text-green-800 mb-2">Transaction Successful!</p>
           <a
             href={`https://stellar.expert/explorer/testnet/tx/${txHash}`}
             target="_blank"
@@ -134,9 +127,7 @@ export const ExecuteStepButton: React.FC<ExecuteStepButtonProps> = ({
 
       {txState === 'failure' && error && (
         <div className="p-4 bg-red-50 border border-red-200 rounded-lg">
-          <p className="text-sm font-medium text-red-800 mb-1">
-            Transaction Failed
-          </p>
+          <p className="text-sm font-medium text-red-800 mb-1">Transaction Failed</p>
           <p className="text-sm text-red-600">{error}</p>
         </div>
       )}

--- a/frontend/src/components/BuybackCampaign/__tests__/ExecuteStepButton.integration.test.tsx
+++ b/frontend/src/components/BuybackCampaign/__tests__/ExecuteStepButton.integration.test.tsx
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ExecuteStepButton } from '../ExecuteStepButton';
+import * as useStellarHook from '../../../hooks/useStellar';
+import * as useWalletHook from '../../../hooks/useWallet';
+
+vi.mock('../../../hooks/useStellar');
+vi.mock('../../../hooks/useWallet');
+
+// Shared mutable callbacks so tests can control when the monitor fires
+let capturedOnStatus: ((u: { hash: string; status: string; timestamp: number; error?: string }) => void) | null = null;
+
+vi.mock('../../../services/transactionMonitor', () => {
+  return {
+    TransactionMonitor: function MockTransactionMonitor() {
+      return {
+        startMonitoring: function (_hash: string, onStatus: typeof capturedOnStatus) {
+          capturedOnStatus = onStatus;
+        },
+        stopMonitoring: vi.fn(),
+        destroy: vi.fn(),
+      };
+    },
+  };
+});
+
+const mockWallet = { address: 'GTEST123456789', isConnected: true };
+const mockExecuteBuybackStep = vi.fn();
+
+const defaultProps = {
+  campaignId: 1,
+  currentStep: 0,
+  stepAmount: '2000',
+  status: 'ACTIVE' as const,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  capturedOnStatus = null;
+  vi.mocked(useStellarHook.useStellar).mockReturnValue({
+    executeBuybackStep: mockExecuteBuybackStep,
+    getCampaign: vi.fn(),
+  });
+  vi.mocked(useWalletHook.useWallet).mockReturnValue({
+    wallet: mockWallet,
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    isConnecting: false,
+    error: null,
+  });
+});
+
+function fireMonitor(status: 'success' | 'failed' | 'timeout', hash: string) {
+  capturedOnStatus?.({ hash, status, timestamp: Date.now() });
+}
+
+describe('ExecuteStepButton integration', () => {
+  it('submits wallet transaction and confirms via monitor', async () => {
+    const hash = 'abc123';
+    mockExecuteBuybackStep.mockResolvedValue({ txHash: hash });
+    const onSuccess = vi.fn();
+
+    render(<ExecuteStepButton {...defaultProps} onSuccess={onSuccess} />);
+    fireEvent.click(screen.getByRole('button'));
+
+    // Wait for monitor to be registered (after submit resolves)
+    await waitFor(() => expect(capturedOnStatus).not.toBeNull());
+    fireMonitor('success', hash);
+
+    await waitFor(() => expect(screen.getByText(/transaction successful/i)).toBeInTheDocument());
+    expect(mockExecuteBuybackStep).toHaveBeenCalledWith(1, mockWallet.address);
+    expect(onSuccess).toHaveBeenCalledWith(hash);
+  });
+
+  it('locks button during pending state (no double-submit)', async () => {
+    let resolveStep!: (v: { txHash: string }) => void;
+    mockExecuteBuybackStep.mockReturnValue(new Promise((r) => { resolveStep = r; }));
+
+    render(<ExecuteStepButton {...defaultProps} />);
+    const btn = screen.getByRole('button');
+
+    fireEvent.click(btn);
+    fireEvent.click(btn);
+    fireEvent.click(btn);
+
+    expect(btn).toBeDisabled();
+
+    resolveStep({ txHash: 'xyz' });
+    await waitFor(() => expect(capturedOnStatus).not.toBeNull());
+    fireMonitor('success', 'xyz');
+
+    await waitFor(() => expect(screen.getByText(/transaction successful/i)).toBeInTheDocument());
+    expect(mockExecuteBuybackStep).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows confirming state between submit and monitor resolution', async () => {
+    mockExecuteBuybackStep.mockResolvedValue({ txHash: 'hash1' });
+
+    render(<ExecuteStepButton {...defaultProps} />);
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => expect(screen.getByText(/processing transaction/i)).toBeInTheDocument());
+
+    fireMonitor('success', 'hash1');
+    await waitFor(() => expect(screen.getByText(/transaction successful/i)).toBeInTheDocument());
+  });
+
+  it('surfaces tx hash explorer link on success', async () => {
+    const hash = 'deadbeef1234';
+    mockExecuteBuybackStep.mockResolvedValue({ txHash: hash });
+
+    render(<ExecuteStepButton {...defaultProps} />);
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => expect(capturedOnStatus).not.toBeNull());
+    fireMonitor('success', hash);
+
+    await waitFor(() => {
+      const link = screen.getByRole('link', { name: /view on stellar expert/i });
+      expect(link).toHaveAttribute('href', `https://stellar.expert/explorer/testnet/tx/${hash}`);
+    });
+  });
+
+  it('shows actionable error and allows retry on monitor failure', async () => {
+    const hash = 'failhash';
+    mockExecuteBuybackStep.mockResolvedValue({ txHash: hash });
+    const onError = vi.fn();
+
+    render(<ExecuteStepButton {...defaultProps} onError={onError} />);
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => expect(capturedOnStatus).not.toBeNull());
+    fireMonitor('failed', hash);
+
+    await waitFor(() => expect(screen.getAllByText(/transaction failed/i).length).toBeGreaterThan(0));
+    expect(onError).toHaveBeenCalled();
+
+    // Retry
+    capturedOnStatus = null;
+    mockExecuteBuybackStep.mockResolvedValue({ txHash: 'retry-hash' });
+    fireEvent.click(screen.getByRole('button', { name: /execute buyback step 1/i }));
+
+    await waitFor(() => expect(capturedOnStatus).not.toBeNull());
+    fireMonitor('success', 'retry-hash');
+
+    await waitFor(() => expect(screen.getByText(/transaction successful/i)).toBeInTheDocument());
+  });
+
+  it('shows actionable error when submit itself fails', async () => {
+    mockExecuteBuybackStep.mockRejectedValue(new Error('Wallet rejected'));
+
+    render(<ExecuteStepButton {...defaultProps} />);
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => expect(screen.getByText(/wallet rejected/i)).toBeInTheDocument());
+  });
+});

--- a/frontend/src/services/__tests__/buybackCampaignMapper.test.ts
+++ b/frontend/src/services/__tests__/buybackCampaignMapper.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { mapBuybackCampaign } from '../mappers/buybackCampaignMapper';
+import type { OnChainBuybackCampaign } from '../../../types/campaign';
+
+const validRaw: OnChainBuybackCampaign = {
+  id: 1,
+  token_address: 'CTOKEN123',
+  total_amount: '10000',
+  executed_amount: '4000',
+  current_step: 2,
+  total_steps: 5,
+  status: 'ACTIVE',
+  created_at: '2026-03-24T00:00:00Z',
+  steps: [
+    { id: 1, step_number: 0, amount: '2000', status: 'COMPLETED', executed_at: '2026-03-24T01:00:00Z', tx_hash: 'abc' },
+    { id: 2, step_number: 1, amount: '2000', status: 'COMPLETED', executed_at: '2026-03-24T02:00:00Z', tx_hash: 'def' },
+    { id: 3, step_number: 2, amount: '2000', status: 'PENDING' },
+    { id: 4, step_number: 3, amount: '2000', status: 'PENDING' },
+    { id: 5, step_number: 4, amount: '2000', status: 'PENDING' },
+  ],
+};
+
+describe('mapBuybackCampaign', () => {
+  it('maps a valid contract payload to a UI model', () => {
+    const model = mapBuybackCampaign(validRaw);
+
+    expect(model.id).toBe(1);
+    expect(model.tokenAddress).toBe('CTOKEN123');
+    expect(model.totalAmount).toBe('10000');
+    expect(model.executedAmount).toBe('4000');
+    expect(model.currentStep).toBe(2);
+    expect(model.totalSteps).toBe(5);
+    expect(model.status).toBe('ACTIVE');
+    expect(model.isActive).toBe(true);
+    expect(model.steps).toHaveLength(5);
+  });
+
+  it('calculates progressPercent correctly', () => {
+    const model = mapBuybackCampaign(validRaw);
+    expect(model.progressPercent).toBe(40);
+  });
+
+  it('caps progressPercent at 100', () => {
+    const raw = { ...validRaw, current_step: 10, total_steps: 5 };
+    const model = mapBuybackCampaign(raw);
+    expect(model.progressPercent).toBe(100);
+  });
+
+  it('returns 0 progressPercent when total_steps is 0', () => {
+    const raw = { ...validRaw, current_step: 0, total_steps: 0, steps: [] };
+    const model = mapBuybackCampaign(raw);
+    expect(model.progressPercent).toBe(0);
+  });
+
+  it('maps step fields from snake_case to camelCase', () => {
+    const model = mapBuybackCampaign(validRaw);
+    const step = model.steps[0];
+    expect(step.stepNumber).toBe(0);
+    expect(step.txHash).toBe('abc');
+    expect(step.executedAt).toBe('2026-03-24T01:00:00Z');
+  });
+
+  it('sets isActive=false for COMPLETED campaign', () => {
+    const raw = { ...validRaw, status: 'COMPLETED' as const };
+    const model = mapBuybackCampaign(raw);
+    expect(model.isActive).toBe(false);
+  });
+
+  it('throws on null payload', () => {
+    expect(() => mapBuybackCampaign(null)).toThrow('Campaign payload is not an object');
+  });
+
+  it('throws on missing required field', () => {
+    const { token_address: _, ...incomplete } = validRaw;
+    expect(() => mapBuybackCampaign(incomplete)).toThrow('token_address');
+  });
+
+  it('throws on invalid campaign status', () => {
+    const raw = { ...validRaw, status: 'UNKNOWN' as never };
+    expect(() => mapBuybackCampaign(raw)).toThrow('Invalid campaign status');
+  });
+
+  it('throws on invalid step status', () => {
+    const raw = {
+      ...validRaw,
+      steps: [{ ...validRaw.steps[0], status: 'RUNNING' as never }],
+    };
+    expect(() => mapBuybackCampaign(raw)).toThrow('Invalid step status');
+  });
+
+  it('handles optional step fields being absent', () => {
+    const model = mapBuybackCampaign(validRaw);
+    const pendingStep = model.steps[2];
+    expect(pendingStep.txHash).toBeUndefined();
+    expect(pendingStep.executedAt).toBeUndefined();
+  });
+});

--- a/frontend/src/services/mappers/buybackCampaignMapper.ts
+++ b/frontend/src/services/mappers/buybackCampaignMapper.ts
@@ -1,0 +1,77 @@
+import type {
+  OnChainBuybackCampaign,
+  OnChainBuybackStep,
+  BuybackCampaignModel,
+  BuybackStepModel,
+} from '../../types/campaign';
+
+const REQUIRED_CAMPAIGN_KEYS: (keyof OnChainBuybackCampaign)[] = [
+  'id',
+  'token_address',
+  'total_amount',
+  'executed_amount',
+  'current_step',
+  'total_steps',
+  'status',
+  'created_at',
+  'steps',
+];
+
+const VALID_STATUSES = new Set(['ACTIVE', 'COMPLETED', 'CANCELLED']);
+const VALID_STEP_STATUSES = new Set(['PENDING', 'COMPLETED', 'FAILED']);
+
+function assertValidCampaign(raw: unknown): asserts raw is OnChainBuybackCampaign {
+  if (!raw || typeof raw !== 'object') {
+    throw new Error('Campaign payload is not an object');
+  }
+  for (const key of REQUIRED_CAMPAIGN_KEYS) {
+    if (!(key in (raw as object))) {
+      throw new Error(`Campaign payload missing required field: ${key}`);
+    }
+  }
+  const r = raw as Record<string, unknown>;
+  if (!VALID_STATUSES.has(r.status as string)) {
+    throw new Error(`Invalid campaign status: ${r.status}`);
+  }
+  if (!Array.isArray(r.steps)) {
+    throw new Error('Campaign steps must be an array');
+  }
+}
+
+function mapStep(raw: OnChainBuybackStep): BuybackStepModel {
+  if (!VALID_STEP_STATUSES.has(raw.status)) {
+    throw new Error(`Invalid step status: ${raw.status}`);
+  }
+  return {
+    id: raw.id,
+    stepNumber: raw.step_number,
+    amount: raw.amount,
+    status: raw.status,
+    executedAt: raw.executed_at,
+    txHash: raw.tx_hash,
+  };
+}
+
+export function mapBuybackCampaign(raw: unknown): BuybackCampaignModel {
+  assertValidCampaign(raw);
+
+  const steps = raw.steps.map(mapStep);
+  const progressPercent =
+    raw.total_steps > 0
+      ? Math.min(100, (raw.current_step / raw.total_steps) * 100)
+      : 0;
+
+  return {
+    id: raw.id,
+    tokenAddress: raw.token_address,
+    totalAmount: raw.total_amount,
+    executedAmount: raw.executed_amount,
+    currentStep: raw.current_step,
+    totalSteps: raw.total_steps,
+    status: raw.status,
+    createdAt: raw.created_at,
+    steps,
+    progressPercent,
+    isActive: raw.status === 'ACTIVE',
+  };
+}

--- a/frontend/src/services/stellar.service.ts
+++ b/frontend/src/services/stellar.service.ts
@@ -244,7 +244,6 @@ export class StellarService {
       return false;
     }
   }
-}
 
   async fundTestAccount(publicKey: string): Promise<void> {
     try {

--- a/frontend/src/services/stellar.service.ts
+++ b/frontend/src/services/stellar.service.ts
@@ -20,6 +20,7 @@ import { ErrorCode } from '../types';
 
 import { WalletService } from './wallet';
 import type { ProposalParams, VoteParams } from '../types/governance';
+import type { OnChainBuybackCampaign } from '../types/campaign';
 
 export interface TransactionDetails {
   hash: string;
@@ -161,7 +162,7 @@ export class StellarService {
     }
   }
 
-  async getCampaign(campaignId: number): Promise<any> {
+  async getBuybackCampaign(campaignId: number): Promise<OnChainBuybackCampaign> {
     if (!this.contractClient) {
       throw this.createError(
         ErrorCode.CONTRACT_ERROR,
@@ -171,7 +172,7 @@ export class StellarService {
 
     try {
       const operation = this.contractClient.call(
-        'get_campaign',
+        'get_buyback_campaign',
         nativeToScVal(campaignId, { type: 'u64' })
       );
 
@@ -187,14 +188,15 @@ export class StellarService {
       const simulated = await this.server.simulateTransaction(transaction);
 
       if (Soroban.Api.isSimulationSuccess(simulated)) {
-        return scValToNative(simulated.result!.retval);
+        const raw = scValToNative(simulated.result!.retval) as OnChainBuybackCampaign;
+        return raw;
       }
 
       throw new Error('Simulation failed');
     } catch (error) {
       throw this.createError(
         ErrorCode.CONTRACT_ERROR,
-        'Failed to get campaign',
+        'Failed to get buyback campaign',
         error instanceof Error ? error.message : undefined
       );
     }

--- a/frontend/src/types/campaign.ts
+++ b/frontend/src/types/campaign.ts
@@ -64,3 +64,57 @@ export interface CampaignTransactionState {
   timestamp: number;
   error?: string;
 }
+
+// ── On-chain / contract types ────────────────────────────────────────────────
+
+export type OnChainStepStatus = 'PENDING' | 'COMPLETED' | 'FAILED';
+export type OnChainCampaignStatus = 'ACTIVE' | 'COMPLETED' | 'CANCELLED';
+
+/** Raw step shape returned by the Soroban contract */
+export interface OnChainBuybackStep {
+  id: number;
+  step_number: number;
+  amount: string;
+  status: OnChainStepStatus;
+  executed_at?: string;
+  tx_hash?: string;
+}
+
+/** Raw campaign shape returned by `get_buyback_campaign` */
+export interface OnChainBuybackCampaign {
+  id: number;
+  token_address: string;
+  total_amount: string;
+  executed_amount: string;
+  current_step: number;
+  total_steps: number;
+  status: OnChainCampaignStatus;
+  created_at: string;
+  steps: OnChainBuybackStep[];
+}
+
+// ── UI / dashboard models ────────────────────────────────────────────────────
+
+export interface BuybackStepModel {
+  id: number;
+  stepNumber: number;
+  amount: string;
+  status: OnChainStepStatus;
+  executedAt?: string;
+  txHash?: string;
+}
+
+export interface BuybackCampaignModel {
+  id: number;
+  tokenAddress: string;
+  totalAmount: string;
+  executedAmount: string;
+  currentStep: number;
+  totalSteps: number;
+  status: OnChainCampaignStatus;
+  createdAt: string;
+  steps: BuybackStepModel[];
+  /** 0–100 */
+  progressPercent: number;
+  isActive: boolean;
+}


### PR DESCRIPTION
Replaces untyped getCampaign with getBuybackCampaign calling the correct get_buyback_campaign contract function. Adds a mapper to validate and 
transform raw contract payloads into typed UI models, and updates CampaignDashboard to consume them.

Changes:
- types/campaign.ts — added OnChainBuybackCampaign and BuybackCampaignModel types
- stellar.service.ts — replaced getCampaign(): any with getBuybackCampaign(): Promise<OnChainBuybackCampaign>
- mappers/buybackCampaignMapper.ts — validates + maps contract payload to UI model
- CampaignDashboard.tsx — uses typed service + mapper, no more any
- buybackCampaignMapper.test.ts — 11 tests, all passing


Closes #608 