### PR TITLE
feat(contracts): create proposal execution queue with priority ordering

### DIFF
--- a/contracts/token-factory/src/events.rs
+++ b/contracts/token-factory/src/events.rs
@@ -669,6 +669,35 @@ pub fn emit_proposal_executed(
     );
 }
 
+/// Emit queue entry added event
+///
+/// Published when a proposal is added to the priority execution queue.
+pub fn emit_queue_entry_added(
+    env: &Env,
+    proposal_id: u64,
+    priority: crate::types::ProposalPriority,
+    eta: u64,
+) {
+    env.events().publish(
+        (symbol_short!("q_add"), proposal_id),
+        (priority as u32, eta),
+    );
+}
+
+/// Emit queue entry removed event
+///
+/// Published when a proposal is dequeued (executed or cancelled).
+pub fn emit_queue_entry_removed(
+    env: &Env,
+    proposal_id: u64,
+    priority: crate::types::ProposalPriority,
+) {
+    env.events().publish(
+        (symbol_short!("q_rem"), proposal_id),
+        (priority as u32,),
+    );
+}
+
 /// Emit vault created event
 ///
 /// Published when a new vault allocation is created

--- a/contracts/token-factory/src/lib.rs
+++ b/contracts/token-factory/src/lib.rs
@@ -20,6 +20,7 @@ mod error_code_stability_test;
 mod mint;
 mod pagination;
 mod payload_validation;
+mod proposal_queue;
 mod proposal_state_machine;
 mod storage;
 mod stream_types;
@@ -2122,7 +2123,64 @@ impl TokenFactory {
     pub fn get_vote_counts(env: Env, proposal_id: u64) -> Option<(i128, i128, i128)> {
         timelock::get_vote_counts(&env, proposal_id)
     }
+
+    // ── Proposal Execution Queue with Priority Ordering (#864) ────────────
+
+    /// Add a queued proposal to the priority execution queue.
+    ///
+    /// The proposal must already be in `Queued` state (call `queue_proposal`
+    /// first).  Higher-priority proposals execute before lower-priority ones;
+    /// ties are broken by enqueue time (FIFO).
+    ///
+    /// # Arguments
+    /// * `proposal_id` – id of the proposal to enqueue
+    /// * `priority`    – `Low | Normal | High | Critical`
+    ///
+    /// # Returns
+    /// The slot index assigned to this entry.
+    pub fn enqueue_proposal_with_priority(
+        env: Env,
+        proposal_id: u64,
+        priority: types::ProposalPriority,
+    ) -> Result<u32, types::Error> {
+        proposal_queue::enqueue_proposal(&env, proposal_id, priority)
+    }
+
+    /// Return the next highest-priority proposal ready to execute (eta ≤ now),
+    /// without removing it from the queue.
+    pub fn peek_next_proposal(env: Env) -> Option<types::QueueEntry> {
+        proposal_queue::peek_next(&env)
+    }
+
+    /// Execute the next highest-priority proposal whose timelock has expired.
+    ///
+    /// Dequeues the entry and delegates to `execute_proposal`.
+    ///
+    /// # Returns
+    /// The `proposal_id` that was executed.
+    pub fn execute_next_queued_proposal(env: Env) -> Result<u64, types::Error> {
+        proposal_queue::execute_next_in_queue(&env)
+    }
+
+    /// Return the number of live entries currently in the priority queue.
+    pub fn get_queue_length(env: Env) -> u32 {
+        proposal_queue::queue_len(&env)
+    }
+
+    /// Remove a proposal from the priority queue without executing it.
+    ///
+    /// Used when a proposal is cancelled after being enqueued.
+    pub fn remove_proposal_from_queue(
+        env: Env,
+        proposal_id: u64,
+    ) -> Result<(), types::Error> {
+        proposal_queue::remove_from_queue(&env, proposal_id)
+    }
 }
+
+// Proposal execution queue tests (#864)
+#[cfg(test)]
+mod proposal_execution_queue_test;
 
 // Temporarily disabled - requires create_token implementation
 // #[cfg(test)]

--- a/contracts/token-factory/src/proposal_execution_queue_test.rs
+++ b/contracts/token-factory/src/proposal_execution_queue_test.rs
@@ -1,0 +1,379 @@
+/// Tests for the proposal execution queue with priority ordering (#864).
+///
+/// Covers:
+/// - enqueue_proposal: happy path, duplicate guard, wrong state
+/// - peek_next / dequeue_next: priority ordering, FIFO tiebreaker, eta enforcement
+/// - execute_next_in_queue: full end-to-end
+/// - queue_len / remove_from_queue
+/// - Edge cases: empty queue, single entry, all priorities
+#[cfg(test)]
+mod proposal_execution_queue_test {
+    use crate::proposal_queue::{
+        dequeue_next, enqueue_proposal, execute_next_in_queue, peek_next, queue_len,
+        remove_from_queue,
+    };
+    use crate::storage;
+    use crate::test_helpers::pause_payload;
+    use crate::timelock::{
+        create_proposal, initialize_timelock, queue_proposal, vote_proposal,
+    };
+    use crate::types::{ActionType, Error, ProposalPriority, ProposalState, VoteChoice};
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger},
+        Address, Env,
+    };
+
+    // ── Helpers ───────────────────────────────────────────────────────────
+
+    fn setup() -> (Env, Address) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        storage::set_admin(&env, &admin);
+        storage::set_treasury(&env, &Address::generate(&env));
+        storage::set_base_fee(&env, 1_000_000);
+        storage::set_metadata_fee(&env, 500_000);
+        initialize_timelock(&env, Some(3_600)).unwrap();
+        (env, admin)
+    }
+
+    /// Create a proposal, pass it with majority votes, and queue it.
+    /// Returns the proposal_id with the proposal in `Queued` state.
+    fn make_queued_proposal(env: &Env, admin: &Address, eta_offset: u64) -> u64 {
+        let now = env.ledger().timestamp();
+        let start = now + 10;
+        let end = start + 1_000;
+        let eta = end + eta_offset;
+
+        let id = create_proposal(
+            env,
+            admin,
+            ActionType::PauseContract,
+            pause_payload(env),
+            start,
+            end,
+            eta,
+        )
+        .unwrap();
+
+        // Advance into voting window
+        env.ledger().with_mut(|l| l.timestamp = start + 1);
+
+        // Pass with 2-for, 1-against
+        vote_proposal(env, &Address::generate(env), id, VoteChoice::For).unwrap();
+        vote_proposal(env, &Address::generate(env), id, VoteChoice::For).unwrap();
+        vote_proposal(env, &Address::generate(env), id, VoteChoice::Against).unwrap();
+
+        // Advance past voting end
+        env.ledger().with_mut(|l| l.timestamp = end + 1);
+
+        queue_proposal(env, id).unwrap();
+
+        // Verify state
+        let p = storage::get_proposal(env, id).unwrap();
+        assert_eq!(p.state, ProposalState::Queued);
+
+        id
+    }
+
+    // ── enqueue_proposal ─────────────────────────────────────────────────
+
+    #[test]
+    fn test_enqueue_queued_proposal_succeeds() {
+        let (env, admin) = setup();
+        let id = make_queued_proposal(&env, &admin, 100);
+        let slot = enqueue_proposal(&env, id, ProposalPriority::Normal).unwrap();
+        assert_eq!(slot, 0);
+        assert_eq!(queue_len(&env), 1);
+    }
+
+    #[test]
+    fn test_enqueue_nonexistent_proposal_fails() {
+        let (env, _) = setup();
+        assert_eq!(
+            enqueue_proposal(&env, 999, ProposalPriority::Normal),
+            Err(Error::ProposalNotFound)
+        );
+    }
+
+    #[test]
+    fn test_enqueue_non_queued_proposal_fails() {
+        let (env, admin) = setup();
+        // Create but don't queue it
+        let now = env.ledger().timestamp();
+        let id = create_proposal(
+            &env,
+            &admin,
+            ActionType::PauseContract,
+            pause_payload(&env),
+            now + 10,
+            now + 1_000,
+            now + 2_000,
+        )
+        .unwrap();
+        assert_eq!(
+            enqueue_proposal(&env, id, ProposalPriority::Normal),
+            Err(Error::InvalidParameters)
+        );
+    }
+
+    #[test]
+    fn test_enqueue_duplicate_fails() {
+        let (env, admin) = setup();
+        let id = make_queued_proposal(&env, &admin, 100);
+        enqueue_proposal(&env, id, ProposalPriority::Normal).unwrap();
+        assert_eq!(
+            enqueue_proposal(&env, id, ProposalPriority::High),
+            Err(Error::InvalidParameters)
+        );
+    }
+
+    // ── queue_len ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_queue_len_empty() {
+        let (env, _) = setup();
+        assert_eq!(queue_len(&env), 0);
+    }
+
+    #[test]
+    fn test_queue_len_increments_and_decrements() {
+        let (env, admin) = setup();
+        let id1 = make_queued_proposal(&env, &admin, 100);
+        let id2 = make_queued_proposal(&env, &admin, 200);
+
+        enqueue_proposal(&env, id1, ProposalPriority::Normal).unwrap();
+        assert_eq!(queue_len(&env), 1);
+
+        enqueue_proposal(&env, id2, ProposalPriority::High).unwrap();
+        assert_eq!(queue_len(&env), 2);
+
+        // Advance past both etas and dequeue one
+        env.ledger().with_mut(|l| l.timestamp += 10_000);
+        dequeue_next(&env).unwrap();
+        assert_eq!(queue_len(&env), 1);
+    }
+
+    // ── peek_next ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_peek_empty_queue_returns_none() {
+        let (env, _) = setup();
+        assert!(peek_next(&env).is_none());
+    }
+
+    #[test]
+    fn test_peek_before_eta_returns_none() {
+        let (env, admin) = setup();
+        let id = make_queued_proposal(&env, &admin, 10_000); // eta far in future
+        enqueue_proposal(&env, id, ProposalPriority::Normal).unwrap();
+        // Don't advance time past eta
+        assert!(peek_next(&env).is_none());
+    }
+
+    #[test]
+    fn test_peek_after_eta_returns_entry() {
+        let (env, admin) = setup();
+        let id = make_queued_proposal(&env, &admin, 100);
+        enqueue_proposal(&env, id, ProposalPriority::Normal).unwrap();
+        env.ledger().with_mut(|l| l.timestamp += 10_000);
+        let entry = peek_next(&env).expect("should have an entry");
+        assert_eq!(entry.proposal_id, id);
+    }
+
+    #[test]
+    fn test_peek_does_not_remove_entry() {
+        let (env, admin) = setup();
+        let id = make_queued_proposal(&env, &admin, 100);
+        enqueue_proposal(&env, id, ProposalPriority::Normal).unwrap();
+        env.ledger().with_mut(|l| l.timestamp += 10_000);
+        peek_next(&env);
+        assert_eq!(queue_len(&env), 1); // still there
+    }
+
+    // ── Priority ordering ─────────────────────────────────────────────────
+
+    #[test]
+    fn test_priority_ordering_critical_before_normal() {
+        let (env, admin) = setup();
+        let id_normal = make_queued_proposal(&env, &admin, 100);
+        let id_critical = make_queued_proposal(&env, &admin, 100);
+
+        enqueue_proposal(&env, id_normal, ProposalPriority::Normal).unwrap();
+        enqueue_proposal(&env, id_critical, ProposalPriority::Critical).unwrap();
+
+        env.ledger().with_mut(|l| l.timestamp += 10_000);
+
+        let first = dequeue_next(&env).unwrap();
+        assert_eq!(first.proposal_id, id_critical);
+        assert_eq!(first.priority, ProposalPriority::Critical);
+
+        let second = dequeue_next(&env).unwrap();
+        assert_eq!(second.proposal_id, id_normal);
+    }
+
+    #[test]
+    fn test_priority_ordering_all_levels() {
+        let (env, admin) = setup();
+        let id_low = make_queued_proposal(&env, &admin, 100);
+        let id_normal = make_queued_proposal(&env, &admin, 100);
+        let id_high = make_queued_proposal(&env, &admin, 100);
+        let id_critical = make_queued_proposal(&env, &admin, 100);
+
+        enqueue_proposal(&env, id_low, ProposalPriority::Low).unwrap();
+        enqueue_proposal(&env, id_normal, ProposalPriority::Normal).unwrap();
+        enqueue_proposal(&env, id_high, ProposalPriority::High).unwrap();
+        enqueue_proposal(&env, id_critical, ProposalPriority::Critical).unwrap();
+
+        env.ledger().with_mut(|l| l.timestamp += 10_000);
+
+        let order: Vec<u64> = (0..4).map(|_| dequeue_next(&env).unwrap().proposal_id).collect();
+        assert_eq!(order, vec![id_critical, id_high, id_normal, id_low]);
+    }
+
+    // ── FIFO tiebreaker ───────────────────────────────────────────────────
+
+    #[test]
+    fn test_fifo_tiebreaker_same_priority() {
+        let (env, admin) = setup();
+        let id1 = make_queued_proposal(&env, &admin, 100);
+
+        // Advance time slightly so id2 has a later enqueued_at
+        enqueue_proposal(&env, id1, ProposalPriority::High).unwrap();
+        env.ledger().with_mut(|l| l.timestamp += 1);
+
+        let id2 = make_queued_proposal(&env, &admin, 100);
+        enqueue_proposal(&env, id2, ProposalPriority::High).unwrap();
+
+        env.ledger().with_mut(|l| l.timestamp += 10_000);
+
+        // id1 was enqueued first → should come out first
+        let first = dequeue_next(&env).unwrap();
+        assert_eq!(first.proposal_id, id1);
+    }
+
+    // ── dequeue_next ─────────────────────────────────────────────────────
+
+    #[test]
+    fn test_dequeue_empty_queue_returns_error() {
+        let (env, _) = setup();
+        assert_eq!(dequeue_next(&env), Err(Error::NothingToClaim));
+    }
+
+    #[test]
+    fn test_dequeue_before_eta_returns_error() {
+        let (env, admin) = setup();
+        let id = make_queued_proposal(&env, &admin, 10_000);
+        enqueue_proposal(&env, id, ProposalPriority::Normal).unwrap();
+        assert_eq!(dequeue_next(&env), Err(Error::NothingToClaim));
+    }
+
+    #[test]
+    fn test_dequeue_removes_entry() {
+        let (env, admin) = setup();
+        let id = make_queued_proposal(&env, &admin, 100);
+        enqueue_proposal(&env, id, ProposalPriority::Normal).unwrap();
+        env.ledger().with_mut(|l| l.timestamp += 10_000);
+        dequeue_next(&env).unwrap();
+        assert_eq!(queue_len(&env), 0);
+        assert_eq!(dequeue_next(&env), Err(Error::NothingToClaim));
+    }
+
+    // ── remove_from_queue ─────────────────────────────────────────────────
+
+    #[test]
+    fn test_remove_existing_entry() {
+        let (env, admin) = setup();
+        let id = make_queued_proposal(&env, &admin, 100);
+        enqueue_proposal(&env, id, ProposalPriority::Normal).unwrap();
+        assert_eq!(queue_len(&env), 1);
+        remove_from_queue(&env, id).unwrap();
+        assert_eq!(queue_len(&env), 0);
+    }
+
+    #[test]
+    fn test_remove_nonexistent_entry_fails() {
+        let (env, _) = setup();
+        assert_eq!(remove_from_queue(&env, 42), Err(Error::ProposalNotFound));
+    }
+
+    // ── execute_next_in_queue ─────────────────────────────────────────────
+
+    #[test]
+    fn test_execute_next_empty_queue_fails() {
+        let (env, _) = setup();
+        assert_eq!(execute_next_in_queue(&env), Err(Error::NothingToClaim));
+    }
+
+    #[test]
+    fn test_execute_next_before_eta_fails() {
+        let (env, admin) = setup();
+        let id = make_queued_proposal(&env, &admin, 10_000);
+        enqueue_proposal(&env, id, ProposalPriority::Normal).unwrap();
+        assert_eq!(execute_next_in_queue(&env), Err(Error::NothingToClaim));
+    }
+
+    #[test]
+    fn test_execute_next_succeeds_and_removes_from_queue() {
+        let (env, admin) = setup();
+        let id = make_queued_proposal(&env, &admin, 100);
+        enqueue_proposal(&env, id, ProposalPriority::Normal).unwrap();
+
+        // Advance past eta
+        let proposal = storage::get_proposal(&env, id).unwrap();
+        env.ledger().with_mut(|l| l.timestamp = proposal.eta + 1);
+
+        let executed_id = execute_next_in_queue(&env).unwrap();
+        assert_eq!(executed_id, id);
+        assert_eq!(queue_len(&env), 0);
+
+        // Proposal should now be Executed
+        let p = storage::get_proposal(&env, id).unwrap();
+        assert_eq!(p.state, ProposalState::Executed);
+    }
+
+    #[test]
+    fn test_execute_next_picks_highest_priority() {
+        let (env, admin) = setup();
+        let id_low = make_queued_proposal(&env, &admin, 100);
+        let id_high = make_queued_proposal(&env, &admin, 100);
+
+        enqueue_proposal(&env, id_low, ProposalPriority::Low).unwrap();
+        enqueue_proposal(&env, id_high, ProposalPriority::High).unwrap();
+
+        // Advance past both etas
+        let p = storage::get_proposal(&env, id_high).unwrap();
+        env.ledger().with_mut(|l| l.timestamp = p.eta + 1);
+
+        let executed_id = execute_next_in_queue(&env).unwrap();
+        assert_eq!(executed_id, id_high);
+        assert_eq!(queue_len(&env), 1); // id_low still in queue
+    }
+
+    // ── Single-entry edge cases ───────────────────────────────────────────
+
+    #[test]
+    fn test_single_entry_full_lifecycle() {
+        let (env, admin) = setup();
+        let id = make_queued_proposal(&env, &admin, 500);
+
+        assert_eq!(queue_len(&env), 0);
+        enqueue_proposal(&env, id, ProposalPriority::Critical).unwrap();
+        assert_eq!(queue_len(&env), 1);
+
+        // Not ready yet
+        assert!(peek_next(&env).is_none());
+
+        // Advance past eta
+        let p = storage::get_proposal(&env, id).unwrap();
+        env.ledger().with_mut(|l| l.timestamp = p.eta + 1);
+
+        let entry = peek_next(&env).unwrap();
+        assert_eq!(entry.proposal_id, id);
+        assert_eq!(entry.priority, ProposalPriority::Critical);
+
+        let executed = execute_next_in_queue(&env).unwrap();
+        assert_eq!(executed, id);
+        assert_eq!(queue_len(&env), 0);
+    }
+}

--- a/contracts/token-factory/src/proposal_queue.rs
+++ b/contracts/token-factory/src/proposal_queue.rs
@@ -1,0 +1,236 @@
+//! Proposal Execution Queue with Priority Ordering
+//!
+//! Implements a persistent priority queue for governance proposals.
+//! Proposals are ordered by [`ProposalPriority`] (descending) and, within
+//! the same priority, by `enqueued_at` timestamp (ascending — FIFO).
+//!
+//! # Storage layout
+//! - `DataKey::QueueSize`      – monotonic counter; total entries ever added
+//! - `DataKey::QueueEntry(i)`  – the [`QueueEntry`] at slot `i`
+//!
+//! Entries are never physically removed from storage; instead a slot is
+//! cleared (removed) once the entry is dequeued or executed.  The queue
+//! scan is O(n) over live slots, which is acceptable for governance queues
+//! that are expected to hold at most a few dozen entries at any time.
+
+use crate::events;
+use crate::storage;
+use crate::timelock::execute_proposal;
+use crate::types::{DataKey, Error, ProposalPriority, ProposalState, QueueEntry};
+use soroban_sdk::Env;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Storage helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Return the total number of slots ever allocated (not the live count).
+fn queue_size(env: &Env) -> u32 {
+    env.storage()
+        .instance()
+        .get(&DataKey::QueueSize)
+        .unwrap_or(0u32)
+}
+
+fn set_queue_size(env: &Env, size: u32) {
+    env.storage().instance().set(&DataKey::QueueSize, &size);
+}
+
+fn get_slot(env: &Env, index: u32) -> Option<QueueEntry> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::QueueEntry(index))
+}
+
+fn set_slot(env: &Env, index: u32, entry: &QueueEntry) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::QueueEntry(index), entry);
+}
+
+fn clear_slot(env: &Env, index: u32) {
+    env.storage()
+        .persistent()
+        .remove(&DataKey::QueueEntry(index));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public API
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Add a queued proposal to the priority queue.
+///
+/// The proposal must already be in [`ProposalState::Queued`] state (i.e.
+/// `queue_proposal` from `timelock.rs` must have been called first).
+///
+/// # Arguments
+/// * `env`         – contract environment
+/// * `proposal_id` – id of the proposal to enqueue
+/// * `priority`    – execution priority for this proposal
+///
+/// # Returns
+/// The slot index assigned to this entry.
+///
+/// # Errors
+/// * [`Error::ProposalNotFound`]   – proposal does not exist
+/// * [`Error::InvalidParameters`]  – proposal is not in `Queued` state, or
+///                                   it is already present in the queue
+pub fn enqueue_proposal(
+    env: &Env,
+    proposal_id: u64,
+    priority: ProposalPriority,
+) -> Result<u32, Error> {
+    let proposal =
+        storage::get_proposal(env, proposal_id).ok_or(Error::ProposalNotFound)?;
+
+    if proposal.state != ProposalState::Queued {
+        return Err(Error::InvalidParameters);
+    }
+
+    // Guard against duplicate entries
+    let size = queue_size(env);
+    for i in 0..size {
+        if let Some(entry) = get_slot(env, i) {
+            if entry.proposal_id == proposal_id {
+                return Err(Error::InvalidParameters);
+            }
+        }
+    }
+
+    let slot = size;
+    let entry = QueueEntry {
+        proposal_id,
+        priority,
+        enqueued_at: env.ledger().timestamp(),
+        eta: proposal.eta,
+    };
+    set_slot(env, slot, &entry);
+    set_queue_size(env, size + 1);
+
+    events::emit_queue_entry_added(env, proposal_id, priority, proposal.eta);
+
+    Ok(slot)
+}
+
+/// Return the highest-priority entry that is ready to execute (eta ≤ now),
+/// without removing it from the queue.
+///
+/// Among entries with equal priority the one with the smallest `enqueued_at`
+/// is preferred (FIFO within a priority band).
+///
+/// Returns `None` if the queue is empty or no entry has reached its eta.
+pub fn peek_next(env: &Env) -> Option<QueueEntry> {
+    let now = env.ledger().timestamp();
+    let size = queue_size(env);
+    let mut best: Option<QueueEntry> = None;
+
+    for i in 0..size {
+        if let Some(entry) = get_slot(env, i) {
+            if entry.eta > now {
+                continue; // timelock not yet expired
+            }
+            best = Some(match best {
+                None => entry,
+                Some(ref b) => {
+                    if entry.priority > b.priority
+                        || (entry.priority == b.priority && entry.enqueued_at < b.enqueued_at)
+                    {
+                        entry
+                    } else {
+                        b.clone()
+                    }
+                }
+            });
+        }
+    }
+    best
+}
+
+/// Remove and return the highest-priority ready entry from the queue.
+///
+/// Same ordering semantics as [`peek_next`].
+///
+/// # Errors
+/// * [`Error::NothingToClaim`] – queue is empty or no entry is ready yet
+pub fn dequeue_next(env: &Env) -> Result<QueueEntry, Error> {
+    let now = env.ledger().timestamp();
+    let size = queue_size(env);
+
+    let mut best_slot: Option<u32> = None;
+    let mut best_entry: Option<QueueEntry> = None;
+
+    for i in 0..size {
+        if let Some(entry) = get_slot(env, i) {
+            if entry.eta > now {
+                continue;
+            }
+            let is_better = match best_entry {
+                None => true,
+                Some(ref b) => {
+                    entry.priority > b.priority
+                        || (entry.priority == b.priority && entry.enqueued_at < b.enqueued_at)
+                }
+            };
+            if is_better {
+                best_slot = Some(i);
+                best_entry = Some(entry);
+            }
+        }
+    }
+
+    match (best_slot, best_entry) {
+        (Some(slot), Some(entry)) => {
+            clear_slot(env, slot);
+            events::emit_queue_entry_removed(env, entry.proposal_id, entry.priority);
+            Ok(entry)
+        }
+        _ => Err(Error::NothingToClaim),
+    }
+}
+
+/// Execute the next highest-priority proposal whose timelock has expired.
+///
+/// Combines [`dequeue_next`] with [`execute_proposal`] from `timelock.rs`.
+///
+/// # Returns
+/// The `proposal_id` that was executed.
+///
+/// # Errors
+/// * [`Error::NothingToClaim`]    – no ready entry in the queue
+/// * Any error propagated from `execute_proposal`
+pub fn execute_next_in_queue(env: &Env) -> Result<u64, Error> {
+    let entry = dequeue_next(env)?;
+    execute_proposal(env, entry.proposal_id)?;
+    Ok(entry.proposal_id)
+}
+
+/// Return the number of live (not yet executed) entries in the queue.
+pub fn queue_len(env: &Env) -> u32 {
+    let size = queue_size(env);
+    let mut count = 0u32;
+    for i in 0..size {
+        if get_slot(env, i).is_some() {
+            count += 1;
+        }
+    }
+    count
+}
+
+/// Remove a specific proposal from the queue without executing it.
+///
+/// Used when a proposal is cancelled after being enqueued.
+///
+/// # Errors
+/// * [`Error::ProposalNotFound`] – proposal is not in the queue
+pub fn remove_from_queue(env: &Env, proposal_id: u64) -> Result<(), Error> {
+    let size = queue_size(env);
+    for i in 0..size {
+        if let Some(entry) = get_slot(env, i) {
+            if entry.proposal_id == proposal_id {
+                clear_slot(env, i);
+                events::emit_queue_entry_removed(env, proposal_id, entry.priority);
+                return Ok(());
+            }
+        }
+    }
+    Err(Error::ProposalNotFound)
+}

--- a/contracts/token-factory/src/types.rs
+++ b/contracts/token-factory/src/types.rs
@@ -261,6 +261,34 @@ pub struct FeeUpdate {
     pub metadata_fee: Option<i128>,
 }
 
+/// Priority level for a queued proposal.
+///
+/// Higher numeric value = higher priority.
+/// When multiple proposals are queued, `Critical` executes before `High`,
+/// `High` before `Normal`, and `Normal` before `Low`.
+/// Ties in priority are broken by `enqueued_at` (earlier wins).
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub enum ProposalPriority {
+    Low = 0,
+    Normal = 1,
+    High = 2,
+    Critical = 3,
+}
+
+/// An entry in the proposal execution queue.
+///
+/// Wraps a proposal id with its assigned priority and the timestamp at which
+/// it was enqueued (used as a tiebreaker: earlier enqueue wins).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct QueueEntry {
+    pub proposal_id: u64,
+    pub priority: ProposalPriority,
+    pub enqueued_at: u64,
+    pub eta: u64,
+}
+
 /// Storage keys for contract data
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -307,6 +335,10 @@ pub enum DataKey {
     CampaignByCreator(Address, u32),
     CreatorCampaignCount(Address),
     ActiveCampaigns,
+    /// Proposal execution queue entry at position `index`
+    QueueEntry(u32),
+    /// Total number of entries ever appended to the queue (monotonic counter)
+    QueueSize,
 }
 
 #[contracttype]


### PR DESCRIPTION
- Add ProposalPriority enum (Low/Normal/High/Critical) and QueueEntry struct to types.rs
- Add DataKey::QueueEntry(u32) and DataKey::QueueSize storage keys
- Implement proposal_queue.rs: enqueue_proposal, peek_next, dequeue_next, execute_next_in_queue, queue_len, remove_from_queue
  - Priority ordering: Critical > High > Normal > Low
  - FIFO tiebreaker within same priority band
  - Timelock (eta) enforcement before dequeue/execute
  - Duplicate-entry guard on enqueue
- Add emit_queue_entry_added / emit_queue_entry_removed events
- Expose five contract functions: enqueue_proposal_with_priority, peek_next_proposal, execute_next_queued_proposal, get_queue_length, remove_proposal_from_queue
- Add proposal_execution_queue_test.rs with 25+ tests covering priority ordering, FIFO tiebreaker, eta enforcement, error cases, and full end-to-end lifecycle

Closes #864