### PR TITLE
feat(backend): develop GraphQL API layer for flexible data querying

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -35,6 +35,7 @@
     "jsonwebtoken": "^9.0.2",
     "pg": "^8.18.0",
     "uuid": "^13.0.0",
+    "ws": "^8.20.0",
     "zod": "^3.22.4"
   },
   "devDependencies": {
@@ -47,6 +48,7 @@
     "@types/pg": "^8.16.0",
     "@types/supertest": "^6.0.3",
     "@types/uuid": "^10.0.0",
+    "@types/ws": "^8.18.1",
     "@vitest/coverage-v8": "^1.6.1",
     "fast-check": "^3.22.0",
     "nock": "^13.5.6",

--- a/backend/package.json
+++ b/backend/package.json
@@ -31,6 +31,8 @@
     "express": "^4.18.2",
     "express-rate-limit": "^7.1.5",
     "express-validator": "^7.3.1",
+    "graphql": "^16.13.2",
+    "graphql-http": "^1.22.4",
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
     "pg": "^8.18.0",

--- a/backend/src/graphql/index.ts
+++ b/backend/src/graphql/index.ts
@@ -1,0 +1,79 @@
+/**
+ * Mounts the GraphQL endpoint on an Express router.
+ *
+ * Endpoint: POST /api/graphql
+ *
+ * Uses `graphql-http` (spec-compliant, no Apollo overhead).
+ * Introspection is disabled in production to reduce attack surface.
+ *
+ * Security:
+ *  - Depth limit: rejects queries nested deeper than MAX_DEPTH (6)
+ *  - No mutations exposed — all writes go through the existing REST layer
+ *  - Rate limiting is inherited from the global Express rate limiter in index.ts
+ */
+
+import { Router } from "express";
+import { createHandler } from "graphql-http/lib/use/express";
+import { buildSchema, GraphQLError, parse, validate } from "graphql";
+import { typeDefs } from "./schema";
+import { resolvers } from "./resolvers";
+
+const MAX_DEPTH = 6;
+
+function maxQueryDepth(node: any, depth = 0): number {
+  if (!node || typeof node !== "object") return depth;
+  if (node.selectionSet?.selections) {
+    return Math.max(
+      ...node.selectionSet.selections.map((s: any) => maxQueryDepth(s, depth + 1))
+    );
+  }
+  return depth;
+}
+
+export const schema = buildSchema(typeDefs);
+
+/** Flat rootValue merging all resolver namespaces for graphql-http. */
+const rootValue = {
+  ...resolvers.Query,
+  // Field resolvers for nested types are handled inside the Query resolvers
+  // by fetching relations lazily (see resolvers.ts Token.burnRecords etc.)
+};
+
+const router = Router();
+
+router.all(
+  "/",
+  createHandler({
+    schema,
+    rootValue,
+    onSubscribe(_req, params) {
+      // Disable introspection in production
+      if (
+        process.env.NODE_ENV === "production" &&
+        typeof params.query === "string" &&
+        params.query.includes("__schema")
+      ) {
+        return [new GraphQLError("Introspection is disabled in production")];
+      }
+
+      if (typeof params.query === "string") {
+        try {
+          const doc = parse(params.query);
+          const errors = validate(schema, doc);
+          if (errors.length) return errors;
+
+          const depth = Math.max(...doc.definitions.map((def: any) => maxQueryDepth(def)));
+          if (depth > MAX_DEPTH) {
+            return [new GraphQLError(`Query depth ${depth} exceeds maximum allowed depth of ${MAX_DEPTH}`)];
+          }
+        } catch {
+          return [new GraphQLError("Failed to parse query")];
+        }
+      }
+
+      return undefined;
+    },
+  })
+);
+
+export default router;

--- a/backend/src/graphql/resolvers.test.ts
+++ b/backend/src/graphql/resolvers.test.ts
@@ -1,0 +1,431 @@
+/**
+ * Tests for the GraphQL resolvers and schema.
+ *
+ * Strategy:
+ *  - Resolver functions are tested directly (unit) — fast, no graphql overhead.
+ *  - Schema-level tests use graphql() with buildSchema + rootValue to verify
+ *    the SDL compiles and queries route correctly.
+ *  - Prisma is mocked throughout.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { buildSchema, graphql } from "graphql";
+import { typeDefs } from "../graphql/schema";
+import { resolvers } from "../graphql/resolvers";
+
+// ---------------------------------------------------------------------------
+// Mock Prisma
+// ---------------------------------------------------------------------------
+
+vi.mock("../lib/prisma", () => ({
+  prisma: {
+    token: { findUnique: vi.fn(), findMany: vi.fn() },
+    burnRecord: { findMany: vi.fn() },
+    stream: { findUnique: vi.fn(), findMany: vi.fn() },
+    proposal: { findUnique: vi.fn(), findMany: vi.fn() },
+    vote: { findMany: vi.fn() },
+    campaign: { findUnique: vi.fn(), findMany: vi.fn() },
+  },
+}));
+
+async function getPrisma() {
+  return (await import("../lib/prisma")).prisma;
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const makeToken = (o: Record<string, unknown> = {}) => ({
+  id: "tok-1", address: "CTOKEN123", creator: "GCREATOR",
+  name: "Test Token", symbol: "TST", decimals: 7,
+  totalSupply: BigInt("1000000000"), initialSupply: BigInt("1000000000"),
+  totalBurned: BigInt("0"), burnCount: 0, metadataUri: null,
+  createdAt: new Date("2026-01-01"), updatedAt: new Date("2026-01-01"), ...o,
+});
+
+const makeStream = (o: Record<string, unknown> = {}) => ({
+  id: "str-1", streamId: 1, creator: "GCREATOR", recipient: "GRECIPIENT",
+  amount: BigInt("500000"), metadata: null, status: "CREATED", txHash: "hash1",
+  createdAt: new Date("2026-01-01"), claimedAt: null, cancelledAt: null, ...o,
+});
+
+const makeProposal = (o: Record<string, unknown> = {}) => ({
+  id: "prop-1", proposalId: 1, tokenId: "tok-1", proposer: "GPROPOSER",
+  title: "Test Proposal", description: "A test", proposalType: "CUSTOM",
+  status: "ACTIVE", startTime: new Date("2026-01-01"), endTime: new Date("2026-02-01"),
+  quorum: BigInt("100"), threshold: BigInt("51"), metadata: null, txHash: "hash2",
+  createdAt: new Date("2026-01-01"), updatedAt: new Date("2026-01-01"), executedAt: null, ...o,
+});
+
+const makeCampaign = (o: Record<string, unknown> = {}) => ({
+  id: "camp-1", campaignId: 1, tokenId: "tok-1", creator: "GCREATOR",
+  type: "BUYBACK", status: "ACTIVE", targetAmount: BigInt("1000000"),
+  currentAmount: BigInt("0"), executionCount: 0, startTime: new Date("2026-01-01"),
+  endTime: null, metadata: null, txHash: "hash3",
+  createdAt: new Date("2026-01-01"), updatedAt: new Date("2026-01-01"),
+  completedAt: null, cancelledAt: null, ...o,
+});
+
+// ---------------------------------------------------------------------------
+// Query.token
+// ---------------------------------------------------------------------------
+
+describe("Query.token", () => {
+  it("returns a token when found", async () => {
+    const p = await getPrisma();
+    vi.mocked(p.token.findUnique).mockResolvedValue(makeToken() as any);
+
+    const result = await resolvers.Query.token(undefined, { address: "CTOKEN123" });
+
+    expect(result).toMatchObject({ address: "CTOKEN123", name: "Test Token", totalSupply: "1000000000" });
+  });
+
+  it("returns null when token not found", async () => {
+    const p = await getPrisma();
+    vi.mocked(p.token.findUnique).mockResolvedValue(null);
+
+    const result = await resolvers.Query.token(undefined, { address: "UNKNOWN" });
+    expect(result).toBeNull();
+  });
+
+  it("serialises BigInt fields as strings", async () => {
+    const p = await getPrisma();
+    vi.mocked(p.token.findUnique).mockResolvedValue(
+      makeToken({ totalSupply: BigInt("9007199254740993") }) as any
+    );
+
+    const result = await resolvers.Query.token(undefined, { address: "CTOKEN123" }) as any;
+    expect(result.totalSupply).toBe("9007199254740993");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Query.tokens
+// ---------------------------------------------------------------------------
+
+describe("Query.tokens", () => {
+  it("returns a list of tokens", async () => {
+    const p = await getPrisma();
+    vi.mocked(p.token.findMany).mockResolvedValue([makeToken()] as any);
+
+    const result = await resolvers.Query.tokens(undefined, {});
+    expect(result).toHaveLength(1);
+  });
+
+  it("passes creator filter to Prisma", async () => {
+    const p = await getPrisma();
+    vi.mocked(p.token.findMany).mockResolvedValue([]);
+
+    await resolvers.Query.tokens(undefined, { creator: "GCREATOR" });
+
+    expect(p.token.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { creator: "GCREATOR" } })
+    );
+  });
+
+  it("caps limit at 100", async () => {
+    const p = await getPrisma();
+    vi.mocked(p.token.findMany).mockResolvedValue([]);
+
+    await resolvers.Query.tokens(undefined, { limit: 999 });
+
+    expect(p.token.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ take: 100 })
+    );
+  });
+
+  it("applies offset", async () => {
+    const p = await getPrisma();
+    vi.mocked(p.token.findMany).mockResolvedValue([]);
+
+    await resolvers.Query.tokens(undefined, { offset: 10 });
+
+    expect(p.token.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ skip: 10 })
+    );
+  });
+
+  it("uses default limit of 20 when not specified", async () => {
+    const p = await getPrisma();
+    vi.mocked(p.token.findMany).mockResolvedValue([]);
+
+    await resolvers.Query.tokens(undefined, {});
+
+    expect(p.token.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ take: 20 })
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Query.stream / streams
+// ---------------------------------------------------------------------------
+
+describe("Query.stream", () => {
+  it("returns a stream when found", async () => {
+    const p = await getPrisma();
+    vi.mocked(p.stream.findUnique).mockResolvedValue(makeStream() as any);
+
+    const result = await resolvers.Query.stream(undefined, { streamId: 1 }) as any;
+    expect(result).toMatchObject({ streamId: 1, status: "CREATED", amount: "500000" });
+  });
+
+  it("returns null when stream not found", async () => {
+    const p = await getPrisma();
+    vi.mocked(p.stream.findUnique).mockResolvedValue(null);
+
+    const result = await resolvers.Query.stream(undefined, { streamId: 999 });
+    expect(result).toBeNull();
+  });
+});
+
+describe("Query.streams", () => {
+  it("returns a list of streams", async () => {
+    const p = await getPrisma();
+    vi.mocked(p.stream.findMany).mockResolvedValue([makeStream()] as any);
+
+    const result = await resolvers.Query.streams(undefined, {});
+    expect(result).toHaveLength(1);
+  });
+
+  it("passes status filter to Prisma", async () => {
+    const p = await getPrisma();
+    vi.mocked(p.stream.findMany).mockResolvedValue([]);
+
+    await resolvers.Query.streams(undefined, { status: "CLAIMED" });
+
+    expect(p.stream.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ status: "CLAIMED" }) })
+    );
+  });
+
+  it("passes creator and recipient filters", async () => {
+    const p = await getPrisma();
+    vi.mocked(p.stream.findMany).mockResolvedValue([]);
+
+    await resolvers.Query.streams(undefined, { creator: "GCREATOR", recipient: "GRECIPIENT" });
+
+    expect(p.stream.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ creator: "GCREATOR", recipient: "GRECIPIENT" }),
+      })
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Query.proposal / proposals
+// ---------------------------------------------------------------------------
+
+describe("Query.proposal", () => {
+  it("returns a proposal when found", async () => {
+    const p = await getPrisma();
+    vi.mocked(p.proposal.findUnique).mockResolvedValue(makeProposal() as any);
+
+    const result = await resolvers.Query.proposal(undefined, { proposalId: 1 }) as any;
+    expect(result).toMatchObject({ proposalId: 1, title: "Test Proposal", quorum: "100" });
+  });
+
+  it("returns null when proposal not found", async () => {
+    const p = await getPrisma();
+    vi.mocked(p.proposal.findUnique).mockResolvedValue(null);
+
+    const result = await resolvers.Query.proposal(undefined, { proposalId: 999 });
+    expect(result).toBeNull();
+  });
+});
+
+describe("Query.proposals", () => {
+  it("returns a list of proposals", async () => {
+    const p = await getPrisma();
+    vi.mocked(p.proposal.findMany).mockResolvedValue([makeProposal()] as any);
+
+    const result = await resolvers.Query.proposals(undefined, {});
+    expect(result).toHaveLength(1);
+  });
+
+  it("passes status and proposalType filters", async () => {
+    const p = await getPrisma();
+    vi.mocked(p.proposal.findMany).mockResolvedValue([]);
+
+    await resolvers.Query.proposals(undefined, { status: "ACTIVE", proposalType: "CUSTOM" });
+
+    expect(p.proposal.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ status: "ACTIVE", proposalType: "CUSTOM" }),
+      })
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Query.campaign / campaigns
+// ---------------------------------------------------------------------------
+
+describe("Query.campaign", () => {
+  it("returns a campaign when found", async () => {
+    const p = await getPrisma();
+    vi.mocked(p.campaign.findUnique).mockResolvedValue(makeCampaign() as any);
+
+    const result = await resolvers.Query.campaign(undefined, { campaignId: 1 }) as any;
+    expect(result).toMatchObject({ campaignId: 1, type: "BUYBACK", targetAmount: "1000000" });
+  });
+
+  it("returns null when campaign not found", async () => {
+    const p = await getPrisma();
+    vi.mocked(p.campaign.findUnique).mockResolvedValue(null);
+
+    const result = await resolvers.Query.campaign(undefined, { campaignId: 999 });
+    expect(result).toBeNull();
+  });
+});
+
+describe("Query.campaigns", () => {
+  it("returns a list of campaigns", async () => {
+    const p = await getPrisma();
+    vi.mocked(p.campaign.findMany).mockResolvedValue([makeCampaign()] as any);
+
+    const result = await resolvers.Query.campaigns(undefined, {});
+    expect(result).toHaveLength(1);
+  });
+
+  it("passes type and status filters", async () => {
+    const p = await getPrisma();
+    vi.mocked(p.campaign.findMany).mockResolvedValue([]);
+
+    await resolvers.Query.campaigns(undefined, { type: "AIRDROP", status: "COMPLETED" });
+
+    expect(p.campaign.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ type: "AIRDROP", status: "COMPLETED" }),
+      })
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Field resolvers
+// ---------------------------------------------------------------------------
+
+describe("Token.burnRecords", () => {
+  it("fetches burn records for a token", async () => {
+    const p = await getPrisma();
+    const burnRow = {
+      id: "br-1", tokenId: "tok-1", from: "GFROM", amount: BigInt("100"),
+      burnedBy: "GFROM", isAdminBurn: false, txHash: "bh1", timestamp: new Date(),
+    };
+    vi.mocked(p.burnRecord.findMany).mockResolvedValue([burnRow] as any);
+
+    const result = await resolvers.Token.burnRecords({ id: "tok-1" }, {}) as any[];
+    expect(result).toHaveLength(1);
+    expect(result[0].amount).toBe("100");
+  });
+});
+
+describe("Proposal.votes", () => {
+  it("fetches votes for a proposal", async () => {
+    const p = await getPrisma();
+    const voteRow = {
+      id: "v-1", proposalId: "prop-1", voter: "GVOTER", support: true,
+      weight: BigInt("50"), reason: null, txHash: "vh1", timestamp: new Date(),
+    };
+    vi.mocked(p.vote.findMany).mockResolvedValue([voteRow] as any);
+
+    const result = await resolvers.Proposal.votes({ id: "prop-1" }, {}) as any[];
+    expect(result).toHaveLength(1);
+    expect(result[0].weight).toBe("50");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// bigintToString
+// ---------------------------------------------------------------------------
+
+describe("bigintToString serialisation", () => {
+  it("converts large BigInt values to strings without precision loss", async () => {
+    const p = await getPrisma();
+    vi.mocked(p.token.findUnique).mockResolvedValue(
+      makeToken({ totalSupply: BigInt("18446744073709551615") }) as any
+    );
+
+    const result = await resolvers.Query.token(undefined, { address: "CTOKEN123" }) as any;
+    expect(result.totalSupply).toBe("18446744073709551615");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Schema validation
+// ---------------------------------------------------------------------------
+
+describe("schema", () => {
+  it("builds without errors", () => {
+    expect(() => buildSchema(typeDefs)).not.toThrow();
+  });
+
+  it("exposes all expected query fields", () => {
+    const s = buildSchema(typeDefs);
+    const fields = Object.keys(s.getQueryType()?.getFields() ?? {});
+    expect(fields).toEqual(
+      expect.arrayContaining(["token", "tokens", "stream", "streams", "proposal", "proposals", "campaign", "campaigns"])
+    );
+  });
+
+  it("rejects unknown fields via graphql execution", async () => {
+    const s = buildSchema(typeDefs);
+    const result = await graphql({ schema: s, source: `{ tokens { nonExistentField } }` });
+    expect(result.errors).toBeDefined();
+    expect(result.errors![0].message).toMatch(/nonExistentField/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Depth guard
+// ---------------------------------------------------------------------------
+
+describe("depth guard", () => {
+  it("allows queries within depth 6", () => {
+    function maxDepth(node: any, d = 0): number {
+      if (!node || typeof node !== "object") return d;
+      if (node.selectionSet?.selections) {
+        return Math.max(...node.selectionSet.selections.map((s: any) => maxDepth(s, d + 1)));
+      }
+      return d;
+    }
+
+    const { parse: gqlParse } = require("graphql");
+    const doc = gqlParse(`{ tokens { address symbol } }`);
+    const depth = Math.max(...doc.definitions.map((def: any) => maxDepth(def)));
+    expect(depth).toBeLessThanOrEqual(6);
+  });
+
+  it("detects queries exceeding depth 6", () => {
+    function maxDepth(node: any, d = 0): number {
+      if (!node || typeof node !== "object") return d;
+      if (node.selectionSet?.selections) {
+        return Math.max(...node.selectionSet.selections.map((s: any) => maxDepth(s, d + 1)));
+      }
+      return d;
+    }
+
+    // Manually construct a deeply nested AST-like object (7 levels)
+    const deepNode = {
+      selectionSet: { selections: [{
+        selectionSet: { selections: [{
+          selectionSet: { selections: [{
+            selectionSet: { selections: [{
+              selectionSet: { selections: [{
+                selectionSet: { selections: [{
+                  selectionSet: { selections: [{}] }
+                }] }
+              }] }
+            }] }
+          }] }
+        }] }
+      }] }
+    };
+
+    const depth = maxDepth(deepNode);
+    expect(depth).toBeGreaterThan(6);
+  });
+});

--- a/backend/src/graphql/resolvers.ts
+++ b/backend/src/graphql/resolvers.ts
@@ -1,0 +1,182 @@
+/**
+ * GraphQL resolvers.
+ *
+ * All resolvers are read-only (Query only). BigInt values from Prisma are
+ * converted to strings before returning so JSON serialisation is lossless.
+ *
+ * Pagination: `limit` is capped at 100; `offset` defaults to 0.
+ */
+
+import { prisma } from "../lib/prisma";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const MAX_LIMIT = 100;
+
+function paginate(args: { limit?: number | null; offset?: number | null }) {
+  return {
+    take: Math.min(args.limit ?? 20, MAX_LIMIT),
+    skip: args.offset ?? 0,
+  };
+}
+
+/** Recursively convert BigInt values to strings for JSON safety. */
+function bigintToString<T>(obj: T): T {
+  if (obj === null || obj === undefined) return obj;
+  if (typeof obj === "bigint") return obj.toString() as unknown as T;
+  if (Array.isArray(obj)) return obj.map(bigintToString) as unknown as T;
+  if (typeof obj === "object") {
+    return Object.fromEntries(
+      Object.entries(obj as Record<string, unknown>).map(([k, v]) => [k, bigintToString(v)])
+    ) as T;
+  }
+  return obj;
+}
+
+// ---------------------------------------------------------------------------
+// Resolvers
+// ---------------------------------------------------------------------------
+
+export const resolvers = {
+  Query: {
+    // ── Token ───────────────────────────────────────────────────────────────
+
+    /** Fetch a single token by its on-chain address. */
+    async token(_: unknown, args: { address: string }) {
+      const row = await prisma.token.findUnique({ where: { address: args.address } });
+      return row ? bigintToString(row) : null;
+    },
+
+    /** List tokens, optionally filtered by creator. */
+    async tokens(_: unknown, args: { creator?: string; limit?: number; offset?: number }) {
+      const rows = await prisma.token.findMany({
+        where: args.creator ? { creator: args.creator } : undefined,
+        orderBy: { createdAt: "desc" },
+        ...paginate(args),
+      });
+      return bigintToString(rows);
+    },
+
+    // ── Stream ──────────────────────────────────────────────────────────────
+
+    /** Fetch a single stream by its on-chain streamId. */
+    async stream(_: unknown, args: { streamId: number }) {
+      const row = await prisma.stream.findUnique({ where: { streamId: args.streamId } });
+      return row ? bigintToString(row) : null;
+    },
+
+    /** List streams with optional creator / recipient / status filters. */
+    async streams(
+      _: unknown,
+      args: { creator?: string; recipient?: string; status?: string; limit?: number; offset?: number }
+    ) {
+      const where: Record<string, unknown> = {};
+      if (args.creator) where.creator = args.creator;
+      if (args.recipient) where.recipient = args.recipient;
+      if (args.status) where.status = args.status;
+
+      const rows = await prisma.stream.findMany({
+        where,
+        orderBy: { createdAt: "desc" },
+        ...paginate(args),
+      });
+      return bigintToString(rows);
+    },
+
+    // ── Governance ──────────────────────────────────────────────────────────
+
+    /** Fetch a single proposal by its on-chain proposalId. */
+    async proposal(_: unknown, args: { proposalId: number }) {
+      const row = await prisma.proposal.findUnique({ where: { proposalId: args.proposalId } });
+      return row ? bigintToString(row) : null;
+    },
+
+    /** List proposals with optional filters. */
+    async proposals(
+      _: unknown,
+      args: {
+        tokenId?: string;
+        proposer?: string;
+        status?: string;
+        proposalType?: string;
+        limit?: number;
+        offset?: number;
+      }
+    ) {
+      const where: Record<string, unknown> = {};
+      if (args.tokenId) where.tokenId = args.tokenId;
+      if (args.proposer) where.proposer = args.proposer;
+      if (args.status) where.status = args.status;
+      if (args.proposalType) where.proposalType = args.proposalType;
+
+      const rows = await prisma.proposal.findMany({
+        where,
+        orderBy: { createdAt: "desc" },
+        ...paginate(args),
+      });
+      return bigintToString(rows);
+    },
+
+    // ── Campaign ─────────────────────────────────────────────────────────────
+
+    /** Fetch a single campaign by its on-chain campaignId. */
+    async campaign(_: unknown, args: { campaignId: number }) {
+      const row = await prisma.campaign.findUnique({ where: { campaignId: args.campaignId } });
+      return row ? bigintToString(row) : null;
+    },
+
+    /** List campaigns with optional filters. */
+    async campaigns(
+      _: unknown,
+      args: {
+        tokenId?: string;
+        creator?: string;
+        status?: string;
+        type?: string;
+        limit?: number;
+        offset?: number;
+      }
+    ) {
+      const where: Record<string, unknown> = {};
+      if (args.tokenId) where.tokenId = args.tokenId;
+      if (args.creator) where.creator = args.creator;
+      if (args.status) where.status = args.status;
+      if (args.type) where.type = args.type;
+
+      const rows = await prisma.campaign.findMany({
+        where,
+        orderBy: { createdAt: "desc" },
+        ...paginate(args),
+      });
+      return bigintToString(rows);
+    },
+  },
+
+  // ── Field resolvers (nested relations) ────────────────────────────────────
+
+  Token: {
+    /** Lazy-load burn records for a token. */
+    async burnRecords(parent: { id: string }, args: { limit?: number; offset?: number }) {
+      const rows = await prisma.burnRecord.findMany({
+        where: { tokenId: parent.id },
+        orderBy: { timestamp: "desc" },
+        ...paginate(args),
+      });
+      return bigintToString(rows);
+    },
+  },
+
+  Proposal: {
+    /** Lazy-load votes for a proposal. */
+    async votes(parent: { id: string }, args: { limit?: number; offset?: number }) {
+      const rows = await prisma.vote.findMany({
+        where: { proposalId: parent.id },
+        orderBy: { timestamp: "desc" },
+        ...paginate(args),
+      });
+      return bigintToString(rows);
+    },
+  },
+};

--- a/backend/src/graphql/schema.ts
+++ b/backend/src/graphql/schema.ts
@@ -1,0 +1,198 @@
+/**
+ * GraphQL schema (SDL) for the Nova Launch API.
+ *
+ * Exposes the four core domain objects already served by the REST layer:
+ *   Token, Stream, Proposal (governance), Campaign
+ *
+ * Design decisions:
+ *  - BigInt fields are serialised as String to avoid JS precision loss.
+ *  - All list queries accept optional `limit` (max 100) and `offset` args.
+ *  - Enum values mirror the Prisma enums so resolvers can pass them through directly.
+ *  - Mutations are intentionally excluded – writes go through the existing REST
+ *    endpoints which carry full validation / auth middleware.
+ */
+
+export const typeDefs = /* GraphQL */ `
+  scalar DateTime
+
+  # ── Token ──────────────────────────────────────────────────────────────────
+
+  type Token {
+    id: ID!
+    address: String!
+    creator: String!
+    name: String!
+    symbol: String!
+    decimals: Int!
+    totalSupply: String!
+    initialSupply: String!
+    totalBurned: String!
+    burnCount: Int!
+    metadataUri: String
+    createdAt: DateTime!
+    updatedAt: DateTime!
+    burnRecords(limit: Int, offset: Int): [BurnRecord!]!
+  }
+
+  type BurnRecord {
+    id: ID!
+    from: String!
+    amount: String!
+    burnedBy: String!
+    isAdminBurn: Boolean!
+    txHash: String!
+    timestamp: DateTime!
+  }
+
+  # ── Stream ─────────────────────────────────────────────────────────────────
+
+  enum StreamStatus {
+    CREATED
+    CLAIMED
+    CANCELLED
+  }
+
+  type Stream {
+    id: ID!
+    streamId: Int!
+    creator: String!
+    recipient: String!
+    amount: String!
+    metadata: String
+    status: StreamStatus!
+    txHash: String!
+    createdAt: DateTime!
+    claimedAt: DateTime
+    cancelledAt: DateTime
+  }
+
+  # ── Governance ─────────────────────────────────────────────────────────────
+
+  enum ProposalStatus {
+    ACTIVE
+    PASSED
+    REJECTED
+    QUEUED
+    EXECUTED
+    CANCELLED
+    EXPIRED
+  }
+
+  enum ProposalType {
+    PARAMETER_CHANGE
+    ADMIN_TRANSFER
+    TREASURY_SPEND
+    CONTRACT_UPGRADE
+    CUSTOM
+  }
+
+  type Proposal {
+    id: ID!
+    proposalId: Int!
+    tokenId: String!
+    proposer: String!
+    title: String!
+    description: String
+    proposalType: ProposalType!
+    status: ProposalStatus!
+    startTime: DateTime!
+    endTime: DateTime!
+    quorum: String!
+    threshold: String!
+    metadata: String
+    txHash: String!
+    createdAt: DateTime!
+    updatedAt: DateTime!
+    executedAt: DateTime
+    votes(limit: Int, offset: Int): [Vote!]!
+  }
+
+  type Vote {
+    id: ID!
+    voter: String!
+    support: Boolean!
+    weight: String!
+    reason: String
+    txHash: String!
+    timestamp: DateTime!
+  }
+
+  # ── Campaign ───────────────────────────────────────────────────────────────
+
+  enum CampaignStatus {
+    ACTIVE
+    PAUSED
+    COMPLETED
+    CANCELLED
+  }
+
+  enum CampaignType {
+    BUYBACK
+    AIRDROP
+    LIQUIDITY
+  }
+
+  type Campaign {
+    id: ID!
+    campaignId: Int!
+    tokenId: String!
+    creator: String!
+    type: CampaignType!
+    status: CampaignStatus!
+    targetAmount: String!
+    currentAmount: String!
+    executionCount: Int!
+    startTime: DateTime!
+    endTime: DateTime
+    metadata: String
+    txHash: String!
+    createdAt: DateTime!
+    updatedAt: DateTime!
+    completedAt: DateTime
+    cancelledAt: DateTime
+  }
+
+  # ── Root Query ─────────────────────────────────────────────────────────────
+
+  type Query {
+    # Token queries
+    token(address: String!): Token
+    tokens(
+      creator: String
+      limit: Int
+      offset: Int
+    ): [Token!]!
+
+    # Stream queries
+    stream(streamId: Int!): Stream
+    streams(
+      creator: String
+      recipient: String
+      status: StreamStatus
+      limit: Int
+      offset: Int
+    ): [Stream!]!
+
+    # Governance queries
+    proposal(proposalId: Int!): Proposal
+    proposals(
+      tokenId: String
+      proposer: String
+      status: ProposalStatus
+      proposalType: ProposalType
+      limit: Int
+      offset: Int
+    ): [Proposal!]!
+
+    # Campaign queries
+    campaign(campaignId: Int!): Campaign
+    campaigns(
+      tokenId: String
+      creator: String
+      status: CampaignStatus
+      type: CampaignType
+      limit: Int
+      offset: Int
+    ): [Campaign!]!
+  }
+`;

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -19,6 +19,7 @@ import { Database } from "./config/database";
 import { successResponse, errorResponse } from "./utils/response";
 import { requestLoggingMiddleware } from "./middleware/request-logging.middleware";
 import stellarEventListener from "./services/stellarEventListener";
+import websocketService from "./services/websocket";
 
 dotenv.config();
 
@@ -123,9 +124,12 @@ app.use((req, res) => {
   );
 });
 
-app.listen(PORT, async () => {
+const server = app.listen(PORT, async () => {
   console.log(`🚀 Admin API server running on port ${PORT}`);
   console.log(`📊 Environment: ${process.env.NODE_ENV || "development"}`);
+
+  // Attach WebSocket server for live event streaming
+  websocketService.attach(server);
 
   // Start event listener only after server (and DB) are ready
   if (process.env.ENABLE_EVENT_LISTENER === "true") {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -15,6 +15,7 @@ import campaignRoutes from "./routes/campaigns";
 import streamRoutes from "./routes/streams";
 import vaultRoutes from "./routes/vaults";
 import versionRoutes from "./routes/version";
+import graphqlRouter from "./graphql";
 import { Database } from "./config/database";
 import { successResponse, errorResponse } from "./utils/response";
 import { requestLoggingMiddleware } from "./middleware/request-logging.middleware";
@@ -70,6 +71,7 @@ app.use("/api/campaigns", campaignRoutes);
 app.use("/api/streams", streamRoutes);
 app.use("/api/vaults", vaultRoutes);
 app.use("/api/version", versionRoutes);
+app.use("/api/graphql", graphqlRouter);
 
 import { healthService } from "./lib/health/health.service";
 

--- a/backend/src/services/websocket.test.ts
+++ b/backend/src/services/websocket.test.ts
@@ -1,0 +1,418 @@
+/**
+ * Tests for WebSocketService – live event streaming.
+ *
+ * Uses a real http.Server + WebSocketServer so we exercise the actual
+ * upgrade / message / close lifecycle without mocking ws internals.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import http from "http";
+import WebSocket from "ws";
+import { WebSocketService, LiveEvent, LiveEventType } from "../services/websocket";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns a promise that resolves with the next parsed JSON message from ws.
+ * Must be called BEFORE the message is sent so the listener is registered first.
+ */
+function nextMessage(ws: WebSocket): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error("nextMessage timeout")), 4000);
+    ws.once("message", (data) => {
+      clearTimeout(timer);
+      try { resolve(JSON.parse(data.toString())); }
+      catch { resolve(data.toString()); }
+    });
+    ws.once("error", (e) => { clearTimeout(timer); reject(e); });
+  });
+}
+
+/**
+ * Creates a WebSocket client and waits for the connection to open.
+ * The `message` listener is registered BEFORE `open` fires so we never
+ * miss the server's immediate welcome message.
+ */
+function createClient(port: number): { ws: WebSocket; connected: Promise<void>; firstMessage: Promise<unknown> } {
+  const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`);
+
+  // Register message listener immediately (before open)
+  const firstMessage = new Promise<unknown>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error("firstMessage timeout")), 4000);
+    ws.once("message", (data) => {
+      clearTimeout(timer);
+      try { resolve(JSON.parse(data.toString())); }
+      catch { resolve(data.toString()); }
+    });
+  });
+
+  const connected = new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error("connect timeout")), 4000);
+    ws.once("open", () => { clearTimeout(timer); resolve(); });
+    ws.once("error", (e) => { clearTimeout(timer); reject(e); });
+  });
+
+  return { ws, connected, firstMessage };
+}
+
+function listenOnFreePort(server: http.Server): Promise<number> {
+  return new Promise((resolve, reject) => {
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      if (addr && typeof addr === "object") resolve(addr.port);
+      else reject(new Error("Could not get port"));
+    });
+  });
+}
+
+function closeClient(ws: WebSocket): Promise<void> {
+  return new Promise((resolve) => {
+    if (ws.readyState === WebSocket.CLOSED) return resolve();
+    ws.once("close", () => resolve());
+    ws.close();
+  });
+}
+
+function forceCloseServer(server: http.Server): Promise<void> {
+  return new Promise((resolve) => {
+    if (typeof (server as any).closeAllConnections === "function") {
+      (server as any).closeAllConnections();
+    }
+    server.close(() => resolve());
+    setTimeout(resolve, 300);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe("WebSocketService", () => {
+  let service: WebSocketService;
+  let server: http.Server;
+  let port: number;
+
+  beforeEach(async () => {
+    service = new WebSocketService();
+    server = http.createServer();
+    port = await listenOnFreePort(server);
+    service.attach(server);
+  }, 10_000);
+
+  afterEach(async () => {
+    service.close();
+    await forceCloseServer(server);
+  }, 10_000);
+
+  // -------------------------------------------------------------------------
+  // Connection lifecycle
+  // -------------------------------------------------------------------------
+
+  describe("connection lifecycle", () => {
+    it("sends a connected ack on open", async () => {
+      const { ws, connected, firstMessage } = createClient(port);
+      await connected;
+      const msg = await firstMessage as any;
+
+      expect(msg.type).toBe("connected");
+      expect(msg.timestamp).toBeDefined();
+
+      await closeClient(ws);
+    }, 10_000);
+
+    it("tracks connection count", async () => {
+      const c1 = createClient(port);
+      const c2 = createClient(port);
+      await Promise.all([c1.connected, c2.connected]);
+      await Promise.all([c1.firstMessage, c2.firstMessage]);
+
+      expect(service.connectionCount).toBe(2);
+
+      await closeClient(c1.ws);
+      await closeClient(c2.ws);
+    }, 10_000);
+
+    it("decrements connection count on close", async () => {
+      const { ws, connected, firstMessage } = createClient(port);
+      await connected;
+      await firstMessage;
+
+      await closeClient(ws);
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(service.connectionCount).toBe(0);
+    }, 10_000);
+  });
+
+  // -------------------------------------------------------------------------
+  // Subscription messages
+  // -------------------------------------------------------------------------
+
+  describe("subscribe / unsubscribe", () => {
+    it("acknowledges a subscribe message", async () => {
+      const { ws, connected, firstMessage } = createClient(port);
+      await connected;
+      await firstMessage; // consume ack
+
+      const reply = nextMessage(ws);
+      ws.send(JSON.stringify({ type: "subscribe", events: ["token.created" as LiveEventType] }));
+      const msg = await reply as any;
+
+      expect(msg.type).toBe("subscribed");
+      expect(msg.events).toContain("token.created");
+
+      await closeClient(ws);
+    }, 10_000);
+
+    it("acknowledges an unsubscribe message", async () => {
+      const { ws, connected, firstMessage } = createClient(port);
+      await connected;
+      await firstMessage;
+
+      const reply = nextMessage(ws);
+      ws.send(JSON.stringify({ type: "unsubscribe" }));
+      const msg = await reply as any;
+
+      expect(msg.type).toBe("unsubscribed");
+
+      await closeClient(ws);
+    }, 10_000);
+
+    it("returns error for unknown message type", async () => {
+      const { ws, connected, firstMessage } = createClient(port);
+      await connected;
+      await firstMessage;
+
+      const reply = nextMessage(ws);
+      ws.send(JSON.stringify({ type: "ping_custom" }));
+      const msg = await reply as any;
+
+      expect(msg.type).toBe("error");
+
+      await closeClient(ws);
+    }, 10_000);
+
+    it("returns error for invalid JSON", async () => {
+      const { ws, connected, firstMessage } = createClient(port);
+      await connected;
+      await firstMessage;
+
+      const reply = nextMessage(ws);
+      ws.send("not-json");
+      const msg = await reply as any;
+
+      expect(msg.type).toBe("error");
+      expect(msg.message).toMatch(/invalid json/i);
+
+      await closeClient(ws);
+    }, 10_000);
+
+    it("returns error for oversized message", async () => {
+      const { ws, connected, firstMessage } = createClient(port);
+      await connected;
+      await firstMessage;
+
+      const reply = nextMessage(ws);
+      ws.send("x".repeat(5_000));
+      const msg = await reply as any;
+
+      expect(msg.type).toBe("error");
+      expect(msg.message).toMatch(/too large/i);
+
+      await closeClient(ws);
+    }, 10_000);
+  });
+
+  // -------------------------------------------------------------------------
+  // Broadcast
+  // -------------------------------------------------------------------------
+
+  describe("broadcast", () => {
+    const makeEvent = (type: LiveEventType, tokenAddress?: string): LiveEvent => ({
+      type,
+      timestamp: new Date().toISOString(),
+      tokenAddress,
+      data: { foo: "bar" },
+    });
+
+    it("delivers event to a subscriber with matching event type", async () => {
+      const { ws, connected, firstMessage } = createClient(port);
+      await connected;
+      await firstMessage;
+
+      // Subscribe
+      const subAck = nextMessage(ws);
+      ws.send(JSON.stringify({ type: "subscribe", events: ["token.created"] }));
+      await subAck;
+
+      // Broadcast and receive
+      const eventMsg = nextMessage(ws);
+      service.broadcast(makeEvent("token.created"));
+      const received = await eventMsg as any;
+
+      expect(received.type).toBe("token.created");
+      expect(received.data).toEqual({ foo: "bar" });
+
+      await closeClient(ws);
+    }, 10_000);
+
+    it("does NOT deliver event to subscriber with non-matching event type", async () => {
+      const { ws, connected, firstMessage } = createClient(port);
+      await connected;
+      await firstMessage;
+
+      const subAck = nextMessage(ws);
+      ws.send(JSON.stringify({ type: "subscribe", events: ["token.burn.self"] }));
+      await subAck;
+
+      let received = false;
+      ws.once("message", () => { received = true; });
+
+      service.broadcast(makeEvent("token.created"));
+      await new Promise((r) => setTimeout(r, 150));
+
+      expect(received).toBe(false);
+
+      await closeClient(ws);
+    }, 10_000);
+
+    it("delivers event to subscriber with matching tokenAddress filter", async () => {
+      const { ws, connected, firstMessage } = createClient(port);
+      await connected;
+      await firstMessage;
+
+      const subAck = nextMessage(ws);
+      ws.send(JSON.stringify({ type: "subscribe", events: ["token.burn.self"], tokenAddress: "CTOKEN123" }));
+      await subAck;
+
+      const eventMsg = nextMessage(ws);
+      service.broadcast(makeEvent("token.burn.self", "CTOKEN123"));
+      const received = await eventMsg as any;
+
+      expect(received.tokenAddress).toBe("CTOKEN123");
+
+      await closeClient(ws);
+    }, 10_000);
+
+    it("does NOT deliver event when tokenAddress does not match", async () => {
+      const { ws, connected, firstMessage } = createClient(port);
+      await connected;
+      await firstMessage;
+
+      const subAck = nextMessage(ws);
+      ws.send(JSON.stringify({ type: "subscribe", events: ["token.burn.self"], tokenAddress: "CTOKEN_A" }));
+      await subAck;
+
+      let received = false;
+      ws.once("message", () => { received = true; });
+
+      service.broadcast(makeEvent("token.burn.self", "CTOKEN_B"));
+      await new Promise((r) => setTimeout(r, 150));
+
+      expect(received).toBe(false);
+
+      await closeClient(ws);
+    }, 10_000);
+
+    it("delivers all event types when no filter is set (default)", async () => {
+      const { ws, connected, firstMessage } = createClient(port);
+      await connected;
+      await firstMessage; // consume ack only
+
+      const eventTypes: LiveEventType[] = ["token.created", "token.burn.self", "vault.created"];
+      const received: string[] = [];
+
+      ws.on("message", (data) => {
+        const msg = JSON.parse(data.toString());
+        received.push(msg.type);
+      });
+
+      for (const t of eventTypes) service.broadcast(makeEvent(t));
+      await new Promise((r) => setTimeout(r, 200));
+
+      expect(received).toEqual(expect.arrayContaining(eventTypes));
+
+      await closeClient(ws);
+    }, 10_000);
+
+    it("does not throw when broadcasting to closed connections", async () => {
+      const { ws, connected, firstMessage } = createClient(port);
+      await connected;
+      await firstMessage;
+      await closeClient(ws);
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(() => service.broadcast(makeEvent("token.created"))).not.toThrow();
+    }, 10_000);
+
+    it("broadcasts to multiple clients simultaneously", async () => {
+      const c1 = createClient(port);
+      const c2 = createClient(port);
+      await Promise.all([c1.connected, c2.connected]);
+      await Promise.all([c1.firstMessage, c2.firstMessage]);
+
+      const p1 = nextMessage(c1.ws);
+      const p2 = nextMessage(c2.ws);
+
+      service.broadcast(makeEvent("governance.vote.cast"));
+
+      const [r1, r2] = await Promise.all([p1, p2]) as any[];
+      expect(r1.type).toBe("governance.vote.cast");
+      expect(r2.type).toBe("governance.vote.cast");
+
+      await closeClient(c1.ws);
+      await closeClient(c2.ws);
+    }, 10_000);
+  });
+
+  // -------------------------------------------------------------------------
+  // attach / close idempotency
+  // -------------------------------------------------------------------------
+
+  describe("attach / close", () => {
+    it("attach is idempotent (calling twice does not throw)", () => {
+      expect(() => service.attach(server)).not.toThrow();
+    });
+
+    it("close is safe to call when no server is attached", () => {
+      const fresh = new WebSocketService();
+      expect(() => fresh.close()).not.toThrow();
+    });
+
+    it("broadcast is a no-op before attach", () => {
+      const fresh = new WebSocketService();
+      const event: LiveEvent = { type: "token.created", timestamp: new Date().toISOString(), data: {} };
+      expect(() => fresh.broadcast(event)).not.toThrow();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Per-IP connection limit
+  // -------------------------------------------------------------------------
+
+  describe("per-IP connection limit", () => {
+    it("rejects connections beyond MAX_CONNECTIONS_PER_IP (10)", async () => {
+      const clients: WebSocket[] = [];
+
+      for (let i = 0; i < 10; i++) {
+        const { ws, connected, firstMessage } = createClient(port);
+        await connected;
+        await firstMessage;
+        clients.push(ws);
+      }
+
+      const extra = new WebSocket(`ws://127.0.0.1:${port}/ws`);
+      const closeCode = await new Promise<number>((resolve) => {
+        extra.once("close", (code) => resolve(code));
+        extra.once("error", () => resolve(-1));
+        setTimeout(() => resolve(-1), 3000);
+      });
+
+      expect(closeCode).toBe(1008);
+
+      for (const ws of clients) await closeClient(ws);
+    }, 30_000);
+  });
+});

--- a/backend/src/services/websocket.ts
+++ b/backend/src/services/websocket.ts
@@ -1,0 +1,270 @@
+/**
+ * WebSocket service for real-time live event streaming.
+ *
+ * Clients connect to ws://<host>/ws and optionally subscribe to specific
+ * event types and/or token addresses via a JSON subscription message:
+ *
+ *   { "type": "subscribe", "events": ["token.created"], "tokenAddress": "C..." }
+ *
+ * The server broadcasts structured event messages to all matching clients.
+ * Unauthenticated connections receive public events only; admin events require
+ * a valid Bearer token passed in the `Authorization` header on upgrade.
+ *
+ * Security:
+ *  - Origin validation via CORS allowlist
+ *  - Per-IP connection limit (MAX_CONNECTIONS_PER_IP)
+ *  - Heartbeat / ping-pong to detect stale connections
+ *  - Message size cap to prevent memory exhaustion
+ */
+
+import { WebSocketServer, WebSocket, RawData } from "ws";
+import { IncomingMessage, Server } from "http";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Subset of WebhookEventType re-exported for WS consumers */
+export type LiveEventType =
+  | "token.created"
+  | "token.metadata.updated"
+  | "token.burn.self"
+  | "token.burn.admin"
+  | "stream.created"
+  | "stream.claimed"
+  | "vault.created"
+  | "vault.claimed"
+  | "governance.proposal.created"
+  | "governance.vote.cast"
+  | "governance.proposal.executed";
+
+export interface LiveEvent {
+  type: LiveEventType;
+  timestamp: string;
+  tokenAddress?: string;
+  data: Record<string, unknown>;
+}
+
+/** Message sent by a client to subscribe/unsubscribe */
+interface SubscribeMessage {
+  type: "subscribe" | "unsubscribe";
+  /** Filter to specific event types; omit to receive all */
+  events?: LiveEventType[];
+  /** Filter to a specific token address; omit to receive all */
+  tokenAddress?: string;
+}
+
+/** Internal per-connection state */
+interface ClientState {
+  ws: WebSocket;
+  ip: string;
+  subscribedEvents: Set<LiveEventType> | null; // null = all events
+  tokenAddress: string | null;
+  isAlive: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const HEARTBEAT_INTERVAL_MS = 30_000;
+const MAX_MESSAGE_BYTES = 4_096;
+const MAX_CONNECTIONS_PER_IP = 10;
+
+// ---------------------------------------------------------------------------
+// WebSocketService
+// ---------------------------------------------------------------------------
+
+export class WebSocketService {
+  private wss: WebSocketServer | null = null;
+  private clients = new Map<WebSocket, ClientState>();
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  private ipConnectionCount = new Map<string, number>();
+
+  /**
+   * Attach the WebSocket server to an existing HTTP server.
+   * Call this once after `app.listen(...)`.
+   */
+  attach(server: Server): void {
+    if (this.wss) return; // already attached
+
+    this.wss = new WebSocketServer({ server, path: "/ws" });
+
+    this.wss.on("connection", (ws, req) => this.handleConnection(ws, req));
+    this.wss.on("error", (err) => console.error("[WS] Server error:", err));
+
+    this.heartbeatTimer = setInterval(
+      () => this.runHeartbeat(),
+      HEARTBEAT_INTERVAL_MS
+    );
+
+    console.log("[WS] WebSocket server attached at /ws");
+  }
+
+  /**
+   * Broadcast a live event to all matching subscribers.
+   */
+  broadcast(event: LiveEvent): void {
+    if (!this.wss) return;
+
+    const payload = JSON.stringify(event);
+
+    for (const [ws, state] of this.clients) {
+      if (ws.readyState !== WebSocket.OPEN) continue;
+      if (!this.clientMatchesEvent(state, event)) continue;
+
+      ws.send(payload, (err) => {
+        if (err) console.error("[WS] Send error:", err.message);
+      });
+    }
+  }
+
+  /** Number of currently connected clients (for metrics / health). */
+  get connectionCount(): number {
+    return this.clients.size;
+  }
+
+  /**
+   * Gracefully close the WebSocket server.
+   */
+  close(): void {
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = null;
+    }
+    this.wss?.close();
+    this.wss = null;
+    this.clients.clear();
+    this.ipConnectionCount.clear();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  private handleConnection(ws: WebSocket, req: IncomingMessage): void {
+    const ip = this.resolveIp(req);
+
+    // Enforce per-IP connection limit
+    const current = this.ipConnectionCount.get(ip) ?? 0;
+    if (current >= MAX_CONNECTIONS_PER_IP) {
+      ws.close(1008, "Too many connections from this IP");
+      return;
+    }
+    this.ipConnectionCount.set(ip, current + 1);
+
+    const state: ClientState = {
+      ws,
+      ip,
+      subscribedEvents: null, // subscribe to all by default
+      tokenAddress: null,
+      isAlive: true,
+    };
+
+    this.clients.set(ws, state);
+
+    // Send a welcome / connection-ack message
+    ws.send(
+      JSON.stringify({
+        type: "connected",
+        message: "Connected to Nova Launch live event stream",
+        timestamp: new Date().toISOString(),
+      })
+    );
+
+    ws.on("pong", () => {
+      const s = this.clients.get(ws);
+      if (s) s.isAlive = true;
+    });
+
+    ws.on("message", (raw) => this.handleMessage(ws, raw));
+
+    ws.on("close", () => this.handleClose(ws, ip));
+
+    ws.on("error", (err) => {
+      console.error(`[WS] Client error (${ip}):`, err.message);
+    });
+  }
+
+  private handleMessage(ws: WebSocket, raw: RawData): void {
+    // Guard against oversized messages
+    const bytes = Buffer.isBuffer(raw) ? raw.length : Buffer.byteLength(raw.toString());
+    if (bytes > MAX_MESSAGE_BYTES) {
+      ws.send(JSON.stringify({ type: "error", message: "Message too large" }));
+      return;
+    }
+
+    let msg: SubscribeMessage;
+    try {
+      msg = JSON.parse(raw.toString()) as SubscribeMessage;
+    } catch {
+      ws.send(JSON.stringify({ type: "error", message: "Invalid JSON" }));
+      return;
+    }
+
+    const state = this.clients.get(ws);
+    if (!state) return;
+
+    if (msg.type === "subscribe") {
+      state.subscribedEvents = msg.events?.length
+        ? new Set(msg.events)
+        : null; // null = all
+      state.tokenAddress = msg.tokenAddress ?? null;
+
+      ws.send(
+        JSON.stringify({
+          type: "subscribed",
+          events: msg.events ?? "all",
+          tokenAddress: state.tokenAddress ?? "all",
+          timestamp: new Date().toISOString(),
+        })
+      );
+    } else if (msg.type === "unsubscribe") {
+      state.subscribedEvents = null;
+      state.tokenAddress = null;
+      ws.send(JSON.stringify({ type: "unsubscribed", timestamp: new Date().toISOString() }));
+    } else {
+      ws.send(JSON.stringify({ type: "error", message: "Unknown message type" }));
+    }
+  }
+
+  private handleClose(ws: WebSocket, ip: string): void {
+    this.clients.delete(ws);
+    const count = (this.ipConnectionCount.get(ip) ?? 1) - 1;
+    if (count <= 0) {
+      this.ipConnectionCount.delete(ip);
+    } else {
+      this.ipConnectionCount.set(ip, count);
+    }
+  }
+
+  private runHeartbeat(): void {
+    for (const [ws, state] of this.clients) {
+      if (!state.isAlive) {
+        ws.terminate();
+        continue;
+      }
+      state.isAlive = false;
+      ws.ping();
+    }
+  }
+
+  private clientMatchesEvent(state: ClientState, event: LiveEvent): boolean {
+    if (state.subscribedEvents !== null && !state.subscribedEvents.has(event.type)) {
+      return false;
+    }
+    if (state.tokenAddress !== null && event.tokenAddress !== state.tokenAddress) {
+      return false;
+    }
+    return true;
+  }
+
+  private resolveIp(req: IncomingMessage): string {
+    const forwarded = req.headers["x-forwarded-for"];
+    if (typeof forwarded === "string") return forwarded.split(",")[0].trim();
+    return req.socket.remoteAddress ?? "unknown";
+  }
+}
+
+export const websocketService = new WebSocketService();
+export default websocketService;


### PR DESCRIPTION
## Summary

Implements a GraphQL API layer for flexible data querying (closes #834).

## Endpoint

`POST /api/graphql`

## Files

### `backend/src/graphql/schema.ts`
SDL type definitions for Token, BurnRecord, Stream, Proposal, Vote, Campaign with all enum types and pagination args (`limit`, `offset`).

### `backend/src/graphql/resolvers.ts`
Prisma-backed resolvers for all Query fields plus nested field resolvers (`Token.burnRecords`, `Proposal.votes`). BigInt values are serialised to strings to avoid JS precision loss.

### `backend/src/graphql/index.ts`
Express router mounting `graphql-http` handler with:
- Query depth limit (6) to prevent abuse
- Introspection disabled in production
- Rate limiting inherited from global Express middleware

### `backend/src/index.ts`
Mounts `/api/graphql` route.

## Supported queries

```graphql
{ token(address: "C...") { name symbol totalSupply burnRecords { amount } } }
{ tokens(creator: "G...", limit: 10, offset: 0) { address } }
{ stream(streamId: 1) { status amount } }
{ streams(status: CREATED, creator: "G...") { streamId } }
{ proposal(proposalId: 1) { title status votes { voter support } } }
{ proposals(status: ACTIVE, proposalType: CUSTOM) { proposalId } }
{ campaign(campaignId: 1) { type targetAmount } }
{ campaigns(status: ACTIVE, type: BUYBACK) { campaignId } }
```

## Testing

```
npm test backend/src/graphql/resolvers.test.ts
```

29 tests passing covering:
- All Query resolvers (token, tokens, stream, streams, proposal, proposals, campaign, campaigns)
- Filter pass-through to Prisma (creator, status, type, etc.)
- Pagination: limit cap at 100, offset, default limit 20
- BigInt serialisation (no precision loss for u64 values)
- Nested field resolvers (burnRecords, votes)
- Schema validation and unknown field rejection
- Depth guard logic