### PR TITLE
feat(webhooks): implement HMAC signatures and replay protection

### DIFF
--- a/backend/examples/webhook-receiver.js
+++ b/backend/examples/webhook-receiver.js
@@ -15,14 +15,43 @@ app.use(express.json());
 const WEBHOOK_SECRET = process.env.WEBHOOK_SECRET || 'your-secret-here';
 
 /**
- * Verify webhook signature
+ * Verify webhook signature with replay protection (v1)
+ * 
+ * Signature format: v1.<timestamp>.<signature>
+ * Signed content: <timestamp>.<raw_body_string>
  */
-function verifySignature(payload, signature, secret) {
+function verifyWebhookSignature(payload, header, secret, toleranceSeconds = 300) {
+  if (!header || !header.startsWith('v1.')) {
+    return false;
+  }
+
+  const parts = header.split('.');
+  if (parts.length !== 3) {
+    return false;
+  }
+
+  const timestamp = parseInt(parts[1], 10);
+  const signature = parts[2];
+
+  if (isNaN(timestamp)) {
+    return false;
+  }
+
+  // 1. Prevent replay attacks by checking if the timestamp is too old
+  const now = Math.floor(Date.now() / 1000);
+  if (Math.abs(now - timestamp) > toleranceSeconds) {
+    console.error(`Replay attack detected or clock drift: diff=${Math.abs(now - timestamp)}s`);
+    return false;
+  }
+
+  // 2. Generate expected signature
+  const message = `${timestamp}.${payload}`;
   const expectedSignature = crypto
     .createHmac('sha256', secret)
-    .update(payload)
+    .update(message)
     .digest('hex');
   
+  // 3. Constant-time comparison to prevent timing attacks
   return crypto.timingSafeEqual(
     Buffer.from(signature),
     Buffer.from(expectedSignature)
@@ -34,18 +63,19 @@ function verifySignature(payload, signature, secret) {
  */
 app.post('/webhook', (req, res) => {
   try {
-    const signature = req.headers['x-webhook-signature'];
+    const signatureHeader = req.headers['x-webhook-signature'];
     const eventType = req.headers['x-webhook-event'];
     
-    if (!signature) {
-      return res.status(401).json({ error: 'Missing signature' });
+    if (!signatureHeader) {
+      return res.status(401).json({ error: 'Missing signature header' });
     }
     
     // Verify signature
+    // Note: Use raw body for verification if your parser modifies req.body
     const payload = JSON.stringify(req.body);
-    if (!verifySignature(payload, signature, WEBHOOK_SECRET)) {
-      console.error('Invalid signature');
-      return res.status(401).json({ error: 'Invalid signature' });
+    if (!verifyWebhookSignature(payload, signatureHeader, WEBHOOK_SECRET)) {
+      console.error('Invalid signature or replay detected');
+      return res.status(401).json({ error: 'Authentication failed' });
     }
     
     // Process event

--- a/backend/src/__tests__/webhook-signing.integration.test.ts
+++ b/backend/src/__tests__/webhook-signing.integration.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import { 
+  generateWebhookSignature, 
+  verifyWebhookSignature, 
+  generateWebhookSecret 
+} from "../utils/crypto";
+import webhookService from "../services/webhookService";
+import { WebhookEventType } from "../types/webhook";
+
+describe("Webhook Signing and Verification (v1)", () => {
+  const secret = generateWebhookSecret();
+  const payload = JSON.stringify({
+    event: "token.created",
+    timestamp: new Date().toISOString(),
+    data: { id: "123" }
+  });
+
+  it("should generate a valid v1 signature", () => {
+    const signature = generateWebhookSignature(payload, secret);
+    expect(signature).toMatch(/^v1\.\d+\.[a-f0-9]{64}$/);
+  });
+
+  it("should verify a valid signature", () => {
+    const signature = generateWebhookSignature(payload, secret);
+    const isValid = verifyWebhookSignature(payload, signature, secret);
+    expect(isValid).toBe(true);
+  });
+
+  it("should fail verification with wrong secret", () => {
+    const signature = generateWebhookSignature(payload, secret);
+    const isValid = verifyWebhookSignature(payload, signature, "wrong-secret");
+    expect(isValid).toBe(false);
+  });
+
+  it("should fail verification with tampered payload", () => {
+    const signature = generateWebhookSignature(payload, secret);
+    const tamperedPayload = payload.replace("123", "456");
+    const isValid = verifyWebhookSignature(tamperedPayload, signature, secret);
+    expect(isValid).toBe(false);
+  });
+
+  it("should fail verification if signature is too old (replay protection)", () => {
+    // 10 minutes ago
+    const oldTimestamp = Math.floor(Date.now() / 1000) - 600;
+    const signature = generateWebhookSignature(payload, secret, oldTimestamp);
+    
+    // Default tolerance is 300s (5 min)
+    const isValid = verifyWebhookSignature(payload, signature, secret);
+    expect(isValid).toBe(false);
+  });
+
+  it("should pass verification within the tolerance window", () => {
+    // 2 minutes ago
+    const recentTimestamp = Math.floor(Date.now() / 1000) - 120;
+    const signature = generateWebhookSignature(payload, secret, recentTimestamp);
+    
+    const isValid = verifyWebhookSignature(payload, signature, secret);
+    expect(isValid).toBe(true);
+  });
+
+  it("should work through WebhookService.createPayload", () => {
+    const event = WebhookEventType.TOKEN_CREATED;
+    const data = { 
+      tokenAddress: "G123", 
+      creator: "G456", 
+      name: "T", 
+      symbol: "T", 
+      decimals: 7, 
+      initialSupply: "1", 
+      transactionHash: "h", 
+      ledger: 1 
+    };
+    
+    const payloadObj = webhookService.createPayload(event, data, secret);
+    
+    expect(payloadObj.signature).toBeDefined();
+    expect(payloadObj.signature).toMatch(/^v1\.\d+\.[a-f0-9]{64}$/);
+    
+    // Verify using the signature from the payload object
+    const payloadStr = JSON.stringify({
+      event: payloadObj.event,
+      timestamp: payloadObj.timestamp,
+      data: payloadObj.data
+    });
+    
+    const isValid = verifyWebhookSignature(payloadStr, payloadObj.signature, secret);
+    expect(isValid).toBe(true);
+  });
+});

--- a/backend/src/routes/webhooks.ts
+++ b/backend/src/routes/webhooks.ts
@@ -22,16 +22,12 @@ router.post(
     try {
       const subscription = await webhookService.createSubscription(req.body);
 
-      // Return subscription without exposing the secret
-      const { secret, ...publicData } = subscription;
-
+      // Return subscription with full secret ONLY on creation
+      // Users must store this secret securely as it won't be shown again
       res.status(201).json({
         success: true,
-        data: {
-          ...publicData,
-          secret: `${secret.substring(0, 8)}...`, // Show only first 8 chars
-        },
-        message: "Webhook subscription created successfully",
+        data: subscription,
+        message: "Webhook subscription created successfully. Please store your secret securely; it will not be shown again.",
       });
     } catch (error) {
       console.error("Error creating subscription:", error);

--- a/backend/src/services/webhookService.ts
+++ b/backend/src/services/webhookService.ts
@@ -8,7 +8,7 @@ import {
   WebhookEventData,
   WebhookDeliveryLog,
 } from "../types/webhook";
-import { generateWebhookSecret, generateSignature } from "../utils/crypto";
+import { generateWebhookSecret, generateWebhookSignature } from "../utils/crypto";
 
 export class WebhookService {
   /**
@@ -192,14 +192,15 @@ export class WebhookService {
     data: WebhookEventData,
     secret: string
   ): WebhookPayload {
+    const timestamp = new Date().toISOString();
     const payload: Omit<WebhookPayload, "signature"> = {
       event,
-      timestamp: new Date().toISOString(),
+      timestamp,
       data,
     };
 
     const payloadString = JSON.stringify(payload);
-    const signature = generateSignature(payloadString, secret);
+    const signature = generateWebhookSignature(payloadString, secret);
 
     return {
       ...payload,

--- a/backend/src/utils/crypto.ts
+++ b/backend/src/utils/crypto.ts
@@ -8,21 +8,58 @@ export function generateWebhookSecret(length: number = 32): string {
 }
 
 /**
- * Generate HMAC signature for webhook payload
+ * Generate HMAC signature for webhook payload with timestamp (v1)
+ * Format: v1.<timestamp>.<signature>
+ * Message signed: <timestamp>.<payload_string>
  */
-export function generateSignature(payload: string, secret: string): string {
-  return crypto.createHmac("sha256", secret).update(payload).digest("hex");
+export function generateWebhookSignature(
+  payload: string,
+  secret: string,
+  timestamp: number = Math.floor(Date.now() / 1000)
+): string {
+  const message = `${timestamp}.${payload}`;
+  const signature = crypto
+    .createHmac("sha256", secret)
+    .update(message)
+    .digest("hex");
+  return `v1.${timestamp}.${signature}`;
 }
 
 /**
- * Verify webhook signature
+ * Verify advanced webhook signature with replay protection (5 min window)
  */
-export function verifySignature(
+export function verifyWebhookSignature(
   payload: string,
-  signature: string,
-  secret: string
+  header: string,
+  secret: string,
+  toleranceSeconds: number = 300 // 5 minutes
 ): boolean {
-  const expectedSignature = generateSignature(payload, secret);
+  if (!header || !header.startsWith("v1.")) {
+    return false;
+  }
+
+  const parts = header.split(".");
+  if (parts.length !== 3) {
+    return false;
+  }
+
+  const timestamp = parseInt(parts[1], 10);
+  const signature = parts[2];
+
+  if (isNaN(timestamp)) {
+    return false;
+  }
+
+  // Check for replay attacks
+  const now = Math.floor(Date.now() / 1000);
+  if (Math.abs(now - timestamp) > toleranceSeconds) {
+    return false;
+  }
+
+  // Verify signature
+  const expectedHeader = generateWebhookSignature(payload, secret, timestamp);
+  const expectedSignature = expectedHeader.split(".")[2];
+
   return crypto.timingSafeEqual(
     Buffer.from(signature),
     Buffer.from(expectedSignature)


### PR DESCRIPTION
- Add generateWebhookSignature and verifyWebhookSignature to crypto utils
- Update WebhookService to use timestamp-based v1 signatures
- Implement replay protection with 5-minute tolerance window
- Update example webhook receiver with secure verification logic
- Add technical documentation for webhook signatures
- Expose full secret only during initial subscription creation
- Add integration test for signing and verification

Closes #620 