### PR TITLE
chore: Implement OpenAPI/Swagger Documentation for All API Endpoints

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -1,0 +1,1688 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Nova Launch API",
+    "version": "1.0.0",
+    "description": "REST API for the Nova Launch Stellar token deployment platform.",
+    "contact": {
+      "name": "Nova Launch",
+      "url": "https://github.com/Emmyt24/Nova-launch"
+    },
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "servers": [
+    {
+      "url": "http://localhost:3000",
+      "description": "Local development"
+    },
+    {
+      "url": "https://api.nova-launch.app",
+      "description": "Production"
+    }
+  ],
+  "tags": [
+    {
+      "name": "Health",
+      "description": "Liveness and readiness probes"
+    },
+    {
+      "name": "Version",
+      "description": "Backend version info"
+    },
+    {
+      "name": "Stats",
+      "description": "Platform statistics"
+    },
+    {
+      "name": "Tokens",
+      "description": "Token search and discovery"
+    },
+    {
+      "name": "Leaderboard",
+      "description": "Token leaderboards"
+    },
+    {
+      "name": "Governance",
+      "description": "On-chain governance proposals"
+    },
+    {
+      "name": "Campaigns",
+      "description": "Token campaigns"
+    },
+    {
+      "name": "Streams",
+      "description": "Token streams"
+    },
+    {
+      "name": "Vaults",
+      "description": "Token vaults"
+    },
+    {
+      "name": "Webhooks",
+      "description": "Webhook subscriptions and delivery"
+    }
+  ],
+  "paths": {
+    "/health/live": {
+      "get": {
+        "tags": [
+          "Health"
+        ],
+        "summary": "Liveness probe",
+        "description": "Returns 200 as long as the process is running.",
+        "responses": {
+          "200": {
+            "description": "Process is alive",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthStatus"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/health/ready": {
+      "get": {
+        "tags": [
+          "Health"
+        ],
+        "summary": "Readiness probe",
+        "description": "Checks all dependency connections.",
+        "responses": {
+          "200": {
+            "description": "All dependencies healthy"
+          },
+          "207": {
+            "description": "Degraded — some dependencies unreachable"
+          },
+          "503": {
+            "description": "Unhealthy"
+          }
+        }
+      }
+    },
+    "/api/version": {
+      "get": {
+        "tags": [
+          "Version"
+        ],
+        "summary": "Backend version info",
+        "responses": {
+          "200": {
+            "description": "Version details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "backendVersion": {
+                      "type": "string"
+                    },
+                    "contractId": {
+                      "type": "string"
+                    },
+                    "network": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/stats": {
+      "get": {
+        "tags": [
+          "Stats"
+        ],
+        "summary": "Platform statistics",
+        "responses": {
+          "200": {
+            "description": "Platform stats",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "totalTokens": {
+                      "type": "integer"
+                    },
+                    "totalUsers": {
+                      "type": "integer"
+                    },
+                    "totalBurned": {
+                      "type": "string"
+                    },
+                    "uptime": {
+                      "type": "string"
+                    },
+                    "lastUpdated": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/tokens/search": {
+      "get": {
+        "tags": [
+          "Tokens"
+        ],
+        "summary": "Search and filter tokens",
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Search by name or symbol"
+          },
+          {
+            "name": "creator",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "startDate",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "endDate",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "minSupply",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "maxSupply",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "hasBurns",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "true",
+                "false"
+              ]
+            }
+          },
+          {
+            "name": "sortBy",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "created",
+                "burned",
+                "supply",
+                "name"
+              ],
+              "default": "created"
+            }
+          },
+          {
+            "name": "sortOrder",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "default": "desc"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 1
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 20,
+              "maximum": 50
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Token search results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/TokenRecord"
+                      }
+                    },
+                    "pagination": {
+                      "$ref": "#/components/schemas/Pagination"
+                    },
+                    "cached": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/leaderboard/most-burned": {
+      "get": {
+        "tags": [
+          "Leaderboard"
+        ],
+        "summary": "Tokens with highest burn volume",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PeriodParam"
+          },
+          {
+            "$ref": "#/components/parameters/PageParam"
+          },
+          {
+            "$ref": "#/components/parameters/LimitParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Leaderboard results"
+          },
+          "500": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/leaderboard/most-active": {
+      "get": {
+        "tags": [
+          "Leaderboard"
+        ],
+        "summary": "Tokens with most burn transactions",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PeriodParam"
+          },
+          {
+            "$ref": "#/components/parameters/PageParam"
+          },
+          {
+            "$ref": "#/components/parameters/LimitParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Leaderboard results"
+          }
+        }
+      }
+    },
+    "/api/leaderboard/newest": {
+      "get": {
+        "tags": [
+          "Leaderboard"
+        ],
+        "summary": "Recently created tokens",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PageParam"
+          },
+          {
+            "$ref": "#/components/parameters/LimitParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Leaderboard results"
+          }
+        }
+      }
+    },
+    "/api/leaderboard/largest-supply": {
+      "get": {
+        "tags": [
+          "Leaderboard"
+        ],
+        "summary": "Tokens with highest total supply",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PageParam"
+          },
+          {
+            "$ref": "#/components/parameters/LimitParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Leaderboard results"
+          }
+        }
+      }
+    },
+    "/api/leaderboard/most-burners": {
+      "get": {
+        "tags": [
+          "Leaderboard"
+        ],
+        "summary": "Tokens with most unique burners",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PeriodParam"
+          },
+          {
+            "$ref": "#/components/parameters/PageParam"
+          },
+          {
+            "$ref": "#/components/parameters/LimitParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Leaderboard results"
+          }
+        }
+      }
+    },
+    "/api/governance/proposals": {
+      "get": {
+        "tags": [
+          "Governance"
+        ],
+        "summary": "List governance proposals",
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "ACTIVE",
+                "PASSED",
+                "REJECTED",
+                "EXECUTED",
+                "CANCELLED",
+                "EXPIRED"
+              ]
+            }
+          },
+          {
+            "name": "proposalType",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "PARAMETER_CHANGE",
+                "ADMIN_TRANSFER",
+                "TREASURY_SPEND",
+                "CONTRACT_UPGRADE",
+                "CUSTOM"
+              ]
+            }
+          },
+          {
+            "name": "tokenId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "proposer",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 50,
+              "maximum": 100
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 0
+            }
+          },
+          {
+            "name": "sortBy",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "createdAt",
+                "startTime",
+                "endTime"
+              ],
+              "default": "createdAt"
+            }
+          },
+          {
+            "name": "sortOrder",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "default": "desc"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of proposals",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "proposals": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/ProposalRecord"
+                          }
+                        },
+                        "total": {
+                          "type": "integer"
+                        },
+                        "limit": {
+                          "type": "integer"
+                        },
+                        "offset": {
+                          "type": "integer"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/governance/proposals/{id}": {
+      "get": {
+        "tags": [
+          "Governance"
+        ],
+        "summary": "Get proposal by ID",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Proposal detail"
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/governance/proposals/{id}/votes": {
+      "get": {
+        "tags": [
+          "Governance"
+        ],
+        "summary": "Get votes for a proposal",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 50
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Votes list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "votes": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/GovernanceVoteRecord"
+                          }
+                        },
+                        "total": {
+                          "type": "integer"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/campaigns/stats/{tokenId}": {
+      "get": {
+        "tags": [
+          "Campaigns"
+        ],
+        "summary": "Campaign statistics for a token (or global)",
+        "parameters": [
+          {
+            "name": "tokenId",
+            "in": "path",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Campaign stats"
+          }
+        }
+      }
+    },
+    "/api/campaigns/token/{tokenId}": {
+      "get": {
+        "tags": [
+          "Campaigns"
+        ],
+        "summary": "Campaigns for a token",
+        "parameters": [
+          {
+            "name": "tokenId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Campaign list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CampaignRecord"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/campaigns/creator/{creator}": {
+      "get": {
+        "tags": [
+          "Campaigns"
+        ],
+        "summary": "Campaigns by creator address",
+        "parameters": [
+          {
+            "name": "creator",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Campaign list"
+          }
+        }
+      }
+    },
+    "/api/campaigns/{campaignId}": {
+      "get": {
+        "tags": [
+          "Campaigns"
+        ],
+        "summary": "Get campaign by ID",
+        "parameters": [
+          {
+            "name": "campaignId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Campaign detail"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/campaigns/{campaignId}/executions": {
+      "get": {
+        "tags": [
+          "Campaigns"
+        ],
+        "summary": "Execution history for a campaign",
+        "parameters": [
+          {
+            "name": "campaignId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 50
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Execution history"
+          }
+        }
+      }
+    },
+    "/api/streams/stats/{address}": {
+      "get": {
+        "tags": [
+          "Streams"
+        ],
+        "summary": "Stream statistics for an address or global",
+        "parameters": [
+          {
+            "name": "address",
+            "in": "path",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Stream stats"
+          }
+        }
+      }
+    },
+    "/api/streams/creator/{address}": {
+      "get": {
+        "tags": [
+          "Streams"
+        ],
+        "summary": "Streams created by address",
+        "parameters": [
+          {
+            "name": "address",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "CREATED",
+                "ACTIVE",
+                "COMPLETED",
+                "CANCELLED"
+              ]
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 50
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Stream list"
+          }
+        }
+      }
+    },
+    "/api/streams/recipient/{address}": {
+      "get": {
+        "tags": [
+          "Streams"
+        ],
+        "summary": "Streams where address is the recipient",
+        "parameters": [
+          {
+            "name": "address",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 50
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Stream list"
+          }
+        }
+      }
+    },
+    "/api/streams/{id}": {
+      "get": {
+        "tags": [
+          "Streams"
+        ],
+        "summary": "Get stream by on-chain ID",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Stream detail"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/vaults/creator/{address}": {
+      "get": {
+        "tags": [
+          "Vaults"
+        ],
+        "summary": "Vaults created by address",
+        "parameters": [
+          {
+            "name": "address",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 50
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Vault list"
+          }
+        }
+      }
+    },
+    "/api/vaults/beneficiary/{address}": {
+      "get": {
+        "tags": [
+          "Vaults"
+        ],
+        "summary": "Vaults where address is the beneficiary",
+        "parameters": [
+          {
+            "name": "address",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 50
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Vault list"
+          }
+        }
+      }
+    },
+    "/api/vaults/{id}": {
+      "get": {
+        "tags": [
+          "Vaults"
+        ],
+        "summary": "Get vault by on-chain ID",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Vault detail"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/webhooks/subscribe": {
+      "post": {
+        "tags": [
+          "Webhooks"
+        ],
+        "summary": "Create a webhook subscription",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "url",
+                  "events",
+                  "createdBy"
+                ],
+                "properties": {
+                  "url": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "tokenAddress": {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "events": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "enum": [
+                        "token.burn.self",
+                        "token.burn.admin",
+                        "token.created",
+                        "token.metadata.updated"
+                      ]
+                    }
+                  },
+                  "createdBy": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Subscription created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WebhookSubscription"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input"
+          }
+        }
+      }
+    },
+    "/api/webhooks/unsubscribe/{id}": {
+      "delete": {
+        "tags": [
+          "Webhooks"
+        ],
+        "summary": "Delete a webhook subscription",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Deleted successfully"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/webhooks/subscriptions": {
+      "get": {
+        "tags": [
+          "Webhooks"
+        ],
+        "summary": "List webhook subscriptions",
+        "parameters": [
+          {
+            "name": "createdBy",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Subscription list"
+          }
+        }
+      }
+    },
+    "/api/webhooks/{id}/toggle": {
+      "patch": {
+        "tags": [
+          "Webhooks"
+        ],
+        "summary": "Toggle webhook active state",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Toggled"
+          }
+        }
+      }
+    },
+    "/api/webhooks/{id}/logs": {
+      "get": {
+        "tags": [
+          "Webhooks"
+        ],
+        "summary": "Delivery logs for a webhook",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Delivery logs"
+          }
+        }
+      }
+    },
+    "/api/webhooks/{id}/test": {
+      "post": {
+        "tags": [
+          "Webhooks"
+        ],
+        "summary": "Send a test event to a webhook",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Test result"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "example": false
+          },
+          "error": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "success",
+          "error"
+        ]
+      },
+      "Pagination": {
+        "type": "object",
+        "properties": {
+          "page": {
+            "type": "integer",
+            "example": 1
+          },
+          "limit": {
+            "type": "integer",
+            "example": 20
+          },
+          "total": {
+            "type": "integer",
+            "example": 100
+          },
+          "totalPages": {
+            "type": "integer",
+            "example": 5
+          },
+          "hasNext": {
+            "type": "boolean"
+          },
+          "hasPrev": {
+            "type": "boolean"
+          }
+        }
+      },
+      "TokenRecord": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "address": {
+            "type": "string"
+          },
+          "creator": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "symbol": {
+            "type": "string"
+          },
+          "decimals": {
+            "type": "integer"
+          },
+          "totalSupply": {
+            "type": "string",
+            "description": "BigInt as string"
+          },
+          "initialSupply": {
+            "type": "string",
+            "description": "BigInt as string"
+          },
+          "totalBurned": {
+            "type": "string",
+            "description": "BigInt as string"
+          },
+          "burnCount": {
+            "type": "integer"
+          },
+          "metadataUri": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "CampaignRecord": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "campaignId": {
+            "type": "integer"
+          },
+          "tokenId": {
+            "type": "string"
+          },
+          "creator": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "targetAmount": {
+            "type": "string"
+          },
+          "currentAmount": {
+            "type": "string"
+          },
+          "executionCount": {
+            "type": "integer"
+          },
+          "progress": {
+            "type": "number"
+          },
+          "startTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "endTime": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "ProposalRecord": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "proposalId": {
+            "type": "integer"
+          },
+          "tokenId": {
+            "type": "string"
+          },
+          "proposer": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "ACTIVE",
+              "PASSED",
+              "REJECTED",
+              "EXECUTED",
+              "CANCELLED",
+              "EXPIRED"
+            ]
+          },
+          "proposalType": {
+            "type": "string",
+            "enum": [
+              "PARAMETER_CHANGE",
+              "ADMIN_TRANSFER",
+              "TREASURY_SPEND",
+              "CONTRACT_UPGRADE",
+              "CUSTOM"
+            ]
+          },
+          "quorum": {
+            "type": "string"
+          },
+          "threshold": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "startTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "endTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "votes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GovernanceVoteRecord"
+            }
+          },
+          "executions": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          }
+        }
+      },
+      "GovernanceVoteRecord": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "voter": {
+            "type": "string"
+          },
+          "support": {
+            "type": "boolean"
+          },
+          "weight": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "StreamRecord": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "creator": {
+            "type": "string"
+          },
+          "recipient": {
+            "type": "string"
+          },
+          "tokenAddress": {
+            "type": "string"
+          },
+          "amount": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "CREATED",
+              "ACTIVE",
+              "COMPLETED",
+              "CANCELLED"
+            ]
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "VaultRecord": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "creator": {
+            "type": "string"
+          },
+          "beneficiary": {
+            "type": "string"
+          },
+          "tokenAddress": {
+            "type": "string"
+          },
+          "amount": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "CREATED",
+              "ACTIVE",
+              "COMPLETED",
+              "CANCELLED"
+            ]
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "WebhookSubscription": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "tokenAddress": {
+            "type": "string",
+            "nullable": true
+          },
+          "events": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "token.burn.self",
+                "token.burn.admin",
+                "token.created",
+                "token.metadata.updated"
+              ]
+            }
+          },
+          "secret": {
+            "type": "string"
+          },
+          "active": {
+            "type": "boolean"
+          },
+          "createdBy": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "lastTriggered": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          }
+        }
+      },
+      "HealthStatus": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "healthy",
+              "degraded",
+              "unhealthy"
+            ]
+          },
+          "uptime": {
+            "type": "number"
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "parameters": {
+      "PageParam": {
+        "name": "page",
+        "in": "query",
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "default": 1
+        }
+      },
+      "LimitParam": {
+        "name": "limit",
+        "in": "query",
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100,
+          "default": 20
+        }
+      },
+      "PeriodParam": {
+        "name": "period",
+        "in": "query",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "24h",
+            "7d",
+            "30d",
+            "all"
+          ],
+          "default": "7d"
+        }
+      },
+      "AddressParam": {
+        "name": "address",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string"
+        },
+        "description": "Stellar wallet address"
+      }
+    }
+  }
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -20,9 +20,11 @@
     "lint": "eslint src --ext .ts,.tsx",
     "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json}\"",
     "format:check": "prettier --check \"src/**/*.{ts,tsx,js,jsx,json}\"",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "docs:generate": "tsx scripts/generate-openapi.ts"
   },
   "dependencies": {
+    "@asteasolutions/zod-to-openapi": "^7.3.4",
     "@prisma/adapter-pg": "^7.5.0",
     "@prisma/client": "^5.22.0",
     "axios": "^1.13.5",
@@ -38,6 +40,7 @@
     "ioredis": "^5.10.1",
     "jsonwebtoken": "^9.0.2",
     "pg": "^8.18.0",
+    "swagger-ui-express": "^5.0.1",
     "uuid": "^13.0.0",
     "ws": "^8.20.0",
     "zod": "^3.22.4"
@@ -52,6 +55,7 @@
     "@types/node": "^20.10.6",
     "@types/pg": "^8.16.0",
     "@types/supertest": "^6.0.3",
+    "@types/swagger-ui-express": "^4.1.8",
     "@types/uuid": "^10.0.0",
     "@types/ws": "^8.18.1",
     "@vitest/coverage-v8": "^1.6.1",

--- a/backend/scripts/generate-openapi.ts
+++ b/backend/scripts/generate-openapi.ts
@@ -1,0 +1,5 @@
+import { openApiSpec } from "../src/lib/openapi/spec";
+import { writeFileSync } from "fs";
+
+writeFileSync("openapi.json", JSON.stringify(openApiSpec, null, 2));
+console.log("openapi.json written");

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -16,6 +16,7 @@ import streamRoutes from "./routes/streams";
 import vaultRoutes from "./routes/vaults";
 import versionRoutes from "./routes/version";
 import graphqlRouter from "./graphql";
+import openApiRouter from "./lib/openapi/router";
 import { Database } from "./config/database";
 import { successResponse, errorResponse } from "./utils/response";
 import { requestLoggingMiddleware } from "./middleware/request-logging.middleware";
@@ -72,6 +73,7 @@ app.use("/api/streams", streamRoutes);
 app.use("/api/vaults", vaultRoutes);
 app.use("/api/version", versionRoutes);
 app.use("/api/graphql", graphqlRouter);
+app.use("/api/docs", openApiRouter);
 
 import { healthService } from "./lib/health/health.service";
 

--- a/backend/src/lib/openapi/__tests__/spec.test.ts
+++ b/backend/src/lib/openapi/__tests__/spec.test.ts
@@ -1,0 +1,273 @@
+import { describe, it, expect } from "vitest";
+import { openApiSpec } from "../spec";
+
+describe("OpenAPI spec", () => {
+  // ---------------------------------------------------------------------------
+  // Top-level structure
+  // ---------------------------------------------------------------------------
+
+  it("has required OpenAPI 3.0 top-level fields", () => {
+    expect(openApiSpec.openapi).toBe("3.0.3");
+    expect(openApiSpec.info).toBeDefined();
+    expect(openApiSpec.paths).toBeDefined();
+    expect(openApiSpec.components).toBeDefined();
+  });
+
+  it("has valid info block", () => {
+    expect(openApiSpec.info.title).toBeTruthy();
+    expect(openApiSpec.info.version).toBeTruthy();
+  });
+
+  it("has at least one server defined", () => {
+    expect(Array.isArray(openApiSpec.servers)).toBe(true);
+    expect(openApiSpec.servers!.length).toBeGreaterThan(0);
+    expect(openApiSpec.servers![0].url).toBeTruthy();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Schemas
+  // ---------------------------------------------------------------------------
+
+  it("defines all required component schemas", () => {
+    const schemas = openApiSpec.components!.schemas!;
+    const required = [
+      "ErrorResponse",
+      "Pagination",
+      "TokenRecord",
+      "CampaignRecord",
+      "ProposalRecord",
+      "GovernanceVoteRecord",
+      "StreamRecord",
+      "VaultRecord",
+      "WebhookSubscription",
+      "HealthStatus",
+    ];
+    for (const name of required) {
+      expect(schemas[name], `Missing schema: ${name}`).toBeDefined();
+    }
+  });
+
+  it("ErrorResponse schema has success and error properties", () => {
+    const schema = openApiSpec.components!.schemas!.ErrorResponse as any;
+    expect(schema.properties.success).toBeDefined();
+    expect(schema.properties.error).toBeDefined();
+  });
+
+  it("TokenRecord schema has all expected fields", () => {
+    const schema = openApiSpec.components!.schemas!.TokenRecord as any;
+    const fields = ["id", "address", "creator", "name", "symbol", "decimals", "totalSupply", "totalBurned", "burnCount"];
+    for (const f of fields) {
+      expect(schema.properties[f], `TokenRecord missing field: ${f}`).toBeDefined();
+    }
+  });
+
+  it("ProposalRecord status enum covers all statuses", () => {
+    const schema = openApiSpec.components!.schemas!.ProposalRecord as any;
+    const statusEnum = schema.properties.status.enum;
+    expect(statusEnum).toContain("ACTIVE");
+    expect(statusEnum).toContain("PASSED");
+    expect(statusEnum).toContain("REJECTED");
+    expect(statusEnum).toContain("EXECUTED");
+    expect(statusEnum).toContain("CANCELLED");
+    expect(statusEnum).toContain("EXPIRED");
+  });
+
+  it("WebhookSubscription events enum covers all event types", () => {
+    const schema = openApiSpec.components!.schemas!.WebhookSubscription as any;
+    const eventEnum = schema.properties.events.items.enum;
+    expect(eventEnum).toContain("token.burn.self");
+    expect(eventEnum).toContain("token.burn.admin");
+    expect(eventEnum).toContain("token.created");
+    expect(eventEnum).toContain("token.metadata.updated");
+  });
+
+  // ---------------------------------------------------------------------------
+  // Parameters
+  // ---------------------------------------------------------------------------
+
+  it("defines reusable parameters", () => {
+    const params = openApiSpec.components!.parameters!;
+    expect(params.PageParam).toBeDefined();
+    expect(params.LimitParam).toBeDefined();
+    expect(params.PeriodParam).toBeDefined();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Paths — presence
+  // ---------------------------------------------------------------------------
+
+  const expectedPaths = [
+    "/health/live",
+    "/health/ready",
+    "/api/version",
+    "/api/stats",
+    "/api/tokens/search",
+    "/api/leaderboard/most-burned",
+    "/api/leaderboard/most-active",
+    "/api/leaderboard/newest",
+    "/api/leaderboard/largest-supply",
+    "/api/leaderboard/most-burners",
+    "/api/governance/proposals",
+    "/api/governance/proposals/{id}",
+    "/api/governance/proposals/{id}/votes",
+    "/api/campaigns/stats/{tokenId}",
+    "/api/campaigns/token/{tokenId}",
+    "/api/campaigns/creator/{creator}",
+    "/api/campaigns/{campaignId}",
+    "/api/campaigns/{campaignId}/executions",
+    "/api/streams/stats/{address}",
+    "/api/streams/creator/{address}",
+    "/api/streams/recipient/{address}",
+    "/api/streams/{id}",
+    "/api/vaults/creator/{address}",
+    "/api/vaults/beneficiary/{address}",
+    "/api/vaults/{id}",
+    "/api/webhooks/subscribe",
+    "/api/webhooks/unsubscribe/{id}",
+    "/api/webhooks/subscriptions",
+    "/api/webhooks/{id}/toggle",
+    "/api/webhooks/{id}/logs",
+    "/api/webhooks/{id}/test",
+  ];
+
+  it("documents all expected API paths", () => {
+    for (const path of expectedPaths) {
+      expect(openApiSpec.paths![path], `Missing path: ${path}`).toBeDefined();
+    }
+  });
+
+  it("has no path without at least one HTTP method", () => {
+    const methods = ["get", "post", "put", "patch", "delete", "options", "head"];
+    for (const [path, item] of Object.entries(openApiSpec.paths!)) {
+      const hasMethods = methods.some((m) => (item as any)[m]);
+      expect(hasMethods, `Path ${path} has no HTTP methods`).toBe(true);
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // Paths — HTTP methods
+  // ---------------------------------------------------------------------------
+
+  it("health/live uses GET", () => {
+    expect((openApiSpec.paths!["/health/live"] as any).get).toBeDefined();
+  });
+
+  it("tokens/search uses GET", () => {
+    expect((openApiSpec.paths!["/api/tokens/search"] as any).get).toBeDefined();
+  });
+
+  it("webhooks/subscribe uses POST", () => {
+    expect((openApiSpec.paths!["/api/webhooks/subscribe"] as any).post).toBeDefined();
+  });
+
+  it("webhooks/unsubscribe uses DELETE", () => {
+    expect((openApiSpec.paths!["/api/webhooks/unsubscribe/{id}"] as any).delete).toBeDefined();
+  });
+
+  it("webhooks toggle uses PATCH", () => {
+    expect((openApiSpec.paths!["/api/webhooks/{id}/toggle"] as any).patch).toBeDefined();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Paths — tags
+  // ---------------------------------------------------------------------------
+
+  it("every operation has at least one tag", () => {
+    const methods = ["get", "post", "put", "patch", "delete"];
+    for (const [path, item] of Object.entries(openApiSpec.paths!)) {
+      for (const method of methods) {
+        const op = (item as any)[method];
+        if (op) {
+          expect(Array.isArray(op.tags) && op.tags.length > 0, `${method.toUpperCase()} ${path} has no tags`).toBe(true);
+        }
+      }
+    }
+  });
+
+  it("every operation has a summary", () => {
+    const methods = ["get", "post", "put", "patch", "delete"];
+    for (const [path, item] of Object.entries(openApiSpec.paths!)) {
+      for (const method of methods) {
+        const op = (item as any)[method];
+        if (op) {
+          expect(typeof op.summary === "string" && op.summary.length > 0, `${method.toUpperCase()} ${path} has no summary`).toBe(true);
+        }
+      }
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // Paths — responses
+  // ---------------------------------------------------------------------------
+
+  it("every operation defines at least one response", () => {
+    const methods = ["get", "post", "put", "patch", "delete"];
+    for (const [path, item] of Object.entries(openApiSpec.paths!)) {
+      for (const method of methods) {
+        const op = (item as any)[method];
+        if (op) {
+          expect(op.responses && Object.keys(op.responses).length > 0, `${method.toUpperCase()} ${path} has no responses`).toBe(true);
+        }
+      }
+    }
+  });
+
+  it("tokens/search documents a 400 error response", () => {
+    const op = (openApiSpec.paths!["/api/tokens/search"] as any).get;
+    expect(op.responses["400"]).toBeDefined();
+  });
+
+  it("governance proposals/{id} documents a 404 response", () => {
+    const op = (openApiSpec.paths!["/api/governance/proposals/{id}"] as any).get;
+    expect(op.responses["404"]).toBeDefined();
+  });
+
+  // ---------------------------------------------------------------------------
+  // $ref integrity — all $refs point to defined schemas/parameters
+  // ---------------------------------------------------------------------------
+
+  function collectRefs(obj: unknown, refs: Set<string> = new Set()): Set<string> {
+    if (typeof obj !== "object" || obj === null) return refs;
+    for (const [key, val] of Object.entries(obj as Record<string, unknown>)) {
+      if (key === "$ref" && typeof val === "string") {
+        refs.add(val);
+      } else {
+        collectRefs(val, refs);
+      }
+    }
+    return refs;
+  }
+
+  it("all $ref values resolve within the spec", () => {
+    const refs = collectRefs(openApiSpec.paths);
+    for (const ref of refs) {
+      // e.g. "#/components/schemas/TokenRecord" → ["components","schemas","TokenRecord"]
+      const parts = ref.replace("#/", "").split("/");
+      let node: any = openApiSpec;
+      for (const part of parts) {
+        expect(node, `$ref ${ref} — segment "${part}" not found`).toBeDefined();
+        node = node[part];
+      }
+      expect(node, `$ref ${ref} does not resolve`).toBeDefined();
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // Tags
+  // ---------------------------------------------------------------------------
+
+  it("all tags used in operations are declared at the top level", () => {
+    const declaredTags = new Set((openApiSpec.tags ?? []).map((t: any) => t.name));
+    const methods = ["get", "post", "put", "patch", "delete"];
+    for (const [path, item] of Object.entries(openApiSpec.paths!)) {
+      for (const method of methods) {
+        const op = (item as any)[method];
+        if (op?.tags) {
+          for (const tag of op.tags) {
+            expect(declaredTags.has(tag), `Tag "${tag}" used in ${method.toUpperCase()} ${path} but not declared`).toBe(true);
+          }
+        }
+      }
+    }
+  });
+});

--- a/backend/src/lib/openapi/router.ts
+++ b/backend/src/lib/openapi/router.ts
@@ -1,0 +1,26 @@
+/**
+ * OpenAPI router — serves:
+ *   GET /api/docs        → Swagger UI
+ *   GET /api/docs/json   → Raw OpenAPI JSON spec
+ */
+
+import { Router } from "express";
+import swaggerUi from "swagger-ui-express";
+import { openApiSpec } from "./spec";
+
+const router = Router();
+
+// Serve raw JSON spec
+router.get("/json", (_req, res) => {
+  res.setHeader("Content-Type", "application/json");
+  res.json(openApiSpec);
+});
+
+// Serve Swagger UI
+router.use("/", swaggerUi.serve);
+router.get("/", swaggerUi.setup(openApiSpec, {
+  customSiteTitle: "Nova Launch API Docs",
+  swaggerOptions: { persistAuthorization: true },
+}));
+
+export default router;

--- a/backend/src/lib/openapi/spec.ts
+++ b/backend/src/lib/openapi/spec.ts
@@ -1,0 +1,724 @@
+/**
+ * OpenAPI 3.0 specification for the Nova Launch backend API.
+ * Source of truth for all endpoint documentation.
+ */
+
+import type { OpenAPIObject } from "openapi3-ts/oas30";
+
+// ---------------------------------------------------------------------------
+// Reusable schemas
+// ---------------------------------------------------------------------------
+
+const schemas = {
+  ErrorResponse: {
+    type: "object",
+    properties: {
+      success: { type: "boolean", example: false },
+      error: { type: "string" },
+      message: { type: "string" },
+    },
+    required: ["success", "error"],
+  },
+
+  Pagination: {
+    type: "object",
+    properties: {
+      page: { type: "integer", example: 1 },
+      limit: { type: "integer", example: 20 },
+      total: { type: "integer", example: 100 },
+      totalPages: { type: "integer", example: 5 },
+      hasNext: { type: "boolean" },
+      hasPrev: { type: "boolean" },
+    },
+  },
+
+  TokenRecord: {
+    type: "object",
+    properties: {
+      id: { type: "string" },
+      address: { type: "string" },
+      creator: { type: "string" },
+      name: { type: "string" },
+      symbol: { type: "string" },
+      decimals: { type: "integer" },
+      totalSupply: { type: "string", description: "BigInt as string" },
+      initialSupply: { type: "string", description: "BigInt as string" },
+      totalBurned: { type: "string", description: "BigInt as string" },
+      burnCount: { type: "integer" },
+      metadataUri: { type: "string", nullable: true },
+      createdAt: { type: "string", format: "date-time" },
+      updatedAt: { type: "string", format: "date-time" },
+    },
+  },
+
+  CampaignRecord: {
+    type: "object",
+    properties: {
+      id: { type: "string" },
+      campaignId: { type: "integer" },
+      tokenId: { type: "string" },
+      creator: { type: "string" },
+      type: { type: "string" },
+      status: { type: "string" },
+      targetAmount: { type: "string" },
+      currentAmount: { type: "string" },
+      executionCount: { type: "integer" },
+      progress: { type: "number" },
+      startTime: { type: "string", format: "date-time" },
+      endTime: { type: "string", format: "date-time", nullable: true },
+      createdAt: { type: "string", format: "date-time" },
+      updatedAt: { type: "string", format: "date-time" },
+    },
+  },
+
+  ProposalRecord: {
+    type: "object",
+    properties: {
+      id: { type: "string" },
+      proposalId: { type: "integer" },
+      tokenId: { type: "string" },
+      proposer: { type: "string" },
+      status: {
+        type: "string",
+        enum: ["ACTIVE", "PASSED", "REJECTED", "EXECUTED", "CANCELLED", "EXPIRED"],
+      },
+      proposalType: {
+        type: "string",
+        enum: ["PARAMETER_CHANGE", "ADMIN_TRANSFER", "TREASURY_SPEND", "CONTRACT_UPGRADE", "CUSTOM"],
+      },
+      quorum: { type: "string" },
+      threshold: { type: "string" },
+      createdAt: { type: "string", format: "date-time" },
+      startTime: { type: "string", format: "date-time" },
+      endTime: { type: "string", format: "date-time" },
+      votes: { type: "array", items: { $ref: "#/components/schemas/GovernanceVoteRecord" } },
+      executions: { type: "array", items: { type: "object" } },
+    },
+  },
+
+  GovernanceVoteRecord: {
+    type: "object",
+    properties: {
+      id: { type: "string" },
+      voter: { type: "string" },
+      support: { type: "boolean" },
+      weight: { type: "string" },
+      timestamp: { type: "string", format: "date-time" },
+    },
+  },
+
+  StreamRecord: {
+    type: "object",
+    properties: {
+      id: { type: "integer" },
+      creator: { type: "string" },
+      recipient: { type: "string" },
+      tokenAddress: { type: "string" },
+      amount: { type: "string" },
+      status: { type: "string", enum: ["CREATED", "ACTIVE", "COMPLETED", "CANCELLED"] },
+      createdAt: { type: "string", format: "date-time" },
+    },
+  },
+
+  VaultRecord: {
+    type: "object",
+    properties: {
+      id: { type: "integer" },
+      creator: { type: "string" },
+      beneficiary: { type: "string" },
+      tokenAddress: { type: "string" },
+      amount: { type: "string" },
+      status: { type: "string", enum: ["CREATED", "ACTIVE", "COMPLETED", "CANCELLED"] },
+      createdAt: { type: "string", format: "date-time" },
+    },
+  },
+
+  WebhookSubscription: {
+    type: "object",
+    properties: {
+      id: { type: "string" },
+      url: { type: "string", format: "uri" },
+      tokenAddress: { type: "string", nullable: true },
+      events: {
+        type: "array",
+        items: {
+          type: "string",
+          enum: ["token.burn.self", "token.burn.admin", "token.created", "token.metadata.updated"],
+        },
+      },
+      secret: { type: "string" },
+      active: { type: "boolean" },
+      createdBy: { type: "string" },
+      createdAt: { type: "string", format: "date-time" },
+      lastTriggered: { type: "string", format: "date-time", nullable: true },
+    },
+  },
+
+  HealthStatus: {
+    type: "object",
+    properties: {
+      status: { type: "string", enum: ["healthy", "degraded", "unhealthy"] },
+      uptime: { type: "number" },
+      timestamp: { type: "string", format: "date-time" },
+    },
+  },
+} as const;
+
+// ---------------------------------------------------------------------------
+// Reusable parameters
+// ---------------------------------------------------------------------------
+
+const parameters = {
+  PageParam: {
+    name: "page",
+    in: "query",
+    schema: { type: "integer", minimum: 1, default: 1 },
+  },
+  LimitParam: {
+    name: "limit",
+    in: "query",
+    schema: { type: "integer", minimum: 1, maximum: 100, default: 20 },
+  },
+  PeriodParam: {
+    name: "period",
+    in: "query",
+    schema: { type: "string", enum: ["24h", "7d", "30d", "all"], default: "7d" },
+  },
+  AddressParam: {
+    name: "address",
+    in: "path",
+    required: true,
+    schema: { type: "string" },
+    description: "Stellar wallet address",
+  },
+} as const;
+
+// ---------------------------------------------------------------------------
+// Paths
+// ---------------------------------------------------------------------------
+
+const paths: OpenAPIObject["paths"] = {
+  // Health
+  "/health/live": {
+    get: {
+      tags: ["Health"],
+      summary: "Liveness probe",
+      description: "Returns 200 as long as the process is running.",
+      responses: {
+        "200": {
+          description: "Process is alive",
+          content: { "application/json": { schema: { $ref: "#/components/schemas/HealthStatus" } } },
+        },
+      },
+    },
+  },
+  "/health/ready": {
+    get: {
+      tags: ["Health"],
+      summary: "Readiness probe",
+      description: "Checks all dependency connections.",
+      responses: {
+        "200": { description: "All dependencies healthy" },
+        "207": { description: "Degraded — some dependencies unreachable" },
+        "503": { description: "Unhealthy" },
+      },
+    },
+  },
+
+  // Version
+  "/api/version": {
+    get: {
+      tags: ["Version"],
+      summary: "Backend version info",
+      responses: {
+        "200": {
+          description: "Version details",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  backendVersion: { type: "string" },
+                  contractId: { type: "string" },
+                  network: { type: "string" },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+
+  // Stats
+  "/api/stats": {
+    get: {
+      tags: ["Stats"],
+      summary: "Platform statistics",
+      responses: {
+        "200": {
+          description: "Platform stats",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  totalTokens: { type: "integer" },
+                  totalUsers: { type: "integer" },
+                  totalBurned: { type: "string" },
+                  uptime: { type: "string" },
+                  lastUpdated: { type: "string", format: "date-time" },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+
+  // Tokens
+  "/api/tokens/search": {
+    get: {
+      tags: ["Tokens"],
+      summary: "Search and filter tokens",
+      parameters: [
+        { name: "q", in: "query", schema: { type: "string" }, description: "Search by name or symbol" },
+        { name: "creator", in: "query", schema: { type: "string" } },
+        { name: "startDate", in: "query", schema: { type: "string", format: "date-time" } },
+        { name: "endDate", in: "query", schema: { type: "string", format: "date-time" } },
+        { name: "minSupply", in: "query", schema: { type: "string" } },
+        { name: "maxSupply", in: "query", schema: { type: "string" } },
+        { name: "hasBurns", in: "query", schema: { type: "string", enum: ["true", "false"] } },
+        { name: "sortBy", in: "query", schema: { type: "string", enum: ["created", "burned", "supply", "name"], default: "created" } },
+        { name: "sortOrder", in: "query", schema: { type: "string", enum: ["asc", "desc"], default: "desc" } },
+        { name: "page", in: "query", schema: { type: "integer", default: 1 } },
+        { name: "limit", in: "query", schema: { type: "integer", default: 20, maximum: 50 } },
+      ],
+      responses: {
+        "200": {
+          description: "Token search results",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  success: { type: "boolean" },
+                  data: { type: "array", items: { $ref: "#/components/schemas/TokenRecord" } },
+                  pagination: { $ref: "#/components/schemas/Pagination" },
+                  cached: { type: "boolean" },
+                },
+              },
+            },
+          },
+        },
+        "400": { description: "Invalid parameters", content: { "application/json": { schema: { $ref: "#/components/schemas/ErrorResponse" } } } },
+      },
+    },
+  },
+
+  // Leaderboard
+  "/api/leaderboard/most-burned": {
+    get: {
+      tags: ["Leaderboard"],
+      summary: "Tokens with highest burn volume",
+      parameters: [
+        { $ref: "#/components/parameters/PeriodParam" },
+        { $ref: "#/components/parameters/PageParam" },
+        { $ref: "#/components/parameters/LimitParam" },
+      ],
+      responses: {
+        "200": { description: "Leaderboard results" },
+        "500": { description: "Server error", content: { "application/json": { schema: { $ref: "#/components/schemas/ErrorResponse" } } } },
+      },
+    },
+  },
+  "/api/leaderboard/most-active": {
+    get: {
+      tags: ["Leaderboard"],
+      summary: "Tokens with most burn transactions",
+      parameters: [
+        { $ref: "#/components/parameters/PeriodParam" },
+        { $ref: "#/components/parameters/PageParam" },
+        { $ref: "#/components/parameters/LimitParam" },
+      ],
+      responses: { "200": { description: "Leaderboard results" } },
+    },
+  },
+  "/api/leaderboard/newest": {
+    get: {
+      tags: ["Leaderboard"],
+      summary: "Recently created tokens",
+      parameters: [
+        { $ref: "#/components/parameters/PageParam" },
+        { $ref: "#/components/parameters/LimitParam" },
+      ],
+      responses: { "200": { description: "Leaderboard results" } },
+    },
+  },
+  "/api/leaderboard/largest-supply": {
+    get: {
+      tags: ["Leaderboard"],
+      summary: "Tokens with highest total supply",
+      parameters: [
+        { $ref: "#/components/parameters/PageParam" },
+        { $ref: "#/components/parameters/LimitParam" },
+      ],
+      responses: { "200": { description: "Leaderboard results" } },
+    },
+  },
+  "/api/leaderboard/most-burners": {
+    get: {
+      tags: ["Leaderboard"],
+      summary: "Tokens with most unique burners",
+      parameters: [
+        { $ref: "#/components/parameters/PeriodParam" },
+        { $ref: "#/components/parameters/PageParam" },
+        { $ref: "#/components/parameters/LimitParam" },
+      ],
+      responses: { "200": { description: "Leaderboard results" } },
+    },
+  },
+
+  // Governance
+  "/api/governance/proposals": {
+    get: {
+      tags: ["Governance"],
+      summary: "List governance proposals",
+      parameters: [
+        { name: "status", in: "query", schema: { type: "string", enum: ["ACTIVE", "PASSED", "REJECTED", "EXECUTED", "CANCELLED", "EXPIRED"] } },
+        { name: "proposalType", in: "query", schema: { type: "string", enum: ["PARAMETER_CHANGE", "ADMIN_TRANSFER", "TREASURY_SPEND", "CONTRACT_UPGRADE", "CUSTOM"] } },
+        { name: "tokenId", in: "query", schema: { type: "string" } },
+        { name: "proposer", in: "query", schema: { type: "string" } },
+        { name: "limit", in: "query", schema: { type: "integer", default: 50, maximum: 100 } },
+        { name: "offset", in: "query", schema: { type: "integer", default: 0 } },
+        { name: "sortBy", in: "query", schema: { type: "string", enum: ["createdAt", "startTime", "endTime"], default: "createdAt" } },
+        { name: "sortOrder", in: "query", schema: { type: "string", enum: ["asc", "desc"], default: "desc" } },
+      ],
+      responses: {
+        "200": {
+          description: "List of proposals",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  success: { type: "boolean" },
+                  data: {
+                    type: "object",
+                    properties: {
+                      proposals: { type: "array", items: { $ref: "#/components/schemas/ProposalRecord" } },
+                      total: { type: "integer" },
+                      limit: { type: "integer" },
+                      offset: { type: "integer" },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  "/api/governance/proposals/{id}": {
+    get: {
+      tags: ["Governance"],
+      summary: "Get proposal by ID",
+      parameters: [{ name: "id", in: "path", required: true, schema: { type: "string" } }],
+      responses: {
+        "200": { description: "Proposal detail" },
+        "404": { description: "Not found", content: { "application/json": { schema: { $ref: "#/components/schemas/ErrorResponse" } } } },
+      },
+    },
+  },
+  "/api/governance/proposals/{id}/votes": {
+    get: {
+      tags: ["Governance"],
+      summary: "Get votes for a proposal",
+      parameters: [
+        { name: "id", in: "path", required: true, schema: { type: "string" } },
+        { name: "limit", in: "query", schema: { type: "integer", default: 50 } },
+        { name: "offset", in: "query", schema: { type: "integer", default: 0 } },
+      ],
+      responses: {
+        "200": {
+          description: "Votes list",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  success: { type: "boolean" },
+                  data: {
+                    type: "object",
+                    properties: {
+                      votes: { type: "array", items: { $ref: "#/components/schemas/GovernanceVoteRecord" } },
+                      total: { type: "integer" },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+
+  // Campaigns
+  "/api/campaigns/stats/{tokenId}": {
+    get: {
+      tags: ["Campaigns"],
+      summary: "Campaign statistics for a token (or global)",
+      parameters: [{ name: "tokenId", in: "path", required: false, schema: { type: "string" } }],
+      responses: { "200": { description: "Campaign stats" } },
+    },
+  },
+  "/api/campaigns/token/{tokenId}": {
+    get: {
+      tags: ["Campaigns"],
+      summary: "Campaigns for a token",
+      parameters: [{ name: "tokenId", in: "path", required: true, schema: { type: "string" } }],
+      responses: {
+        "200": {
+          description: "Campaign list",
+          content: { "application/json": { schema: { type: "array", items: { $ref: "#/components/schemas/CampaignRecord" } } } },
+        },
+      },
+    },
+  },
+  "/api/campaigns/creator/{creator}": {
+    get: {
+      tags: ["Campaigns"],
+      summary: "Campaigns by creator address",
+      parameters: [{ name: "creator", in: "path", required: true, schema: { type: "string" } }],
+      responses: { "200": { description: "Campaign list" } },
+    },
+  },
+  "/api/campaigns/{campaignId}": {
+    get: {
+      tags: ["Campaigns"],
+      summary: "Get campaign by ID",
+      parameters: [{ name: "campaignId", in: "path", required: true, schema: { type: "integer" } }],
+      responses: {
+        "200": { description: "Campaign detail" },
+        "404": { description: "Not found" },
+      },
+    },
+  },
+  "/api/campaigns/{campaignId}/executions": {
+    get: {
+      tags: ["Campaigns"],
+      summary: "Execution history for a campaign",
+      parameters: [
+        { name: "campaignId", in: "path", required: true, schema: { type: "integer" } },
+        { name: "limit", in: "query", schema: { type: "integer", default: 50 } },
+        { name: "offset", in: "query", schema: { type: "integer", default: 0 } },
+      ],
+      responses: { "200": { description: "Execution history" } },
+    },
+  },
+
+  // Streams
+  "/api/streams/stats/{address}": {
+    get: {
+      tags: ["Streams"],
+      summary: "Stream statistics for an address or global",
+      parameters: [{ name: "address", in: "path", required: false, schema: { type: "string" } }],
+      responses: { "200": { description: "Stream stats" } },
+    },
+  },
+  "/api/streams/creator/{address}": {
+    get: {
+      tags: ["Streams"],
+      summary: "Streams created by address",
+      parameters: [
+        { name: "address", in: "path", required: true, schema: { type: "string" } },
+        { name: "status", in: "query", schema: { type: "string", enum: ["CREATED", "ACTIVE", "COMPLETED", "CANCELLED"] } },
+        { name: "limit", in: "query", schema: { type: "integer", default: 50 } },
+        { name: "offset", in: "query", schema: { type: "integer", default: 0 } },
+      ],
+      responses: { "200": { description: "Stream list" } },
+    },
+  },
+  "/api/streams/recipient/{address}": {
+    get: {
+      tags: ["Streams"],
+      summary: "Streams where address is the recipient",
+      parameters: [
+        { name: "address", in: "path", required: true, schema: { type: "string" } },
+        { name: "status", in: "query", schema: { type: "string" } },
+        { name: "limit", in: "query", schema: { type: "integer", default: 50 } },
+        { name: "offset", in: "query", schema: { type: "integer", default: 0 } },
+      ],
+      responses: { "200": { description: "Stream list" } },
+    },
+  },
+  "/api/streams/{id}": {
+    get: {
+      tags: ["Streams"],
+      summary: "Get stream by on-chain ID",
+      parameters: [{ name: "id", in: "path", required: true, schema: { type: "integer" } }],
+      responses: {
+        "200": { description: "Stream detail" },
+        "404": { description: "Not found" },
+      },
+    },
+  },
+
+  // Vaults
+  "/api/vaults/creator/{address}": {
+    get: {
+      tags: ["Vaults"],
+      summary: "Vaults created by address",
+      parameters: [
+        { name: "address", in: "path", required: true, schema: { type: "string" } },
+        { name: "status", in: "query", schema: { type: "string" } },
+        { name: "limit", in: "query", schema: { type: "integer", default: 50 } },
+        { name: "offset", in: "query", schema: { type: "integer", default: 0 } },
+      ],
+      responses: { "200": { description: "Vault list" } },
+    },
+  },
+  "/api/vaults/beneficiary/{address}": {
+    get: {
+      tags: ["Vaults"],
+      summary: "Vaults where address is the beneficiary",
+      parameters: [
+        { name: "address", in: "path", required: true, schema: { type: "string" } },
+        { name: "status", in: "query", schema: { type: "string" } },
+        { name: "limit", in: "query", schema: { type: "integer", default: 50 } },
+        { name: "offset", in: "query", schema: { type: "integer", default: 0 } },
+      ],
+      responses: { "200": { description: "Vault list" } },
+    },
+  },
+  "/api/vaults/{id}": {
+    get: {
+      tags: ["Vaults"],
+      summary: "Get vault by on-chain ID",
+      parameters: [{ name: "id", in: "path", required: true, schema: { type: "integer" } }],
+      responses: {
+        "200": { description: "Vault detail" },
+        "404": { description: "Not found" },
+      },
+    },
+  },
+
+  // Webhooks
+  "/api/webhooks/subscribe": {
+    post: {
+      tags: ["Webhooks"],
+      summary: "Create a webhook subscription",
+      requestBody: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: {
+              type: "object",
+              required: ["url", "events", "createdBy"],
+              properties: {
+                url: { type: "string", format: "uri" },
+                tokenAddress: { type: "string", nullable: true },
+                events: {
+                  type: "array",
+                  items: { type: "string", enum: ["token.burn.self", "token.burn.admin", "token.created", "token.metadata.updated"] },
+                },
+                createdBy: { type: "string" },
+              },
+            },
+          },
+        },
+      },
+      responses: {
+        "201": {
+          description: "Subscription created",
+          content: { "application/json": { schema: { $ref: "#/components/schemas/WebhookSubscription" } } },
+        },
+        "400": { description: "Invalid input" },
+      },
+    },
+  },
+  "/api/webhooks/unsubscribe/{id}": {
+    delete: {
+      tags: ["Webhooks"],
+      summary: "Delete a webhook subscription",
+      parameters: [{ name: "id", in: "path", required: true, schema: { type: "string" } }],
+      responses: {
+        "200": { description: "Deleted successfully" },
+        "404": { description: "Not found" },
+      },
+    },
+  },
+  "/api/webhooks/subscriptions": {
+    get: {
+      tags: ["Webhooks"],
+      summary: "List webhook subscriptions",
+      parameters: [{ name: "createdBy", in: "query", required: true, schema: { type: "string" } }],
+      responses: { "200": { description: "Subscription list" } },
+    },
+  },
+  "/api/webhooks/{id}/toggle": {
+    patch: {
+      tags: ["Webhooks"],
+      summary: "Toggle webhook active state",
+      parameters: [{ name: "id", in: "path", required: true, schema: { type: "string" } }],
+      responses: { "200": { description: "Toggled" } },
+    },
+  },
+  "/api/webhooks/{id}/logs": {
+    get: {
+      tags: ["Webhooks"],
+      summary: "Delivery logs for a webhook",
+      parameters: [{ name: "id", in: "path", required: true, schema: { type: "string" } }],
+      responses: { "200": { description: "Delivery logs" } },
+    },
+  },
+  "/api/webhooks/{id}/test": {
+    post: {
+      tags: ["Webhooks"],
+      summary: "Send a test event to a webhook",
+      parameters: [{ name: "id", in: "path", required: true, schema: { type: "string" } }],
+      responses: { "200": { description: "Test result" } },
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Full spec
+// ---------------------------------------------------------------------------
+
+export const openApiSpec: OpenAPIObject = {
+  openapi: "3.0.3",
+  info: {
+    title: "Nova Launch API",
+    version: "1.0.0",
+    description: "REST API for the Nova Launch Stellar token deployment platform.",
+    contact: { name: "Nova Launch", url: "https://github.com/Emmyt24/Nova-launch" },
+    license: { name: "MIT" },
+  },
+  servers: [
+    { url: "http://localhost:3000", description: "Local development" },
+    { url: "https://api.nova-launch.app", description: "Production" },
+  ],
+  tags: [
+    { name: "Health", description: "Liveness and readiness probes" },
+    { name: "Version", description: "Backend version info" },
+    { name: "Stats", description: "Platform statistics" },
+    { name: "Tokens", description: "Token search and discovery" },
+    { name: "Leaderboard", description: "Token leaderboards" },
+    { name: "Governance", description: "On-chain governance proposals" },
+    { name: "Campaigns", description: "Token campaigns" },
+    { name: "Streams", description: "Token streams" },
+    { name: "Vaults", description: "Token vaults" },
+    { name: "Webhooks", description: "Webhook subscriptions and delivery" },
+  ],
+  paths,
+  components: {
+    schemas: schemas as unknown as OpenAPIObject["components"]["schemas"],
+    parameters: parameters as unknown as OpenAPIObject["components"]["parameters"],
+  },
+};
+
+export default openApiSpec;

--- a/backend/src/middleware/__tests__/validation.campaign.test.ts
+++ b/backend/src/middleware/__tests__/validation.campaign.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import request from "supertest";
+import express from "express";
+import campaignRoutes from "../../routes/campaigns";
+
+// Prevent real DB calls
+vi.mock("../../../src/services/campaignProjectionService", () => ({
+  campaignProjectionService: {
+    getCampaignById: vi.fn().mockResolvedValue(null),
+    getExecutionHistory: vi.fn().mockResolvedValue({ executions: [], total: 0 }),
+    getCampaignStats: vi.fn().mockResolvedValue({}),
+    getCampaignsByToken: vi.fn().mockResolvedValue([]),
+    getCampaignsByCreator: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+vi.mock("../../../src/services/campaignEventParser", () => ({
+  campaignEventParser: {
+    parseCampaignCreated: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+const app = express();
+app.use(express.json());
+app.use("/api/campaigns", campaignRoutes);
+
+const VALID_STELLAR = "GTOKEN123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ123456789ABCDEF";
+
+const validBody = {
+  tokenId: "token-abc",
+  creator: VALID_STELLAR,
+  type: "BUYBACK",
+  targetAmount: "1000000",
+  startTime: "2026-05-01T00:00:00.000Z",
+};
+
+describe("POST /api/campaigns — validateCampaignCreate", () => {
+  it("accepts a valid campaign creation request", async () => {
+    const res = await request(app).post("/api/campaigns").send(validBody);
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+  });
+
+  it("rejects missing tokenId", async () => {
+    const { tokenId: _, ...body } = validBody;
+    const res = await request(app).post("/api/campaigns").send(body);
+    expect(res.status).toBe(400);
+    expect(res.body.errors).toEqual(expect.arrayContaining([
+      expect.objectContaining({ path: "tokenId" }),
+    ]));
+  });
+
+  it("rejects missing creator", async () => {
+    const { creator: _, ...body } = validBody;
+    const res = await request(app).post("/api/campaigns").send(body);
+    expect(res.status).toBe(400);
+    expect(res.body.errors).toEqual(expect.arrayContaining([
+      expect.objectContaining({ path: "creator" }),
+    ]));
+  });
+
+  it("rejects invalid Stellar address for creator", async () => {
+    const res = await request(app).post("/api/campaigns").send({ ...validBody, creator: "not-a-stellar-address" });
+    expect(res.status).toBe(400);
+    expect(res.body.errors[0].msg).toMatch(/Stellar address/);
+  });
+
+  it("rejects missing type", async () => {
+    const { type: _, ...body } = validBody;
+    const res = await request(app).post("/api/campaigns").send(body);
+    expect(res.status).toBe(400);
+    expect(res.body.errors).toEqual(expect.arrayContaining([
+      expect.objectContaining({ path: "type" }),
+    ]));
+  });
+
+  it("rejects invalid campaign type", async () => {
+    const res = await request(app).post("/api/campaigns").send({ ...validBody, type: "INVALID" });
+    expect(res.status).toBe(400);
+    expect(res.body.errors[0].msg).toMatch(/BUYBACK|AIRDROP|LIQUIDITY/);
+  });
+
+  it("accepts all valid campaign types", async () => {
+    for (const type of ["BUYBACK", "AIRDROP", "LIQUIDITY"]) {
+      const res = await request(app).post("/api/campaigns").send({ ...validBody, type });
+      expect(res.status).toBe(201);
+    }
+  });
+
+  it("rejects missing targetAmount", async () => {
+    const { targetAmount: _, ...body } = validBody;
+    const res = await request(app).post("/api/campaigns").send(body);
+    expect(res.status).toBe(400);
+    expect(res.body.errors).toEqual(expect.arrayContaining([
+      expect.objectContaining({ path: "targetAmount" }),
+    ]));
+  });
+
+  it("rejects non-integer targetAmount", async () => {
+    const res = await request(app).post("/api/campaigns").send({ ...validBody, targetAmount: "100.5" });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects zero targetAmount", async () => {
+    const res = await request(app).post("/api/campaigns").send({ ...validBody, targetAmount: "0" });
+    expect(res.status).toBe(400);
+    expect(res.body.errors[0].msg).toMatch(/greater than zero/);
+  });
+
+  it("rejects negative targetAmount", async () => {
+    const res = await request(app).post("/api/campaigns").send({ ...validBody, targetAmount: "-100" });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects missing startTime", async () => {
+    const { startTime: _, ...body } = validBody;
+    const res = await request(app).post("/api/campaigns").send(body);
+    expect(res.status).toBe(400);
+    expect(res.body.errors).toEqual(expect.arrayContaining([
+      expect.objectContaining({ path: "startTime" }),
+    ]));
+  });
+
+  it("rejects invalid startTime format", async () => {
+    const res = await request(app).post("/api/campaigns").send({ ...validBody, startTime: "not-a-date" });
+    expect(res.status).toBe(400);
+  });
+
+  it("accepts optional endTime after startTime", async () => {
+    const res = await request(app).post("/api/campaigns").send({
+      ...validBody,
+      endTime: "2026-06-01T00:00:00.000Z",
+    });
+    expect(res.status).toBe(201);
+  });
+
+  it("rejects endTime before startTime", async () => {
+    const res = await request(app).post("/api/campaigns").send({
+      ...validBody,
+      endTime: "2025-01-01T00:00:00.000Z",
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.errors[0].msg).toMatch(/after startTime/);
+  });
+
+  it("rejects endTime equal to startTime", async () => {
+    const res = await request(app).post("/api/campaigns").send({
+      ...validBody,
+      endTime: validBody.startTime,
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("accepts optional metadata within limit", async () => {
+    const res = await request(app).post("/api/campaigns").send({
+      ...validBody,
+      metadata: "some metadata",
+    });
+    expect(res.status).toBe(201);
+  });
+
+  it("rejects metadata exceeding 1024 characters", async () => {
+    const res = await request(app).post("/api/campaigns").send({
+      ...validBody,
+      metadata: "x".repeat(1025),
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.errors[0].msg).toMatch(/1024/);
+  });
+
+  it("rejects non-string metadata", async () => {
+    const res = await request(app).post("/api/campaigns").send({
+      ...validBody,
+      metadata: 12345,
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("GET /api/campaigns/:campaignId — validateCampaignId", () => {
+  it("accepts a valid integer campaignId", async () => {
+    const res = await request(app).get("/api/campaigns/42");
+    expect(res.status).toBe(404); // not found in mock, but validation passed
+  });
+
+  it("rejects a non-integer campaignId", async () => {
+    const res = await request(app).get("/api/campaigns/abc");
+    expect(res.status).toBe(400);
+    expect(res.body.errors).toEqual(expect.arrayContaining([
+      expect.objectContaining({ path: "campaignId" }),
+    ]));
+  });
+
+  it("rejects zero as campaignId", async () => {
+    const res = await request(app).get("/api/campaigns/0");
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects negative campaignId", async () => {
+    const res = await request(app).get("/api/campaigns/-1");
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("GET /api/campaigns/:campaignId/executions — validateCampaignExecutionQuery", () => {
+  it("accepts valid campaignId with no query params", async () => {
+    const res = await request(app).get("/api/campaigns/1/executions");
+    expect(res.status).toBe(200);
+  });
+
+  it("accepts valid limit and offset", async () => {
+    const res = await request(app).get("/api/campaigns/1/executions?limit=10&offset=0");
+    expect(res.status).toBe(200);
+  });
+
+  it("rejects limit above 200", async () => {
+    const res = await request(app).get("/api/campaigns/1/executions?limit=201");
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects limit of zero", async () => {
+    const res = await request(app).get("/api/campaigns/1/executions?limit=0");
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects negative offset", async () => {
+    const res = await request(app).get("/api/campaigns/1/executions?offset=-1");
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects non-integer campaignId", async () => {
+    const res = await request(app).get("/api/campaigns/abc/executions");
+    expect(res.status).toBe(400);
+  });
+});

--- a/backend/src/middleware/validation.ts
+++ b/backend/src/middleware/validation.ts
@@ -1,7 +1,10 @@
-import { body, param, validationResult } from "express-validator";
+import { body, param, query, validationResult } from "express-validator";
 import { Request, Response, NextFunction } from "express";
 import { WebhookEventType } from "../types/webhook";
 import { isValidUrl, isValidStellarAddress } from "../utils/crypto";
+
+/** Valid campaign types as defined by the on-chain contract */
+const CAMPAIGN_TYPES = ["BUYBACK", "AIRDROP", "LIQUIDITY"] as const;
 
 /**
  * Validation middleware to check for errors
@@ -90,5 +93,112 @@ export const validateListSubscriptions = [
       }
       return true;
     }),
+  validate,
+];
+
+/**
+ * Validation rules for campaign creation (POST /api/campaigns).
+ *
+ * Security notes (OWASP):
+ *  - All string inputs are trimmed to prevent whitespace-only values.
+ *  - Numeric amounts are validated as non-negative integer strings to avoid
+ *    floating-point injection and BigInt parse errors.
+ *  - Stellar addresses are validated against the canonical G… format.
+ *  - ISO 8601 date strings are validated and endTime must be after startTime.
+ *  - metadata is capped at 1 KB to prevent oversized payload attacks.
+ */
+export const validateCampaignCreate = [
+  body("tokenId")
+    .isString()
+    .trim()
+    .notEmpty()
+    .withMessage("tokenId is required"),
+
+  body("creator")
+    .isString()
+    .trim()
+    .notEmpty()
+    .withMessage("creator is required")
+    .custom((value) => {
+      if (!isValidStellarAddress(value)) {
+        throw new Error("creator must be a valid Stellar address");
+      }
+      return true;
+    }),
+
+  body("type")
+    .isString()
+    .trim()
+    .notEmpty()
+    .withMessage("type is required")
+    .isIn(CAMPAIGN_TYPES)
+    .withMessage(`type must be one of: ${CAMPAIGN_TYPES.join(", ")}`),
+
+  body("targetAmount")
+    .isString()
+    .trim()
+    .notEmpty()
+    .withMessage("targetAmount is required")
+    .matches(/^\d+$/)
+    .withMessage("targetAmount must be a non-negative integer string")
+    .custom((value) => {
+      if (BigInt(value) <= BigInt(0)) {
+        throw new Error("targetAmount must be greater than zero");
+      }
+      return true;
+    }),
+
+  body("startTime")
+    .isISO8601()
+    .withMessage("startTime must be a valid ISO 8601 date"),
+
+  body("endTime")
+    .optional()
+    .isISO8601()
+    .withMessage("endTime must be a valid ISO 8601 date")
+    .custom((value, { req }) => {
+      if (value && req.body.startTime) {
+        if (new Date(value) <= new Date(req.body.startTime)) {
+          throw new Error("endTime must be after startTime");
+        }
+      }
+      return true;
+    }),
+
+  body("metadata")
+    .optional()
+    .isString()
+    .withMessage("metadata must be a string")
+    .isLength({ max: 1024 })
+    .withMessage("metadata must not exceed 1024 characters"),
+
+  validate,
+];
+
+/**
+ * Validation rules for campaign ID path parameter.
+ */
+export const validateCampaignId = [
+  param("campaignId")
+    .isInt({ min: 1 })
+    .withMessage("campaignId must be a positive integer"),
+  validate,
+];
+
+/**
+ * Validation rules for campaign execution history query params.
+ */
+export const validateCampaignExecutionQuery = [
+  param("campaignId")
+    .isInt({ min: 1 })
+    .withMessage("campaignId must be a positive integer"),
+  query("limit")
+    .optional()
+    .isInt({ min: 1, max: 200 })
+    .withMessage("limit must be between 1 and 200"),
+  query("offset")
+    .optional()
+    .isInt({ min: 0 })
+    .withMessage("offset must be a non-negative integer"),
   validate,
 ];

--- a/backend/src/routes/campaigns.ts
+++ b/backend/src/routes/campaigns.ts
@@ -1,5 +1,10 @@
 import { Router } from "express";
 import { campaignProjectionService } from "../services/campaignProjectionService";
+import {
+  validateCampaignCreate,
+  validateCampaignId,
+  validateCampaignExecutionQuery,
+} from "../middleware/validation";
 
 const router = Router();
 
@@ -40,7 +45,7 @@ router.get("/creator/:creator", async (req, res) => {
 });
 
 /** @contract CampaignExecutionsResponse */
-router.get("/:campaignId/executions", async (req, res) => {
+router.get("/:campaignId/executions", validateCampaignExecutionQuery, async (req, res) => {
   try {
     const campaignId = parseInt(req.params.campaignId);
     const limit = parseInt(req.query.limit as string) || 50;
@@ -59,7 +64,7 @@ router.get("/:campaignId/executions", async (req, res) => {
 });
 
 /** @contract CampaignRecord */
-router.get("/:campaignId", async (req, res) => {
+router.get("/:campaignId", validateCampaignId, async (req, res) => {
   try {
     const campaignId = parseInt(req.params.campaignId);
     const campaign = await campaignProjectionService.getCampaignById(campaignId);
@@ -71,6 +76,36 @@ router.get("/:campaignId", async (req, res) => {
     res.json(campaign);
   } catch (error) {
     res.status(500).json({ error: "Failed to fetch campaign" });
+  }
+});
+
+/**
+ * POST /api/campaigns
+ * Create a new campaign. Validated by validateCampaignCreate middleware.
+ * @contract CampaignRecord
+ */
+router.post("/", validateCampaignCreate, async (req, res) => {
+  try {
+    const { tokenId, creator, type, targetAmount, startTime, endTime, metadata, txHash } = req.body;
+
+    const event = {
+      campaignId: Date.now(), // placeholder — real ID comes from on-chain event
+      tokenId,
+      creator,
+      type,
+      targetAmount: BigInt(targetAmount),
+      startTime: new Date(startTime),
+      endTime: endTime ? new Date(endTime) : undefined,
+      metadata,
+      txHash: txHash ?? "",
+    };
+
+    const { campaignEventParser } = await import("../services/campaignEventParser");
+    await campaignEventParser.parseCampaignCreated(event);
+
+    res.status(201).json({ success: true, message: "Campaign created" });
+  } catch (error) {
+    res.status(500).json({ error: "Failed to create campaign" });
   }
 });
 


### PR DESCRIPTION
# PR Implementations

## Summary: 

- **825**: Adds a fully typed OpenAPI 3.0.3 spec covering all 31 REST endpoints, a Swagger UI served at `/api/docs`, and a `docs:generate` script that writes `openapi.json`.
-  ***826**: add OpenAPI 3.0.3 spec with Swagger UI and docs:generate script
  
## Issues
Closes #825 
Closes #826 