### PR TITLE
Feature/buyback campaign projections

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -244,6 +244,7 @@ model Campaign {
   updatedAt     DateTime       @updatedAt
   completedAt   DateTime?
   cancelledAt   DateTime?
+  pausedAt      DateTime?
 
   executions CampaignExecution[]
 

--- a/backend/src/__tests__/campaignProjection.ingestion.integration.test.ts
+++ b/backend/src/__tests__/campaignProjection.ingestion.integration.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, beforeEach, vi, beforeAll } from "vitest";
+
+// ── In-memory stores ─────────────────────────────────────────────────────────
+const mockCampaigns = new Map<number, any>();
+const mockExecutions = new Map<string, any>();
+
+const mockPrisma = {
+  campaign: {
+    upsert: vi.fn(async ({ where, create }: any) => {
+      if (!mockCampaigns.has(where.campaignId)) {
+        const c = { ...create, id: `campaign-${where.campaignId}`, updatedAt: new Date() };
+        mockCampaigns.set(where.campaignId, c);
+      }
+      return mockCampaigns.get(where.campaignId);
+    }),
+    findUnique: vi.fn(async ({ where }: any) =>
+      mockCampaigns.get(where.campaignId) ?? null
+    ),
+    findMany: vi.fn(async ({ where }: any = {}) => {
+      const all = Array.from(mockCampaigns.values());
+      if (where?.status) return all.filter((c) => c.status === where.status);
+      return all;
+    }),
+    update: vi.fn(async ({ where, data }: any) => {
+      // Support lookup by id or campaignId
+      let campaign: any;
+      if (where.id) {
+        campaign = Array.from(mockCampaigns.values()).find((c) => c.id === where.id);
+      } else {
+        campaign = mockCampaigns.get(where.campaignId);
+      }
+      if (!campaign) throw new Error("Campaign not found");
+
+      if (data.currentAmount?.increment)
+        campaign.currentAmount = (campaign.currentAmount ?? BigInt(0)) + data.currentAmount.increment;
+      if (data.executionCount?.increment)
+        campaign.executionCount = (campaign.executionCount ?? 0) + data.executionCount.increment;
+      if (data.status) campaign.status = data.status;
+      if (data.completedAt) campaign.completedAt = data.completedAt;
+      if (data.cancelledAt) campaign.cancelledAt = data.cancelledAt;
+      if (data.pausedAt) campaign.pausedAt = data.pausedAt;
+      campaign.updatedAt = data.updatedAt ?? new Date();
+      return campaign;
+    }),
+    count: vi.fn(async ({ where }: any = {}) => {
+      const all = Array.from(mockCampaigns.values());
+      if (where?.status) return all.filter((c) => c.status === where.status).length;
+      return all.length;
+    }),
+    aggregate: vi.fn(async () => ({
+      _sum: { currentAmount: BigInt(0), executionCount: 0 },
+    })),
+  },
+  campaignExecution: {
+    create: vi.fn(async ({ data }: any) => {
+      const exec = { ...data, id: `exec-${data.txHash}` };
+      mockExecutions.set(data.txHash, exec);
+      return exec;
+    }),
+    findUnique: vi.fn(async ({ where }: any) =>
+      mockExecutions.get(where.txHash) ?? null
+    ),
+    findMany: vi.fn(async () => Array.from(mockExecutions.values())),
+    count: vi.fn(async () => mockExecutions.size),
+  },
+  $transaction: vi.fn(async (ops: any[]) => {
+    const results = [];
+    for (const op of ops) results.push(await op);
+    return results;
+  }),
+};
+
+vi.mock("@prisma/client", () => ({
+  PrismaClient: vi.fn(() => mockPrisma),
+}));
+
+// ── Imports after mock ────────────────────────────────────────────────────────
+let parser: any;
+let projectionService: any;
+
+beforeAll(async () => {
+  const { CampaignEventParser } = await import(
+    "../services/campaignEventParser"
+  );
+  const { CampaignProjectionService } = await import(
+    "../services/campaignProjectionService"
+  );
+  parser = new CampaignEventParser();
+  projectionService = new CampaignProjectionService();
+});
+
+beforeEach(() => {
+  mockCampaigns.clear();
+  mockExecutions.clear();
+  vi.clearAllMocks();
+});
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+const baseCreate = {
+  campaignId: 1,
+  tokenId: "CTOKEN123",
+  creator: "GCREATOR",
+  type: "BUYBACK" as const,
+  targetAmount: BigInt(1_000_000),
+  startTime: new Date("2026-01-01T00:00:00Z"),
+  txHash: "tx-create-1",
+};
+
+const baseExec = (txHash: string, amount = BigInt(200_000)) => ({
+  campaignId: 1,
+  executor: "GEXECUTOR",
+  amount,
+  txHash,
+  executedAt: new Date(),
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+describe("Campaign Projection Ingestion", () => {
+  it("campaign-created event inserts a projection", async () => {
+    await parser.parseCampaignCreated(baseCreate);
+
+    const projection = await projectionService.getCampaignById(1);
+    expect(projection).not.toBeNull();
+    expect(projection.campaignId).toBe(1);
+    expect(projection.status).toBe("ACTIVE");
+    expect(projection.currentAmount).toBe(BigInt(0));
+    expect(projection.executionCount).toBe(0);
+  });
+
+  it("step execution updates currentAmount and executionCount", async () => {
+    await parser.parseCampaignCreated(baseCreate);
+    await parser.parseCampaignExecution(baseExec("tx-exec-1", BigInt(300_000)));
+    await parser.parseCampaignExecution(baseExec("tx-exec-2", BigInt(200_000)));
+
+    const projection = await projectionService.getCampaignById(1);
+    expect(projection.currentAmount).toBe(BigInt(500_000));
+    expect(projection.executionCount).toBe(2);
+    expect(projection.progress).toBe(50);
+  });
+
+  it("COMPLETED status sets completedAt on projection", async () => {
+    await parser.parseCampaignCreated(baseCreate);
+    await parser.parseCampaignStatusChange({ campaignId: 1, status: "COMPLETED", txHash: "tx-s1" });
+
+    const projection = await projectionService.getCampaignById(1);
+    expect(projection.status).toBe("COMPLETED");
+    expect(projection.completedAt).toBeInstanceOf(Date);
+  });
+
+  it("CANCELLED status sets cancelledAt on projection", async () => {
+    await parser.parseCampaignCreated(baseCreate);
+    await parser.parseCampaignStatusChange({ campaignId: 1, status: "CANCELLED", txHash: "tx-s2" });
+
+    const projection = await projectionService.getCampaignById(1);
+    expect(projection.status).toBe("CANCELLED");
+    expect(projection.cancelledAt).toBeInstanceOf(Date);
+  });
+
+  it("PAUSED status sets pausedAt on projection", async () => {
+    await parser.parseCampaignCreated(baseCreate);
+    await parser.parseCampaignStatusChange({ campaignId: 1, status: "PAUSED", txHash: "tx-s3" });
+
+    const projection = await projectionService.getCampaignById(1);
+    expect(projection.status).toBe("PAUSED");
+    expect(projection.pausedAt).toBeInstanceOf(Date);
+  });
+
+  it("replayed events do not duplicate execution rows", async () => {
+    await parser.parseCampaignCreated(baseCreate);
+
+    const exec = baseExec("tx-exec-dup");
+    await parser.parseCampaignExecution(exec);
+    await parser.parseCampaignExecution(exec); // replay
+    await parser.parseCampaignExecution(exec); // replay again
+
+    expect(mockExecutions.size).toBe(1);
+    const projection = await projectionService.getCampaignById(1);
+    expect(projection.executionCount).toBe(1);
+    expect(projection.currentAmount).toBe(BigInt(200_000));
+  });
+
+  it("replayed full event stream produces identical projection", async () => {
+    const events = [
+      () => parser.parseCampaignCreated(baseCreate),
+      () => parser.parseCampaignExecution(baseExec("tx-r1", BigInt(100_000))),
+      () => parser.parseCampaignExecution(baseExec("tx-r2", BigInt(150_000))),
+      () => parser.parseCampaignStatusChange({ campaignId: 1, status: "COMPLETED", txHash: "tx-r3" }),
+    ];
+
+    for (const e of events) await e();
+    const first = await projectionService.getCampaignById(1);
+
+    for (const e of events) await e(); // replay
+    const second = await projectionService.getCampaignById(1);
+
+    expect(second.currentAmount).toBe(first.currentAmount);
+    expect(second.executionCount).toBe(first.executionCount);
+    expect(second.status).toBe(first.status);
+    expect(mockExecutions.size).toBe(2);
+  });
+
+  it("getActiveCampaigns returns only ACTIVE campaigns", async () => {
+    await parser.parseCampaignCreated({ ...baseCreate, campaignId: 1, txHash: "tx-a1" });
+    await parser.parseCampaignCreated({ ...baseCreate, campaignId: 2, txHash: "tx-a2" });
+    await parser.parseCampaignStatusChange({ campaignId: 2, status: "COMPLETED", txHash: "tx-a3" });
+
+    const active = await projectionService.getActiveCampaigns();
+    expect(active.every((c: any) => c.status === "ACTIVE")).toBe(true);
+    expect(active.length).toBe(1);
+    expect(active[0].campaignId).toBe(1);
+  });
+});

--- a/backend/src/services/campaignEventParser.ts
+++ b/backend/src/services/campaignEventParser.ts
@@ -60,13 +60,12 @@ export class CampaignEventParser {
       throw new Error(`Campaign ${event.campaignId} not found`);
     }
 
-    // Check if execution already exists
+    // Idempotency: skip if already processed
     const existingExecution = await prisma.campaignExecution.findUnique({
       where: { txHash: event.txHash },
     });
 
     if (existingExecution) {
-      // Already processed, skip
       return;
     }
 
@@ -101,15 +100,18 @@ export class CampaignEventParser {
       throw new Error(`Campaign ${event.campaignId} not found`);
     }
 
-    const updateData: any = {
+    const now = new Date();
+    const updateData: Record<string, unknown> = {
       status: event.status,
-      updatedAt: new Date(),
+      updatedAt: now,
     };
 
     if (event.status === "COMPLETED") {
-      updateData.completedAt = new Date();
+      updateData.completedAt = now;
     } else if (event.status === "CANCELLED") {
-      updateData.cancelledAt = new Date();
+      updateData.cancelledAt = now;
+    } else if (event.status === "PAUSED") {
+      updateData.pausedAt = now;
     }
 
     await prisma.campaign.update({

--- a/backend/src/services/campaignProjectionService.ts
+++ b/backend/src/services/campaignProjectionService.ts
@@ -20,6 +20,7 @@ export interface CampaignProjection {
   updatedAt: Date;
   completedAt?: Date;
   cancelledAt?: Date;
+  pausedAt?: Date;
 }
 
 export interface CampaignStats {
@@ -64,6 +65,14 @@ export class CampaignProjectionService {
       orderBy: { createdAt: "desc" },
     });
 
+    return campaigns.map((c) => this.buildProjection(c));
+  }
+
+  async getActiveCampaigns(): Promise<CampaignProjection[]> {
+    const campaigns = await prisma.campaign.findMany({
+      where: { status: "ACTIVE" },
+      orderBy: { createdAt: "desc" },
+    });
     return campaigns.map((c) => this.buildProjection(c));
   }
 
@@ -141,6 +150,7 @@ export class CampaignProjectionService {
       updatedAt: campaign.updatedAt,
       completedAt: campaign.completedAt,
       cancelledAt: campaign.cancelledAt,
+      pausedAt: campaign.pausedAt,
     };
   }
 }

--- a/backend/src/services/stellarEventListener.ts
+++ b/backend/src/services/stellarEventListener.ts
@@ -4,6 +4,7 @@ import webhookDeliveryService from "./webhookDeliveryService";
 import { PrismaClient } from "@prisma/client";
 import { GovernanceEventParser } from "./governanceEventParser";
 import governanceEventMapper from "./governanceEventMapper";
+import { campaignEventParser } from "./campaignEventParser";
 
 const HORIZON_URL =
   process.env.STELLAR_HORIZON_URL || "https://horizon-testnet.stellar.org";
@@ -122,6 +123,12 @@ export class StellarEventListener {
         return;
       }
 
+      // Route buyback campaign events
+      if (this.isBuybackEvent(event)) {
+        await this.processBuybackEvent(event);
+        return;
+      }
+
       // Parse event topic to determine event type
       const eventType = this.parseEventType(event);
 
@@ -233,6 +240,63 @@ export class StellarEventListener {
 
       default:
         return baseData;
+    }
+  }
+
+  /**
+   * Check if a Stellar event is a buyback campaign event
+   */
+  private isBuybackEvent(event: StellarEvent): boolean {
+    const buybackTopics = new Set(["bb_created", "bb_executed", "bb_status"]);
+    return event.topic.length > 0 && buybackTopics.has(event.topic[0]);
+  }
+
+  /**
+   * Route and parse a buyback campaign event
+   */
+  private async processBuybackEvent(event: StellarEvent): Promise<void> {
+    const topic = event.topic[0];
+    const v = event.value ?? {};
+
+    try {
+      if (topic === "bb_created") {
+        await campaignEventParser.parseCampaignCreated({
+          campaignId: Number(v.campaign_id ?? event.topic[1]),
+          tokenId: v.token_id ?? event.topic[2] ?? "",
+          creator: v.creator ?? "",
+          type: "BUYBACK",
+          targetAmount: BigInt(v.target_amount ?? 0),
+          startTime: new Date(v.start_time ? Number(v.start_time) * 1000 : Date.now()),
+          endTime: v.end_time ? new Date(Number(v.end_time) * 1000) : undefined,
+          metadata: v.metadata,
+          txHash: event.transaction_hash,
+        });
+        console.log(`Ingested buyback campaign created: ${v.campaign_id}`);
+      } else if (topic === "bb_executed") {
+        await campaignEventParser.parseCampaignExecution({
+          campaignId: Number(v.campaign_id ?? event.topic[1]),
+          executor: v.executor ?? "",
+          amount: BigInt(v.amount ?? 0),
+          recipient: v.recipient,
+          txHash: event.transaction_hash,
+          executedAt: new Date(event.ledger_close_time),
+        });
+        console.log(`Ingested buyback step executed: ${event.transaction_hash}`);
+      } else if (topic === "bb_status") {
+        const status = (v.status ?? "").toUpperCase() as
+          | "ACTIVE"
+          | "PAUSED"
+          | "COMPLETED"
+          | "CANCELLED";
+        await campaignEventParser.parseCampaignStatusChange({
+          campaignId: Number(v.campaign_id ?? event.topic[1]),
+          status,
+          txHash: event.transaction_hash,
+        });
+        console.log(`Ingested buyback status change: ${status}`);
+      }
+    } catch (error) {
+      console.error(`Error processing buyback event (${topic}):`, error);
     }
   }
 


### PR DESCRIPTION
Routes bb_created, bb_executed, and bb_status contract events through the event listener into typed parser calls, persisting idempotent campaign 
projections server-side.

Changes:
- stellarEventListener.ts — detects and routes buyback events (bb_created/executed/status) into campaignEventParser
- campaignEventParser.ts — adds pausedAt on PAUSED status; removes any on update data
- schema.prisma — adds pausedAt DateTime? to Campaign
- campaignProjectionService.ts — adds pausedAt to projection, adds getActiveCampaigns()
- campaignProjection.ingestion.integration.test.ts — 8 tests, all passing (insert, execution updates, all status transitions, replay safety)

Closes #610 