### PR TITLE
feat(backend): implement database query builder with type safety

### DIFF
--- a/backend/src/lib/queryBuilder.test.ts
+++ b/backend/src/lib/queryBuilder.test.ts
@@ -1,0 +1,281 @@
+import { describe, it, expect } from "vitest";
+import { Prisma } from "@prisma/client";
+import {
+  QueryBuilder,
+  MAX_PAGE_SIZE,
+  DEFAULT_PAGE_SIZE,
+  tokenQuery,
+  burnRecordQuery,
+  campaignQuery,
+  proposalQuery,
+} from "./queryBuilder";
+
+// ─── Unit tests ───────────────────────────────────────────────────────────────
+
+describe("QueryBuilder", () => {
+  // ── build() defaults ──────────────────────────────────────────────────────
+
+  describe("build()", () => {
+    it("returns default page size when no take is set", () => {
+      const result = new QueryBuilder().build();
+      expect(result.take).toBe(DEFAULT_PAGE_SIZE);
+    });
+
+    it("returns empty where/orderBy when nothing is set", () => {
+      const result = new QueryBuilder().build();
+      expect(result.where).toBeUndefined();
+      expect(result.orderBy).toBeUndefined();
+      expect(result.skip).toBeUndefined();
+      expect(result.cursor).toBeUndefined();
+    });
+  });
+
+  // ── where() ───────────────────────────────────────────────────────────────
+
+  describe("where()", () => {
+    it("sets a filter condition", () => {
+      const result = new QueryBuilder<
+        Prisma.TokenWhereInput,
+        Prisma.TokenOrderByWithRelationInput
+      >()
+        .where({ creator: "GABC" })
+        .build();
+
+      expect(result.where).toEqual({ creator: "GABC" });
+    });
+
+    it("merges multiple where calls with AND", () => {
+      const result = new QueryBuilder<
+        Prisma.TokenWhereInput,
+        Prisma.TokenOrderByWithRelationInput
+      >()
+        .where({ creator: "GABC" })
+        .where({ symbol: "TEST" })
+        .build();
+
+      expect(result.where).toEqual({
+        AND: [{ creator: "GABC" }, { symbol: "TEST" }],
+      });
+    });
+
+    it("is immutable — original builder is unchanged", () => {
+      const base = new QueryBuilder<
+        Prisma.TokenWhereInput,
+        Prisma.TokenOrderByWithRelationInput
+      >().where({ creator: "GABC" });
+
+      const derived = base.where({ symbol: "TEST" });
+
+      expect(base.build().where).toEqual({ creator: "GABC" });
+      expect(derived.build().where).toEqual({
+        AND: [{ creator: "GABC" }, { symbol: "TEST" }],
+      });
+    });
+  });
+
+  // ── orderBy() ─────────────────────────────────────────────────────────────
+
+  describe("orderBy()", () => {
+    it("sets a single sort field", () => {
+      const result = new QueryBuilder<
+        Prisma.TokenWhereInput,
+        Prisma.TokenOrderByWithRelationInput
+      >()
+        .orderBy({ createdAt: "desc" })
+        .build();
+
+      expect(result.orderBy).toEqual({ createdAt: "desc" });
+    });
+
+    it("accepts an array of sort fields", () => {
+      const order = [{ createdAt: "desc" as const }, { name: "asc" as const }];
+      const result = new QueryBuilder<
+        Prisma.TokenWhereInput,
+        Prisma.TokenOrderByWithRelationInput
+      >()
+        .orderBy(order)
+        .build();
+
+      expect(result.orderBy).toEqual(order);
+    });
+
+    it("replaces a previously set order", () => {
+      const result = new QueryBuilder<
+        Prisma.TokenWhereInput,
+        Prisma.TokenOrderByWithRelationInput
+      >()
+        .orderBy({ createdAt: "asc" })
+        .orderBy({ createdAt: "desc" })
+        .build();
+
+      expect(result.orderBy).toEqual({ createdAt: "desc" });
+    });
+  });
+
+  // ── paginate() ────────────────────────────────────────────────────────────
+
+  describe("paginate()", () => {
+    it("sets skip and take", () => {
+      const result = new QueryBuilder().paginate({ skip: 40, take: 20 }).build();
+      expect(result.skip).toBe(40);
+      expect(result.take).toBe(20);
+    });
+
+    it("caps take at MAX_PAGE_SIZE", () => {
+      const result = new QueryBuilder()
+        .paginate({ take: MAX_PAGE_SIZE + 500 })
+        .build();
+      expect(result.take).toBe(MAX_PAGE_SIZE);
+    });
+
+    it("clamps negative skip to 0", () => {
+      const result = new QueryBuilder().paginate({ skip: -10 }).build();
+      expect(result.skip).toBe(0);
+    });
+
+    it("uses DEFAULT_PAGE_SIZE when take is omitted", () => {
+      const result = new QueryBuilder().paginate({ skip: 0 }).build();
+      expect(result.take).toBe(DEFAULT_PAGE_SIZE);
+    });
+  });
+
+  // ── limit() ───────────────────────────────────────────────────────────────
+
+  describe("limit()", () => {
+    it("sets take without affecting skip", () => {
+      const result = new QueryBuilder().limit(5).build();
+      expect(result.take).toBe(5);
+      expect(result.skip).toBeUndefined();
+    });
+
+    it("caps at MAX_PAGE_SIZE", () => {
+      const result = new QueryBuilder().limit(MAX_PAGE_SIZE * 2).build();
+      expect(result.take).toBe(MAX_PAGE_SIZE);
+    });
+  });
+
+  // ── after() (cursor pagination) ───────────────────────────────────────────
+
+  describe("after()", () => {
+    it("sets cursor and skip=1", () => {
+      const cursor = { id: "abc-123" };
+      const result = new QueryBuilder().after(cursor).build();
+      expect(result.cursor).toEqual(cursor);
+      expect(result.skip).toBe(1);
+    });
+  });
+
+  // ── chaining ──────────────────────────────────────────────────────────────
+
+  describe("method chaining", () => {
+    it("composes where + orderBy + paginate correctly", () => {
+      const result = new QueryBuilder<
+        Prisma.TokenWhereInput,
+        Prisma.TokenOrderByWithRelationInput
+      >()
+        .where({ creator: "GABC" })
+        .orderBy({ createdAt: "desc" })
+        .paginate({ skip: 0, take: 10 })
+        .build();
+
+      expect(result.where).toEqual({ creator: "GABC" });
+      expect(result.orderBy).toEqual({ createdAt: "desc" });
+      expect(result.skip).toBe(0);
+      expect(result.take).toBe(10);
+    });
+  });
+});
+
+// ─── Factory helpers ──────────────────────────────────────────────────────────
+
+describe("factory helpers", () => {
+  it("tokenQuery() returns a QueryBuilder with Token types", () => {
+    const result = tokenQuery()
+      .where({ creator: "GABC" })
+      .orderBy({ createdAt: "desc" })
+      .paginate({ skip: 0, take: 5 })
+      .build();
+
+    expect(result.where).toEqual({ creator: "GABC" });
+    expect(result.take).toBe(5);
+  });
+
+  it("burnRecordQuery() returns a QueryBuilder with BurnRecord types", () => {
+    const result = burnRecordQuery()
+      .where({ tokenId: "token-1" })
+      .orderBy({ timestamp: "desc" })
+      .build();
+
+    expect(result.where).toEqual({ tokenId: "token-1" });
+    expect(result.orderBy).toEqual({ timestamp: "desc" });
+  });
+
+  it("campaignQuery() returns a QueryBuilder with Campaign types", () => {
+    const result = campaignQuery()
+      .where({ status: "ACTIVE" })
+      .limit(50)
+      .build();
+
+    expect(result.where).toEqual({ status: "ACTIVE" });
+    expect(result.take).toBe(50);
+  });
+
+  it("proposalQuery() returns a QueryBuilder with Proposal types", () => {
+    const result = proposalQuery()
+      .where({ status: "ACTIVE" })
+      .orderBy({ startTime: "asc" })
+      .build();
+
+    expect(result.where).toEqual({ status: "ACTIVE" });
+    expect(result.orderBy).toEqual({ startTime: "asc" });
+  });
+});
+
+// ─── Edge cases ───────────────────────────────────────────────────────────────
+
+describe("edge cases", () => {
+  it("build() caps take even when set directly via constructor", () => {
+    const builder = new QueryBuilder({ take: MAX_PAGE_SIZE + 1 });
+    expect(builder.build().take).toBe(MAX_PAGE_SIZE);
+  });
+
+  it("three chained where() calls nest correctly", () => {
+    const result = new QueryBuilder<
+      Prisma.TokenWhereInput,
+      Prisma.TokenOrderByWithRelationInput
+    >()
+      .where({ creator: "GABC" })
+      .where({ symbol: "TEST" })
+      .where({ decimals: 18 })
+      .build();
+
+    // Third call wraps the already-merged AND
+    expect(result.where).toEqual({
+      AND: [
+        { AND: [{ creator: "GABC" }, { symbol: "TEST" }] },
+        { decimals: 18 },
+      ],
+    });
+  });
+
+  it("cursor pagination and limit can be combined", () => {
+    const result = new QueryBuilder()
+      .after({ id: "cursor-id" })
+      .limit(5)
+      .build();
+
+    expect(result.cursor).toEqual({ id: "cursor-id" });
+    expect(result.take).toBe(5);
+    expect(result.skip).toBe(1);
+  });
+
+  it("take of 0 is preserved (caller intent)", () => {
+    const result = new QueryBuilder().paginate({ take: 0 }).build();
+    expect(result.take).toBe(0);
+  });
+
+  it("take of exactly MAX_PAGE_SIZE is allowed", () => {
+    const result = new QueryBuilder().limit(MAX_PAGE_SIZE).build();
+    expect(result.take).toBe(MAX_PAGE_SIZE);
+  });
+});

--- a/backend/src/lib/queryBuilder.ts
+++ b/backend/src/lib/queryBuilder.ts
@@ -1,0 +1,193 @@
+/**
+ * Type-safe query builder for Prisma models.
+ *
+ * Provides a fluent, composable API for constructing `findMany` queries with
+ * compile-time safety. All filter, sort, and pagination options are validated
+ * at the type level so callers cannot pass unknown fields.
+ *
+ * Design decisions:
+ * - Wraps Prisma's `WhereInput` / `OrderByInput` types directly so the builder
+ *   stays in sync with schema changes automatically.
+ * - Pagination is cursor-based (via `cursor` + `take`) or offset-based
+ *   (`skip` + `take`); both are supported but should not be mixed.
+ * - The builder is immutable: every method returns a new instance, making it
+ *   safe to branch queries from a shared base.
+ *
+ * Security:
+ * - `take` is capped at MAX_PAGE_SIZE to prevent DoS via unbounded result sets.
+ * - All inputs are typed; no raw SQL strings are accepted.
+ *
+ * Limitations:
+ * - Aggregations (count, sum, groupBy) are out of scope; use Prisma directly.
+ * - Nested relation filters are supported via Prisma's `WhereInput` but are not
+ *   given dedicated builder methods to keep the API surface small.
+ */
+
+import { Prisma } from "@prisma/client";
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/** Hard upper bound on page size to prevent unbounded queries. */
+export const MAX_PAGE_SIZE = 1000;
+
+/** Default page size when none is specified. */
+export const DEFAULT_PAGE_SIZE = 20;
+
+// ─── Generic query options ────────────────────────────────────────────────────
+
+export interface QueryOptions<TWhereInput, TOrderByInput> {
+  where?: TWhereInput;
+  orderBy?: TOrderByInput | TOrderByInput[];
+  skip?: number;
+  take?: number;
+  cursor?: { id: string };
+}
+
+// ─── QueryBuilder ─────────────────────────────────────────────────────────────
+
+/**
+ * Immutable, fluent query builder.
+ *
+ * @template TWhereInput  - Prisma `WhereInput` type for the target model.
+ * @template TOrderByInput - Prisma `OrderByWithRelationInput` type.
+ *
+ * @example
+ * ```ts
+ * const query = new QueryBuilder<Prisma.TokenWhereInput, Prisma.TokenOrderByWithRelationInput>()
+ *   .where({ creator: "GABC..." })
+ *   .orderBy({ createdAt: "desc" })
+ *   .paginate({ skip: 0, take: 10 })
+ *   .build();
+ *
+ * const tokens = await prisma.token.findMany(query);
+ * ```
+ */
+export class QueryBuilder<
+  TWhereInput extends object,
+  TOrderByInput extends object,
+> {
+  private readonly options: QueryOptions<TWhereInput, TOrderByInput>;
+
+  constructor(
+    options: QueryOptions<TWhereInput, TOrderByInput> = {}
+  ) {
+    this.options = options;
+  }
+
+  /**
+   * Merges additional filter conditions using Prisma's AND semantics.
+   * Calling `where` multiple times accumulates conditions.
+   */
+  where(filter: TWhereInput): QueryBuilder<TWhereInput, TOrderByInput> {
+    const existing = this.options.where;
+    const merged = existing
+      ? ({ AND: [existing, filter] } as unknown as TWhereInput)
+      : filter;
+    return new QueryBuilder({ ...this.options, where: merged });
+  }
+
+  /**
+   * Sets the sort order. Replaces any previously set order.
+   * Pass an array to sort by multiple fields.
+   */
+  orderBy(
+    order: TOrderByInput | TOrderByInput[]
+  ): QueryBuilder<TWhereInput, TOrderByInput> {
+    return new QueryBuilder({ ...this.options, orderBy: order });
+  }
+
+  /**
+   * Sets offset-based pagination.
+   * `take` is capped at MAX_PAGE_SIZE.
+   */
+  paginate(opts: {
+    skip?: number;
+    take?: number;
+  }): QueryBuilder<TWhereInput, TOrderByInput> {
+    const take = Math.min(opts.take ?? DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE);
+    const skip = Math.max(opts.skip ?? 0, 0);
+    return new QueryBuilder({ ...this.options, skip, take });
+  }
+
+  /**
+   * Sets cursor-based pagination (keyset pagination).
+   * Prefer this over offset pagination for large datasets.
+   */
+  after(cursor: { id: string }): QueryBuilder<TWhereInput, TOrderByInput> {
+    return new QueryBuilder({ ...this.options, cursor, skip: 1 });
+  }
+
+  /**
+   * Limits the number of results without setting a skip offset.
+   * `take` is capped at MAX_PAGE_SIZE.
+   */
+  limit(take: number): QueryBuilder<TWhereInput, TOrderByInput> {
+    return new QueryBuilder({
+      ...this.options,
+      take: Math.min(take, MAX_PAGE_SIZE),
+    });
+  }
+
+  /**
+   * Returns the final Prisma `findMany` argument object.
+   * Applies default page size if no `take` was set.
+   */
+  build(): QueryOptions<TWhereInput, TOrderByInput> {
+    return {
+      ...this.options,
+      take: Math.min(this.options.take ?? DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE),
+    };
+  }
+}
+
+// ─── Model-specific factory helpers ──────────────────────────────────────────
+
+/**
+ * Creates a query builder pre-typed for the `Token` model.
+ *
+ * @example
+ * ```ts
+ * const q = tokenQuery()
+ *   .where({ creator: address })
+ *   .orderBy({ createdAt: "desc" })
+ *   .paginate({ skip: 0, take: 20 })
+ *   .build();
+ * const tokens = await prisma.token.findMany(q);
+ * ```
+ */
+export function tokenQuery(): QueryBuilder<
+  Prisma.TokenWhereInput,
+  Prisma.TokenOrderByWithRelationInput
+> {
+  return new QueryBuilder();
+}
+
+/**
+ * Creates a query builder pre-typed for the `BurnRecord` model.
+ */
+export function burnRecordQuery(): QueryBuilder<
+  Prisma.BurnRecordWhereInput,
+  Prisma.BurnRecordOrderByWithRelationInput
+> {
+  return new QueryBuilder();
+}
+
+/**
+ * Creates a query builder pre-typed for the `Campaign` model.
+ */
+export function campaignQuery(): QueryBuilder<
+  Prisma.CampaignWhereInput,
+  Prisma.CampaignOrderByWithRelationInput
+> {
+  return new QueryBuilder();
+}
+
+/**
+ * Creates a query builder pre-typed for the `Proposal` model.
+ */
+export function proposalQuery(): QueryBuilder<
+  Prisma.ProposalWhereInput,
+  Prisma.ProposalOrderByWithRelationInput
+> {
+  return new QueryBuilder();
+}


### PR DESCRIPTION
## Summary

Closes #847. Implements a type-safe, immutable query builder for Prisma models.

## Changes

**`backend/src/lib/queryBuilder.ts`**
- `QueryBuilder<TWhereInput, TOrderByInput>` — generic immutable fluent builder
- `where(filter)` — merges conditions with AND; each call returns a new instance
- `orderBy(order)` — sets sort; replaces previous order
- `paginate({ skip, take })` — offset pagination; `take` capped at `MAX_PAGE_SIZE` (1000)
- `limit(n)` — shorthand for setting `take` only
- `after({ id })` — cursor-based (keyset) pagination
- `build()` — returns the final Prisma `findMany` argument object
- Factory helpers: `tokenQuery()`, `burnRecordQuery()`, `campaignQuery()`, `proposalQuery()`

**`backend/src/lib/queryBuilder.test.ts`**
- 25 tests covering all methods, immutability, chaining, factory helpers, and edge cases

## Testing

```
npx vitest run src/lib/queryBuilder.test.ts
Test Files  1 passed (1)
     Tests  25 passed (25)
```

## Security

- `take` is hard-capped at 1000 to prevent DoS via unbounded result sets
- No raw SQL; all inputs are typed via Prisma's generated `WhereInput` / `OrderByInput` types
- Negative `skip` values are clamped to 0