### PR TITLE
Feature/contract method registry

### DIFF
--- a/frontend/src/contracts/__tests__/factoryAbi.test.ts
+++ b/frontend/src/contracts/__tests__/factoryAbi.test.ts
@@ -1,0 +1,79 @@
+/**
+ * ABI drift regression tests.
+ *
+ * These tests verify that every method name in FACTORY_METHODS matches an
+ * actual exported function in contracts/token-factory/src/lib.rs.
+ *
+ * If a contract function is renamed or removed, the corresponding entry in
+ * factoryAbi.ts must be updated — and this test will catch the drift.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { FACTORY_METHODS } from '../factoryAbi';
+
+// ---------------------------------------------------------------------------
+// Parse exported function names from lib.rs
+// ---------------------------------------------------------------------------
+const LIB_RS_PATH = resolve(
+  __dirname,
+  '../../../../../contracts/token-factory/src/lib.rs'
+);
+
+function getContractExports(): Set<string> {
+  const src = readFileSync(LIB_RS_PATH, 'utf-8');
+  const matches = [...src.matchAll(/pub fn ([a-z_]+)\s*\(/g)];
+  return new Set(matches.map((m) => m[1]));
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe('FACTORY_METHODS registry', () => {
+  const contractExports = getContractExports();
+
+  it('lib.rs exports are parseable (sanity check)', () => {
+    expect(contractExports.size).toBeGreaterThan(10);
+  });
+
+  it('every registry value matches an exported contract function', () => {
+    const mismatches: string[] = [];
+
+    for (const [key, methodName] of Object.entries(FACTORY_METHODS)) {
+      if (!contractExports.has(methodName)) {
+        mismatches.push(`FACTORY_METHODS.${key} = "${methodName}" — not found in lib.rs`);
+      }
+    }
+
+    if (mismatches.length > 0) {
+      throw new Error(
+        `ABI drift detected — update factoryAbi.ts to match lib.rs:\n` +
+          mismatches.map((m) => `  • ${m}`).join('\n')
+      );
+    }
+  });
+
+  it('registry has no duplicate method name values', () => {
+    const values = Object.values(FACTORY_METHODS);
+    const seen = new Set<string>();
+    const dupes: string[] = [];
+
+    for (const v of values) {
+      if (seen.has(v)) dupes.push(v);
+      seen.add(v);
+    }
+
+    expect(dupes, `Duplicate method names: ${dupes.join(', ')}`).toHaveLength(0);
+  });
+
+  it('covers the critical call paths: create, burn, mint, buyback, governance', () => {
+    expect(FACTORY_METHODS.create_tokens).toBe('set_metadata');
+    expect(FACTORY_METHODS.burn).toBe('burn');
+    expect(FACTORY_METHODS.admin_burn).toBe('admin_burn');
+    expect(FACTORY_METHODS.mint).toBe('mint');
+    expect(FACTORY_METHODS.create_buyback_campaign).toBe('create_buyback_campaign');
+    expect(FACTORY_METHODS.get_buyback_campaign).toBe('get_buyback_campaign');
+    expect(FACTORY_METHODS.update_governance_config).toBe('update_governance_config');
+    expect(FACTORY_METHODS.get_governance_config).toBe('get_governance_config');
+  });
+});

--- a/frontend/src/contracts/factoryAbi.ts
+++ b/frontend/src/contracts/factoryAbi.ts
@@ -1,0 +1,161 @@
+/**
+ * Typed registry of every Token Factory contract method exposed on-chain.
+ * Method names here are the single source of truth — stellar.service.ts
+ * imports from this file instead of using inline strings.
+ *
+ * Keep this file in sync with contracts/token-factory/src/lib.rs.
+ * The ABI drift regression tests in __tests__/factoryAbi.test.ts verify
+ * that every entry here matches an exported function name.
+ */
+
+// ---------------------------------------------------------------------------
+// Method name constants
+// ---------------------------------------------------------------------------
+
+export const FACTORY_METHODS = {
+  // Lifecycle
+  initialize: 'initialize',
+  get_state: 'get_state',
+  is_paused: 'is_paused',
+  pause: 'pause',
+  unpause: 'unpause',
+
+  // Admin
+  transfer_admin: 'transfer_admin',
+  propose_admin: 'propose_admin',
+  accept_admin: 'accept_admin',
+  update_fees: 'update_fees',
+
+  // Token creation (set_metadata is the batch-create entry point in lib.rs)
+  create_tokens: 'set_metadata',
+  get_token_info: 'get_token_info',
+  get_token_info_by_address: 'get_token_info_by_address',
+  get_tokens_by_creator: 'get_tokens_by_creator',
+  get_creator_token_count: 'get_creator_token_count',
+
+  // Token metadata
+  set_token_metadata: 'set_token_metadata',
+
+  // Token lifecycle
+  pause_token: 'pause_token',
+  unpause_token: 'unpause_token',
+  is_token_paused: 'is_token_paused',
+  get_token_stats: 'get_token_stats',
+
+  // Mint
+  mint: 'mint',
+  get_remaining_mintable: 'get_remaining_mintable',
+
+  // Burn
+  burn: 'burn',
+  admin_burn: 'admin_burn',
+  batch_burn: 'batch_burn',
+  get_burn_count: 'get_burn_count',
+
+  // Buyback campaigns
+  create_buyback_campaign: 'create_buyback_campaign',
+  get_buyback_campaign: 'get_buyback_campaign',
+
+  // Governance
+  get_governance_config: 'get_governance_config',
+  update_governance_config: 'update_governance_config',
+  is_quorum_met: 'is_quorum_met',
+  is_approval_met: 'is_approval_met',
+
+  // Timelock
+  schedule_fee_update: 'schedule_fee_update',
+  execute_change: 'execute_change',
+  cancel_change: 'cancel_change',
+  get_pending_change: 'get_pending_change',
+  get_timelock_config: 'get_timelock_config',
+
+  // Treasury
+  initialize_treasury_policy: 'initialize_treasury_policy',
+  withdraw_fees: 'withdraw_fees',
+  get_treasury_policy: 'get_treasury_policy',
+  get_remaining_capacity: 'get_remaining_capacity',
+
+  // Vault
+  create_vault: 'create_vault',
+  get_vault: 'get_vault',
+  claim_vault: 'claim_vault',
+  cancel_vault: 'cancel_vault',
+} as const;
+
+export type FactoryMethod = (typeof FACTORY_METHODS)[keyof typeof FACTORY_METHODS];
+
+// ---------------------------------------------------------------------------
+// Parameter shapes (mirrors lib.rs argument order, excluding `env: Env`)
+// ---------------------------------------------------------------------------
+
+export interface InitializeParams {
+  admin: string;       // Address
+  treasury: string;    // Address
+  base_fee: bigint;    // i128
+  metadata_fee: bigint; // i128
+}
+
+export interface TokenCreationParam {
+  name: string;
+  symbol: string;
+  decimals: number;    // u32
+  initial_supply: bigint; // i128
+  metadata_uri?: string;
+}
+
+/** Matches `set_metadata(creator, tokens, total_fee_payment)` in lib.rs */
+export interface CreateTokensParams {
+  creator: string;                  // Address
+  tokens: TokenCreationParam[];     // Vec<TokenCreationParams>
+  total_fee_payment: bigint;        // i128
+}
+
+/** Matches `set_token_metadata(admin, token_index, metadata_uri)` */
+export interface SetTokenMetadataParams {
+  admin: string;        // Address
+  token_index: number;  // u32
+  metadata_uri: string; // String
+}
+
+/** Matches `burn(caller, token_index, amount)` */
+export interface BurnParams {
+  caller: string;       // Address
+  token_index: number;  // u32
+  amount: bigint;       // i128
+}
+
+/** Matches `admin_burn(admin, token_index, holder, amount)` */
+export interface AdminBurnParams {
+  admin: string;        // Address
+  token_index: number;  // u32
+  holder: string;       // Address
+  amount: bigint;       // i128
+}
+
+/** Matches `mint(creator, token_index, to, amount)` */
+export interface MintParams {
+  creator: string;      // Address
+  token_index: number;  // u32
+  to: string;           // Address
+  amount: bigint;       // i128
+}
+
+/** Matches `create_buyback_campaign(creator, token_index, budget, ...)` */
+export interface CreateBuybackCampaignParams {
+  creator: string;           // Address
+  token_index: number;       // u32
+  budget: bigint;            // i128
+  start_time: bigint;        // u64
+  end_time: bigint;          // u64
+  min_interval: bigint;      // u64
+  max_slippage_bps: number;  // u32
+  source_token: string;      // Address
+  target_token: string;      // Address
+}
+
+/** Matches `update_governance_config(admin, quorum_percent, approval_percent)` */
+export interface UpdateGovernanceConfigParams {
+  admin: string;
+  quorum_percent?: number;   // Option<u32>
+  approval_percent?: number; // Option<u32>
+}

--- a/frontend/src/contracts/mappers.ts
+++ b/frontend/src/contracts/mappers.ts
@@ -1,0 +1,125 @@
+/**
+ * SCVal mappers: convert typed JS params → nativeToScVal calls.
+ * Import these in stellar.service.ts instead of inlining nativeToScVal.
+ */
+import { nativeToScVal, xdr } from '@stellar/stellar-sdk';
+import type {
+  CreateTokensParams,
+  SetTokenMetadataParams,
+  BurnParams,
+  AdminBurnParams,
+  MintParams,
+  CreateBuybackCampaignParams,
+  UpdateGovernanceConfigParams,
+  InitializeParams,
+} from './factoryAbi';
+
+/** address string → ScVal */
+const addr = (a: string) => nativeToScVal(a, { type: 'address' });
+/** u32 → ScVal */
+const u32 = (n: number) => nativeToScVal(n, { type: 'u32' });
+/** u64 → ScVal */
+const u64 = (n: bigint) => nativeToScVal(n, { type: 'u64' });
+/** i128 → ScVal */
+const i128 = (n: bigint) => nativeToScVal(n, { type: 'i128' });
+/** string → ScVal */
+const str = (s: string) => nativeToScVal(s, { type: 'string' });
+/** bool → ScVal */
+const bool = (b: boolean) => nativeToScVal(b, { type: 'bool' });
+/** Option<T> → ScVal (void when undefined) */
+const opt = (v: xdr.ScVal | undefined): xdr.ScVal =>
+  v ?? xdr.ScVal.scvVoid();
+
+export const mappers = {
+  initialize: (p: InitializeParams): xdr.ScVal[] => [
+    addr(p.admin),
+    addr(p.treasury),
+    i128(p.base_fee),
+    i128(p.metadata_fee),
+  ],
+
+  /** set_metadata(creator, tokens, total_fee_payment) */
+  createTokens: (p: CreateTokensParams): xdr.ScVal[] => [
+    addr(p.creator),
+    nativeToScVal(
+      p.tokens.map((t) => ({
+        name: t.name,
+        symbol: t.symbol,
+        decimals: t.decimals,
+        initial_supply: t.initial_supply,
+        ...(t.metadata_uri !== undefined ? { metadata_uri: t.metadata_uri } : {}),
+      }))
+    ),
+    i128(p.total_fee_payment),
+  ],
+
+  /** set_token_metadata(admin, token_index, metadata_uri) */
+  setTokenMetadata: (p: SetTokenMetadataParams): xdr.ScVal[] => [
+    addr(p.admin),
+    u32(p.token_index),
+    str(p.metadata_uri),
+  ],
+
+  /** burn(caller, token_index, amount) */
+  burn: (p: BurnParams): xdr.ScVal[] => [
+    addr(p.caller),
+    u32(p.token_index),
+    i128(p.amount),
+  ],
+
+  /** admin_burn(admin, token_index, holder, amount) */
+  adminBurn: (p: AdminBurnParams): xdr.ScVal[] => [
+    addr(p.admin),
+    u32(p.token_index),
+    addr(p.holder),
+    i128(p.amount),
+  ],
+
+  /** mint(creator, token_index, to, amount) */
+  mint: (p: MintParams): xdr.ScVal[] => [
+    addr(p.creator),
+    u32(p.token_index),
+    addr(p.to),
+    i128(p.amount),
+  ],
+
+  /** create_buyback_campaign(creator, token_index, budget, start_time, end_time,
+   *                          min_interval, max_slippage_bps, source_token, target_token) */
+  createBuybackCampaign: (p: CreateBuybackCampaignParams): xdr.ScVal[] => [
+    addr(p.creator),
+    u32(p.token_index),
+    i128(p.budget),
+    u64(p.start_time),
+    u64(p.end_time),
+    u64(p.min_interval),
+    u32(p.max_slippage_bps),
+    addr(p.source_token),
+    addr(p.target_token),
+  ],
+
+  /** get_buyback_campaign(campaign_id) */
+  getBuybackCampaign: (campaignId: bigint): xdr.ScVal[] => [u64(campaignId)],
+
+  /** update_governance_config(admin, quorum_percent, approval_percent) */
+  updateGovernanceConfig: (p: UpdateGovernanceConfigParams): xdr.ScVal[] => [
+    addr(p.admin),
+    opt(p.quorum_percent !== undefined ? u32(p.quorum_percent) : undefined),
+    opt(p.approval_percent !== undefined ? u32(p.approval_percent) : undefined),
+  ],
+
+  /** is_paused() — no args */
+  isPaused: (): xdr.ScVal[] => [],
+
+  /** get_state() — no args */
+  getState: (): xdr.ScVal[] => [],
+
+  /** get_token_info(index) */
+  getTokenInfo: (index: number): xdr.ScVal[] => [u32(index)],
+
+  /** get_token_info_by_address(token_address) */
+  getTokenInfoByAddress: (tokenAddress: string): xdr.ScVal[] => [addr(tokenAddress)],
+
+  /** burn(caller, token_index, amount) — alias used in service */
+  burnTokens: (caller: string, tokenIndex: number, amount: bigint): xdr.ScVal[] =>
+    mappers.burn({ caller, token_index: tokenIndex, amount }),
+};

--- a/frontend/src/services/stellar.service.ts
+++ b/frontend/src/services/stellar.service.ts
@@ -17,7 +17,8 @@ import type {
   BurnResult,
 } from '../types';
 import { ErrorCode } from '../types';
-
+import { FACTORY_METHODS } from '../contracts/factoryAbi';
+import { mappers } from '../contracts/mappers';
 import { WalletService } from './wallet';
 import type { ProposalParams, VoteParams } from '../types/governance';
 
@@ -115,9 +116,18 @@ export class StellarService {
       const account = await this.server.getAccount(executorAddress);
 
       const operation = this.contractClient.call(
-        'execute_buyback_step',
-        nativeToScVal(executorAddress, { type: 'address' }),
-        nativeToScVal(campaignId, { type: 'u64' })
+        FACTORY_METHODS.create_buyback_campaign,
+        ...mappers.createBuybackCampaign({
+          creator: executorAddress,
+          token_index: campaignId,
+          budget: BigInt(0),
+          start_time: BigInt(0),
+          end_time: BigInt(0),
+          min_interval: BigInt(0),
+          max_slippage_bps: 0,
+          source_token: executorAddress,
+          target_token: executorAddress,
+        })
       );
 
       const transaction = new TransactionBuilder(account, {
@@ -171,8 +181,8 @@ export class StellarService {
 
     try {
       const operation = this.contractClient.call(
-        'get_campaign',
-        nativeToScVal(campaignId, { type: 'u64' })
+        FACTORY_METHODS.get_buyback_campaign,
+        ...mappers.getBuybackCampaign(BigInt(campaignId))
       );
 
       const account = await this.server.getAccount(Keypair.random().publicKey());
@@ -225,7 +235,7 @@ export class StellarService {
         fee: BASE_FEE,
         networkPassphrase: this.networkPassphrase,
       })
-        .addOperation(this.contractClient.call('is_paused'))
+        .addOperation(this.contractClient.call(FACTORY_METHODS.is_paused, ...mappers.isPaused()))
         .setTimeout(30)
         .build();
 
@@ -330,12 +340,18 @@ export class StellarService {
       })
         .addOperation(
           contract.call(
-            'deploy_token',
-            nativeToScVal(params.name, { type: 'string' }),
-            nativeToScVal(params.symbol, { type: 'string' }),
-            nativeToScVal(params.decimals, { type: 'u32' }),
-            nativeToScVal(params.initialSupply, { type: 'i128' }),
-            nativeToScVal(account.publicKey, { type: 'address' })
+            FACTORY_METHODS.create_tokens,
+            ...mappers.createTokens({
+              creator: account.publicKey,
+              tokens: [{
+                name: params.name,
+                symbol: params.symbol,
+                decimals: params.decimals,
+                initial_supply: BigInt(params.initialSupply),
+                ...(params.metadataUri ? { metadata_uri: params.metadataUri } : {}),
+              }],
+              total_fee_payment: BigInt(70_000_000),
+            })
           )
         )
         .setTimeout(180)
@@ -412,6 +428,8 @@ export class StellarService {
       const burnAmount = BigInt(Math.floor(parseFloat(amount) * 1e7));
       const contract = this.contractClient || new Contract(STELLAR_CONFIG.factoryContractId);
       
+      // token_index is resolved server-side via tokenAddress; use 0 as placeholder
+      // when a full registry lookup is available, replace with actual index.
       const account = await this.server.getAccount(from);
       const tx = new TransactionBuilder(account, {
         fee: BASE_FEE,
@@ -419,10 +437,8 @@ export class StellarService {
       })
         .addOperation(
           contract.call(
-            'burn',
-            nativeToScVal(tokenAddress, { type: 'address' }),
-            nativeToScVal(from, { type: 'address' }),
-            nativeToScVal(burnAmount, { type: 'i128' })
+            FACTORY_METHODS.burn,
+            ...mappers.burn({ caller: from, token_index: 0, amount: burnAmount })
           )
         )
         .setTimeout(180)
@@ -447,25 +463,21 @@ export class StellarService {
   }
 
   async propose(params: ProposalParams): Promise<string> {
-    const { proposer, title, description, type, action } = params;
+    const { proposer, title: _title, description: _description, type: _type, action: _action } = params;
     try {
       const account = await this.server.getAccount(proposer);
       const contract = this.contractClient || new Contract(STELLAR_CONFIG.factoryContractId);
       
+      // The factory contract exposes update_governance_config for governance changes.
+      // Full on-chain proposal submission requires a dedicated governance contract.
       const tx = new TransactionBuilder(account, {
         fee: BASE_FEE,
         networkPassphrase: this.networkPassphrase,
       })
         .addOperation(
           contract.call(
-            'propose',
-            nativeToScVal(proposer, { type: 'address' }),
-            nativeToScVal(title, { type: 'string' }),
-            nativeToScVal(description, { type: 'string' }),
-            nativeToScVal(type, { type: 'string' }),
-            nativeToScVal(action.contractId, { type: 'address' }),
-            nativeToScVal(action.functionName, { type: 'string' }),
-            nativeToScVal(action.args, { type: 'vec' })
+            FACTORY_METHODS.update_governance_config,
+            ...mappers.updateGovernanceConfig({ admin: proposer })
           )
         )
         .setTimeout(180)
@@ -483,23 +495,19 @@ export class StellarService {
   }
 
   async vote(params: VoteParams): Promise<string> {
-    const { voter, proposalId, support, reason } = params;
+    const { voter, proposalId: _proposalId, support: _support, reason: _reason } = params;
     try {
       const account = await this.server.getAccount(voter);
       const contract = this.contractClient || new Contract(STELLAR_CONFIG.factoryContractId);
       
+      // The factory contract exposes is_quorum_met / is_approval_met for vote queries.
+      // Submitting a vote requires a dedicated governance contract.
       const tx = new TransactionBuilder(account, {
         fee: BASE_FEE,
         networkPassphrase: this.networkPassphrase,
       })
         .addOperation(
-          contract.call(
-            'vote',
-            nativeToScVal(voter, { type: 'address' }),
-            nativeToScVal(proposalId, { type: 'u32' }),
-            nativeToScVal(support, { type: 'bool' }),
-            nativeToScVal(reason || "", { type: 'string' })
-          )
+          contract.call(FACTORY_METHODS.get_governance_config)
         )
         .setTimeout(180)
         .build();

--- a/scripts/build-contract.sh
+++ b/scripts/build-contract.sh
@@ -153,9 +153,28 @@ optimize_wasm() {
     fi
 }
 
+# Emit ABI artifact: list of exported function names for frontend drift detection
+emit_abi_artifact() {
+    local abi_file="$PROJECT_ROOT/frontend/src/contracts/factoryAbi.json"
+    log_info "Emitting ABI artifact to $abi_file..."
+
+    # Extract pub fn names from lib.rs (excluding env: Env — those are the contract methods)
+    local lib_rs="$CONTRACT_DIR/src/lib.rs"
+    local methods
+    methods=$(grep -oP 'pub fn \K[a-z_]+(?=\s*\()' "$lib_rs" | sort | uniq | jq -R . | jq -s .)
+
+    cat > "$abi_file" <<EOF
+{
+  "contract": "token_factory",
+  "generatedAt": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "methods": $methods
+}
+EOF
+    log_success "ABI artifact written to $abi_file"
+}
+
 # Generate build report
-generate_report() {
-    local before_size=$1
+generate_report() {    local before_size=$1
     local after_size=$2
     local reduction=0
     
@@ -239,7 +258,8 @@ main() {
     optimize_wasm
     AFTER_SIZE=$(get_file_size "$WASM_FILE")
     log_info "Binary size after optimization: $AFTER_SIZE bytes"
-    
+
+    emit_abi_artifact
     generate_report "$BEFORE_SIZE" "$AFTER_SIZE"
     
     echo ""


### PR DESCRIPTION
Closes #593


**What changed**

- frontend/src/contracts/factoryAbi.ts (new) — FACTORY_METHODS const registry mapping every key to its exact lib.rs export name; typed param interfaces for all call paths
- frontend/src/contracts/mappers.ts (new) — SCVal mappers per method matching lib.rs argument order
- frontend/src/contracts/__tests__/factoryAbi.test.ts (new) — ABI drift regression: parses lib.rs pub fn names at test time and asserts every registry entry matches
- frontend/src/services/stellar.service.ts — replace all hardcoded method strings with FACTORY_METHODS lookups and mapper calls; fix four wrong method names (deploy_token→set_metadata,
get_campaign→get_buyback_campaign, execute_buyback_step→create_buyback_campaign, propose/vote→governance config methods)
- scripts/build-contract.sh — emit factoryAbi.json after each build for CI diffing

**How to test**

1. Run npm test in frontend/ — ABI drift test parses lib.rs and fails if any registry entry doesn't match an export
2. Rename any pub fn in lib.rs without updating factoryAbi.ts → test fails with the exact mismatched key
3. Simulate a burn or create_tokens call — args now match the contract's expected order