### PR TITLE
test(integration): add pending transaction recovery coverage

### DIFF
--- a/frontend/src/hooks/useTransactionHistory.ts
+++ b/frontend/src/hooks/useTransactionHistory.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import { useWallet } from './useWallet';
 import type { TokenInfo } from '../types';
 import { transactionHistoryStorage } from '../services/TransactionHistoryStorage';
+import type { PersistedPendingTx } from '../services/TransactionHistoryStorage';
 import {
   fetchTokenHistory,
   convertBackendToken,
@@ -70,6 +71,8 @@ interface UseTransactionHistoryReturn {
   /** Call after a tx is confirmed on-chain to start projection polling */
   watchProjection: (txHash: string, tokenAddress: string) => void;
   projectionStatus: ProjectionStatus;
+  /** Pending txs rehydrated from storage on mount (for resumed monitoring) */
+  rehydratedPendingTxs: PersistedPendingTx[];
 }
 
 const DEFAULT_PAGINATION: PaginationState = {
@@ -126,6 +129,9 @@ export const useTransactionHistory = (): UseTransactionHistoryReturn => {
   const [watchedTxHash, setWatchedTxHash] = useState<string | null>(null);
   const watchedTokenAddressRef = useRef<string | null>(null);
 
+  // Pending txs rehydrated from storage on mount
+  const [rehydratedPendingTxs, setRehydratedPendingTxs] = useState<PersistedPendingTx[]>([]);
+
   // Load local history immediately for optimistic UI
   useEffect(() => {
     if (!address) {
@@ -143,6 +149,16 @@ export const useTransactionHistory = (): UseTransactionHistoryReturn => {
     } finally {
       setLoading(false);
     }
+  }, [address]);
+
+  // Rehydrate persisted pending txs on mount so callers can resume monitoring
+  useEffect(() => {
+    if (!address) {
+      setRehydratedPendingTxs([]);
+      return;
+    }
+    const pending = transactionHistoryStorage.getPendingTxsForWallet(address);
+    setRehydratedPendingTxs(pending);
   }, [address]);
 
   // Fetch from backend on mount and when address/filters/page changes
@@ -297,6 +313,7 @@ export const useTransactionHistory = (): UseTransactionHistoryReturn => {
     search,
     watchProjection,
     projectionStatus,
+    rehydratedPendingTxs,
   };
 };
 

--- a/frontend/src/services/TransactionHistoryStorage.ts
+++ b/frontend/src/services/TransactionHistoryStorage.ts
@@ -1,7 +1,24 @@
 import type { TokenInfo } from "../types";
 
 const STORAGE_KEY = "transaction_history";
+const PENDING_TX_KEY = "pending_transactions";
 const CURRENT_VERSION = "v1";
+
+export type PendingTxType = "deploy" | "burn" | "campaign" | "governance";
+
+/**
+ * Minimal record persisted for an in-flight transaction so monitoring can
+ * be resumed after a page refresh.
+ */
+export interface PersistedPendingTx {
+  txHash: string;
+  type: PendingTxType;
+  walletAddress: string;
+  /** ISO timestamp of when the tx was submitted */
+  submittedAt: string;
+  /** Optional: token/campaign/proposal address associated with the tx */
+  entityAddress?: string;
+}
 
 /**
  * Extended TokenInfo with reconciliation metadata
@@ -333,6 +350,58 @@ export class TransactionHistoryStorage {
   hasWalletData(walletAddress: string): boolean {
     const tokens = this.getTokens(walletAddress);
     return tokens.length > 0;
+  }
+
+  // ── Pending transaction persistence ────────────────────────────────────────
+
+  /**
+   * Persist a pending (in-flight) transaction so it can be resumed after refresh.
+   */
+  savePendingTx(tx: PersistedPendingTx): void {
+    const all = this.loadPendingTxs();
+    // Deduplicate by hash
+    const filtered = all.filter((t) => t.txHash !== tx.txHash);
+    filtered.push(tx);
+    try {
+      localStorage.setItem(PENDING_TX_KEY, JSON.stringify(filtered));
+    } catch {
+      // Non-critical — silently ignore quota errors for pending tx store
+    }
+  }
+
+  /**
+   * Remove a pending transaction (call once it reaches a terminal state).
+   */
+  removePendingTx(txHash: string): void {
+    const all = this.loadPendingTxs();
+    const filtered = all.filter((t) => t.txHash !== txHash);
+    localStorage.setItem(PENDING_TX_KEY, JSON.stringify(filtered));
+  }
+
+  /**
+   * Return all persisted pending transactions.
+   */
+  getPendingTxs(): PersistedPendingTx[] {
+    return this.loadPendingTxs();
+  }
+
+  /**
+   * Return pending transactions for a specific wallet.
+   */
+  getPendingTxsForWallet(walletAddress: string): PersistedPendingTx[] {
+    return this.loadPendingTxs().filter(
+      (t) => t.walletAddress === walletAddress,
+    );
+  }
+
+  private loadPendingTxs(): PersistedPendingTx[] {
+    try {
+      const raw = localStorage.getItem(PENDING_TX_KEY);
+      if (!raw) return [];
+      return JSON.parse(raw) as PersistedPendingTx[];
+    } catch {
+      return [];
+    }
   }
 }
 

--- a/frontend/src/services/transactionMonitor.ts
+++ b/frontend/src/services/transactionMonitor.ts
@@ -158,6 +158,25 @@ export class TransactionMonitor {
     }
 
     /**
+     * Resume monitoring a transaction that was persisted before a page refresh.
+     * Unlike startMonitoring, this is a no-op if the hash is already being tracked,
+     * making it safe to call on every app boot for all persisted pending txs.
+     */
+    resumeMonitoring(
+        transactionHash: string,
+        onStatus?: StatusCallback,
+        onError?: ErrorCallback
+    ): void {
+        if (this.sessions.has(transactionHash)) {
+            // Already active — just attach new callbacks if provided
+            if (onStatus) this.onStatus(transactionHash, onStatus);
+            if (onError) this.onError(transactionHash, onError);
+            return;
+        }
+        this.startMonitoring(transactionHash, onStatus, onError);
+    }
+
+    /**
      * Poll transaction status
      */
     private async poll(transactionHash: string): Promise<void> {

--- a/frontend/src/test/integration/pending-transaction-recovery.integration.test.tsx
+++ b/frontend/src/test/integration/pending-transaction-recovery.integration.test.tsx
@@ -1,0 +1,285 @@
+/**
+ * Pending Transaction Recovery — Integration Tests
+ *
+ * Verifies that the app correctly recovers in-flight transactions after a
+ * page refresh or app reopen. Covers deploy, burn, campaign, and governance
+ * transaction types.
+ *
+ * Scenarios:
+ *   1. Refresh during pending deploy → monitoring resumes, status tracked
+ *   2. Confirmed tx after refresh → final UI state updated correctly
+ *   3. Stale / timed-out tx → labelled as timeout, not re-monitored
+ */
+
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  transactionHistoryStorage,
+  TransactionHistoryStorage,
+} from '../../services/TransactionHistoryStorage';
+import type { PersistedPendingTx } from '../../services/TransactionHistoryStorage';
+import { TransactionMonitor } from '../../services/transactionMonitor';
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const WALLET = 'GRECOVERY_WALLET_ADDRESS_ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+const DEPLOY_HASH = 'deploy_hash_' + 'a'.repeat(52);
+const BURN_HASH = 'burn_hash_' + 'b'.repeat(54);
+const CAMPAIGN_HASH = 'campaign_hash_' + 'c'.repeat(50);
+const GOVERNANCE_HASH = 'governance_hash_' + 'd'.repeat(48);
+const TOKEN_ADDRESS = 'CTOKEN_RECOVERY_ADDRESS_ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makePendingTx(
+  overrides: Partial<PersistedPendingTx> = {},
+): PersistedPendingTx {
+  return {
+    txHash: DEPLOY_HASH,
+    type: 'deploy',
+    walletAddress: WALLET,
+    submittedAt: new Date().toISOString(),
+    entityAddress: TOKEN_ADDRESS,
+    ...overrides,
+  };
+}
+
+/** Simulate a page refresh by clearing in-memory state while keeping localStorage */
+function simulatePageRefresh(): TransactionHistoryStorage {
+  // Return a fresh instance (same localStorage, new in-memory state)
+  return TransactionHistoryStorage.createInstance();
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('Pending Transaction Recovery', () => {
+  beforeEach(() => {
+    transactionHistoryStorage.clearAll();
+    localStorage.removeItem('pending_transactions');
+    vi.clearAllMocks();
+  });
+
+  // ── 1. Refresh during pending deploy resumes status tracking ──────────────
+
+  describe('resuming monitoring after refresh', () => {
+    it('persists a pending deploy tx to storage', () => {
+      const tx = makePendingTx({ txHash: DEPLOY_HASH, type: 'deploy' });
+      transactionHistoryStorage.savePendingTx(tx);
+
+      const stored = transactionHistoryStorage.getPendingTxsForWallet(WALLET);
+      expect(stored).toHaveLength(1);
+      expect(stored[0].txHash).toBe(DEPLOY_HASH);
+      expect(stored[0].type).toBe('deploy');
+    });
+
+    it('persists burn, campaign, and governance pending txs', () => {
+      transactionHistoryStorage.savePendingTx(
+        makePendingTx({ txHash: BURN_HASH, type: 'burn' }),
+      );
+      transactionHistoryStorage.savePendingTx(
+        makePendingTx({ txHash: CAMPAIGN_HASH, type: 'campaign' }),
+      );
+      transactionHistoryStorage.savePendingTx(
+        makePendingTx({ txHash: GOVERNANCE_HASH, type: 'governance' }),
+      );
+
+      const stored = transactionHistoryStorage.getPendingTxsForWallet(WALLET);
+      expect(stored).toHaveLength(3);
+      expect(stored.map((t) => t.type)).toEqual(
+        expect.arrayContaining(['burn', 'campaign', 'governance']),
+      );
+    });
+
+    it('survives a simulated page refresh — pending txs still readable', () => {
+      transactionHistoryStorage.savePendingTx(
+        makePendingTx({ txHash: DEPLOY_HASH }),
+      );
+
+      // Simulate refresh: new storage instance reads from same localStorage
+      const freshStorage = simulatePageRefresh();
+      const recovered = freshStorage.getPendingTxsForWallet(WALLET);
+
+      expect(recovered).toHaveLength(1);
+      expect(recovered[0].txHash).toBe(DEPLOY_HASH);
+    });
+
+    it('resumes monitoring via TransactionMonitor.resumeMonitoring', async () => {
+      const monitor = new TransactionMonitor({ pollingInterval: 50, maxRetries: 5, timeout: 5000, backoffMultiplier: 1 });
+
+      // Persist the pending tx (as would happen before the "refresh")
+      transactionHistoryStorage.savePendingTx(makePendingTx({ txHash: DEPLOY_HASH }));
+
+      // Mock RPC to return pending then success
+      let rpcCalls = 0;
+      globalThis.fetch = vi.fn().mockImplementation(async () => {
+        rpcCalls++;
+        const status = rpcCalls >= 2 ? 'SUCCESS' : 'NOT_FOUND';
+        return {
+          ok: true,
+          json: async () => ({ result: { status } }),
+        };
+      }) as any;
+
+      const statusUpdates: string[] = [];
+      // After "refresh", resume monitoring using the persisted hash
+      monitor.resumeMonitoring(DEPLOY_HASH, (update) => {
+        statusUpdates.push(update.status);
+      });
+
+      // Wait for polling to complete
+      await waitFor(
+        () => expect(statusUpdates).toContain('success'),
+        { timeout: 3000 },
+      );
+
+      monitor.destroy();
+    });
+
+    it('resumeMonitoring is idempotent — no error if already monitoring', () => {
+      const monitor = new TransactionMonitor();
+
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ result: { status: 'NOT_FOUND' } }),
+      }) as any;
+
+      monitor.startMonitoring(DEPLOY_HASH);
+      // Should not throw
+      expect(() => monitor.resumeMonitoring(DEPLOY_HASH)).not.toThrow();
+
+      monitor.destroy();
+    });
+  });
+
+  // ── 2. Confirmed tx after refresh updates final UI state ──────────────────
+
+  describe('confirmed tx after refresh', () => {
+    it('removes pending tx from storage once terminal status is reached', async () => {
+      transactionHistoryStorage.savePendingTx(makePendingTx({ txHash: DEPLOY_HASH }));
+
+      // Confirm it's there
+      expect(transactionHistoryStorage.getPendingTxsForWallet(WALLET)).toHaveLength(1);
+
+      // Simulate confirmation: remove from pending store
+      transactionHistoryStorage.removePendingTx(DEPLOY_HASH);
+
+      expect(transactionHistoryStorage.getPendingTxsForWallet(WALLET)).toHaveLength(0);
+    });
+
+    it('does not re-surface a removed pending tx after another refresh', () => {
+      transactionHistoryStorage.savePendingTx(makePendingTx({ txHash: DEPLOY_HASH }));
+      transactionHistoryStorage.removePendingTx(DEPLOY_HASH);
+
+      const freshStorage = simulatePageRefresh();
+      const recovered = freshStorage.getPendingTxsForWallet(WALLET);
+      expect(recovered).toHaveLength(0);
+    });
+
+    it('monitor emits success and caller can then remove pending tx', async () => {
+      const monitor = new TransactionMonitor({ pollingInterval: 50, maxRetries: 5, timeout: 5000, backoffMultiplier: 1 });
+
+      transactionHistoryStorage.savePendingTx(makePendingTx({ txHash: DEPLOY_HASH }));
+
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ result: { status: 'SUCCESS' } }),
+      }) as any;
+
+      await new Promise<void>((resolve) => {
+        monitor.resumeMonitoring(DEPLOY_HASH, (update) => {
+          if (update.status === 'success') {
+            transactionHistoryStorage.removePendingTx(DEPLOY_HASH);
+            resolve();
+          }
+        });
+      });
+
+      expect(transactionHistoryStorage.getPendingTxsForWallet(WALLET)).toHaveLength(0);
+      monitor.destroy();
+    });
+  });
+
+  // ── 3. Stale / timed-out transactions ─────────────────────────────────────
+
+  describe('stale timed-out transactions', () => {
+    it('labels a tx as timeout when max retries are exceeded', async () => {
+      const monitor = new TransactionMonitor({
+        pollingInterval: 10,
+        maxRetries: 2,
+        timeout: 60000,
+        backoffMultiplier: 1,
+      });
+
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ result: { status: 'NOT_FOUND' } }),
+      }) as any;
+
+      const statusUpdates: string[] = [];
+      monitor.resumeMonitoring(DEPLOY_HASH, (update) => {
+        statusUpdates.push(update.status);
+      });
+
+      await waitFor(
+        () => expect(statusUpdates).toContain('timeout'),
+        { timeout: 3000 },
+      );
+
+      monitor.destroy();
+    });
+
+    it('labels a tx as timeout when the elapsed time exceeds the timeout window', async () => {
+      const monitor = new TransactionMonitor({
+        pollingInterval: 10,
+        maxRetries: 100,
+        timeout: 1, // 1 ms — immediately stale
+        backoffMultiplier: 1,
+      });
+
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ result: { status: 'NOT_FOUND' } }),
+      }) as any;
+
+      const statusUpdates: string[] = [];
+      monitor.resumeMonitoring(DEPLOY_HASH, (update) => {
+        statusUpdates.push(update.status);
+      });
+
+      await waitFor(
+        () => expect(statusUpdates).toContain('timeout'),
+        { timeout: 3000 },
+      );
+
+      monitor.destroy();
+    });
+
+    it('stale tx from a previous session is not re-monitored if already removed', () => {
+      // Tx was submitted, then confirmed before refresh — not in pending store
+      const freshStorage = simulatePageRefresh();
+      const recovered = freshStorage.getPendingTxsForWallet(WALLET);
+      expect(recovered).toHaveLength(0);
+    });
+
+    it('deduplicates pending txs — saving the same hash twice keeps one entry', () => {
+      const tx = makePendingTx({ txHash: DEPLOY_HASH });
+      transactionHistoryStorage.savePendingTx(tx);
+      transactionHistoryStorage.savePendingTx(tx); // duplicate
+
+      const stored = transactionHistoryStorage.getPendingTxsForWallet(WALLET);
+      expect(stored).toHaveLength(1);
+    });
+
+    it('getPendingTxs returns all wallets; getPendingTxsForWallet scopes correctly', () => {
+      const otherWallet = 'GOTHER_WALLET_ABCDEFGHIJKLMNOPQRSTUVWXYZ_PADDING';
+      transactionHistoryStorage.savePendingTx(makePendingTx({ txHash: DEPLOY_HASH, walletAddress: WALLET }));
+      transactionHistoryStorage.savePendingTx(
+        makePendingTx({ txHash: BURN_HASH, type: 'burn', walletAddress: otherWallet }),
+      );
+
+      expect(transactionHistoryStorage.getPendingTxs()).toHaveLength(2);
+      expect(transactionHistoryStorage.getPendingTxsForWallet(WALLET)).toHaveLength(1);
+      expect(transactionHistoryStorage.getPendingTxsForWallet(otherWallet)).toHaveLength(1);
+    });
+  });
+});


### PR DESCRIPTION
This pr Adds recovery support for in-flight transactions that are interrupted by a page refresh or app reopen. Without this, users lose visibility into pending deploy, burn, campaign, and governance transactions.

closes #658 