### PR TITLE
Feature/campaign step details api

### DIFF
--- a/backend/src/__tests__/campaignSteps.routes.test.ts
+++ b/backend/src/__tests__/campaignSteps.routes.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+// ── Mock PrismaClient ─────────────────────────────────────────────────────────
+const { mockFindUnique, mockCount } = vi.hoisted(() => ({
+  mockFindUnique: vi.fn(),
+  mockCount: vi.fn(),
+}));
+
+vi.mock('@prisma/client', () => ({
+  PrismaClient: vi.fn(() => ({
+    buybackCampaign: {
+      create: vi.fn(),
+      findMany: vi.fn().mockResolvedValue([]),
+      findUnique: mockFindUnique,
+      update: vi.fn(),
+      count: vi.fn().mockResolvedValue(0),
+    },
+    buybackStep: {
+      update: vi.fn(),
+      count: mockCount,
+    },
+  })),
+}));
+
+import buybackRoutes from '../routes/buyback';
+
+const app = express();
+app.use(express.json());
+app.use('/api/buyback', buybackRoutes);
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+const makeStep = (
+  n: number,
+  status: 'PENDING' | 'COMPLETED' | 'FAILED',
+  txHash?: string
+) => ({
+  id: n + 1,
+  campaignId: 1,
+  stepNumber: n,
+  amount: '2000',
+  status,
+  executedAt: status !== 'PENDING' ? new Date('2026-03-24T01:00:00Z') : null,
+  txHash: txHash ?? null,
+});
+
+const makeCampaign = (steps: ReturnType<typeof makeStep>[]) => ({
+  id: 1,
+  tokenAddress: 'CTOKEN123',
+  totalAmount: '10000',
+  executedAmount: '0',
+  currentStep: 0,
+  totalSteps: steps.length,
+  status: 'ACTIVE',
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  steps,
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+describe('GET /api/buyback/campaigns/:id/steps', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCount.mockResolvedValue(0);
+  });
+
+  it('returns steps in ascending stepNumber order with pagination envelope', async () => {
+    const steps = [
+      makeStep(0, 'COMPLETED', 'tx-aaa'),
+      makeStep(1, 'COMPLETED', 'tx-bbb'),
+      makeStep(2, 'PENDING'),
+    ];
+    mockFindUnique.mockResolvedValue(makeCampaign(steps));
+    mockCount.mockResolvedValue(3);
+
+    const res = await request(app).get('/api/buyback/campaigns/1/steps').expect(200);
+
+    expect(res.body.steps).toHaveLength(3);
+    expect(res.body.steps[0].stepNumber).toBe(0);
+    expect(res.body.steps[1].stepNumber).toBe(1);
+    expect(res.body.steps[2].stepNumber).toBe(2);
+    expect(res.body.pagination).toMatchObject({ total: 3, limit: 50, offset: 0 });
+  });
+
+  it('completed steps contain executedAt and txHash', async () => {
+    const steps = [makeStep(0, 'COMPLETED', 'tx-completed-1')];
+    mockFindUnique.mockResolvedValue(makeCampaign(steps));
+    mockCount.mockResolvedValue(1);
+
+    const res = await request(app).get('/api/buyback/campaigns/1/steps').expect(200);
+
+    const step = res.body.steps[0];
+    expect(step.status).toBe('COMPLETED');
+    expect(step.txHash).toBe('tx-completed-1');
+    expect(step.executedAt).toBeDefined();
+  });
+
+  it('failed steps contain executedAt and no txHash', async () => {
+    const steps = [makeStep(0, 'FAILED')];
+    mockFindUnique.mockResolvedValue(makeCampaign(steps));
+    mockCount.mockResolvedValue(1);
+
+    const res = await request(app).get('/api/buyback/campaigns/1/steps').expect(200);
+
+    const step = res.body.steps[0];
+    expect(step.status).toBe('FAILED');
+    expect(step.executedAt).toBeDefined();
+    expect(step.txHash == null).toBe(true); // null from DB, undefined after mapping
+  });
+
+  it('empty-step campaign returns empty array with total 0', async () => {
+    mockFindUnique.mockResolvedValue(makeCampaign([]));
+    mockCount.mockResolvedValue(0);
+
+    const res = await request(app).get('/api/buyback/campaigns/1/steps').expect(200);
+
+    expect(res.body.steps).toEqual([]);
+    expect(res.body.pagination.total).toBe(0);
+  });
+
+  it('returns 404 when campaign not found', async () => {
+    mockFindUnique.mockResolvedValue(null);
+
+    const res = await request(app).get('/api/buyback/campaigns/999/steps').expect(404);
+
+    expect(res.body.error).toBe('Campaign not found');
+  });
+
+  it('respects limit and offset query params', async () => {
+    const steps = [makeStep(5, 'PENDING')];
+    mockFindUnique.mockResolvedValue(makeCampaign(steps));
+    mockCount.mockResolvedValue(10);
+
+    const res = await request(app)
+      .get('/api/buyback/campaigns/1/steps?limit=5&offset=5')
+      .expect(200);
+
+    expect(res.body.pagination).toMatchObject({ total: 10, limit: 5, offset: 5 });
+  });
+
+  it('returns 500 on unexpected service error', async () => {
+    mockFindUnique.mockRejectedValue(new Error('DB connection lost'));
+
+    const res = await request(app).get('/api/buyback/campaigns/1/steps').expect(500);
+
+    expect(res.body.error).toBe('Failed to fetch campaign steps');
+  });
+});

--- a/backend/src/routes/buyback.ts
+++ b/backend/src/routes/buyback.ts
@@ -2,6 +2,7 @@ import { Router, Request, Response } from 'express';
 import { PrismaClient } from '@prisma/client';
 import { param, body, query } from 'express-validator';
 import { validate } from '../middleware/validation';
+import { campaignProjectionService } from '../services/campaignProjectionService';
 
 const router = Router();
 const prisma = new PrismaClient();
@@ -89,6 +90,34 @@ router.get(
     } catch (error) {
       console.error('Error fetching campaigns:', error);
       res.status(500).json({ error: 'Failed to fetch campaigns' });
+    }
+  }
+);
+
+router.get(
+  '/campaigns/:id/steps',
+  [
+    param('id').isInt().toInt(),
+    query('limit').optional().isInt({ min: 1, max: 100 }).toInt(),
+    query('offset').optional().isInt({ min: 0 }).toInt(),
+    validate,
+  ],
+  async (req: Request, res: Response) => {
+    try {
+      const id = Number(req.params.id);
+      const limit = Number(req.query.limit ?? 50);
+      const offset = Number(req.query.offset ?? 0);
+
+      const result = await campaignProjectionService.getCampaignSteps(id, limit, offset);
+      res.json({
+        steps: result.steps,
+        pagination: { total: result.total, limit, offset },
+      });
+    } catch (error: any) {
+      if (error?.message?.includes('not found')) {
+        return res.status(404).json({ error: 'Campaign not found' });
+      }
+      res.status(500).json({ error: 'Failed to fetch campaign steps' });
     }
   }
 );

--- a/backend/src/services/campaignProjectionService.ts
+++ b/backend/src/services/campaignProjectionService.ts
@@ -2,6 +2,15 @@ import { PrismaClient } from "@prisma/client";
 
 const prisma = new PrismaClient();
 
+export interface StepDetail {
+  id: number;
+  stepNumber: number;
+  amount: string;
+  status: "PENDING" | "COMPLETED" | "FAILED";
+  executedAt?: Date;
+  txHash?: string;
+}
+
 export interface CampaignProjection {
   id: string;
   campaignId: number;
@@ -74,6 +83,40 @@ export class CampaignProjectionService {
       orderBy: { createdAt: "desc" },
     });
     return campaigns.map((c) => this.buildProjection(c));
+  }
+
+  async getCampaignSteps(
+    campaignId: number,
+    limit = 50,
+    offset = 0
+  ): Promise<{ steps: StepDetail[]; total: number }> {
+    const campaign = await prisma.buybackCampaign.findUnique({
+      where: { id: campaignId },
+      include: {
+        steps: {
+          orderBy: { stepNumber: "asc" },
+          take: limit,
+          skip: offset,
+        },
+      },
+    });
+
+    if (!campaign) throw new Error(`Campaign ${campaignId} not found`);
+
+    const total = await prisma.buybackStep.count({
+      where: { campaignId },
+    });
+
+    const steps: StepDetail[] = campaign.steps.map((s) => ({
+      id: s.id,
+      stepNumber: s.stepNumber,
+      amount: s.amount,
+      status: s.status as StepDetail["status"],
+      executedAt: s.executedAt ?? undefined,
+      txHash: s.txHash ?? undefined,
+    }));
+
+    return { steps, total };
   }
 
   async getCampaignStats(tokenId?: string): Promise<CampaignStats> {

--- a/frontend/src/components/BuybackCampaign/CampaignDashboard.tsx
+++ b/frontend/src/components/BuybackCampaign/CampaignDashboard.tsx
@@ -2,7 +2,9 @@ import React, { useEffect, useState } from 'react';
 import { ExecuteStepButton } from './ExecuteStepButton';
 import { StellarService } from '../../services/stellar.service';
 import { mapBuybackCampaign } from '../../services/mappers/buybackCampaignMapper';
-import type { BuybackCampaignModel } from '../../types/campaign';
+import type { BuybackCampaignModel, BuybackStepModel } from '../../types/campaign';
+
+const BACKEND_URL = import.meta.env.VITE_BACKEND_URL ?? '';
 
 interface CampaignDashboardProps {
   campaignId: number;
@@ -20,9 +22,46 @@ export const CampaignDashboard: React.FC<CampaignDashboardProps> = ({
   const fetchCampaign = async () => {
     try {
       setLoading(true);
-      const service = new StellarService(network);
-      const raw = await service.getBuybackCampaign(campaignId);
-      setCampaign(mapBuybackCampaign(raw));
+
+      // Prefer backend step data; fall back to chain read if unavailable
+      const backendRes = await fetch(
+        `${BACKEND_URL}/api/buyback/campaigns/${campaignId}/steps`
+      ).catch(() => null);
+
+      if (backendRes?.ok) {
+        const { steps } = await backendRes.json() as {
+          steps: Array<{
+            id: number;
+            stepNumber: number;
+            amount: string;
+            status: 'PENDING' | 'COMPLETED' | 'FAILED';
+            executedAt?: string;
+            txHash?: string;
+          }>;
+          pagination: { total: number; limit: number; offset: number };
+        };
+
+        // Also fetch campaign header from chain for live status/amounts
+        const service = new StellarService(network);
+        const raw = await service.getBuybackCampaign(campaignId);
+        const base = mapBuybackCampaign({ ...raw, steps: [] });
+
+        const mappedSteps: BuybackStepModel[] = steps.map((s) => ({
+          id: s.id,
+          stepNumber: s.stepNumber,
+          amount: s.amount,
+          status: s.status,
+          executedAt: s.executedAt,
+          txHash: s.txHash,
+        }));
+
+        setCampaign({ ...base, steps: mappedSteps });
+      } else {
+        // Full chain read fallback
+        const service = new StellarService(network);
+        const raw = await service.getBuybackCampaign(campaignId);
+        setCampaign(mapBuybackCampaign(raw));
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Unknown error');
     } finally {


### PR DESCRIPTION
Exposes GET /api/buyback/campaigns/:id/steps with limit/offset pagination. Frontend fetches from this endpoint first and falls back to chain read 
if unavailable.

- GET /campaigns/:id/steps route (placed before /:id to avoid shadowing)
- getCampaignSteps() in campaignProjectionService with StepDetail type
- CampaignDashboard fetches steps from backend, falls back to Stellar contract
- 7 passing route tests

Closes #611 