### PR TITLE
feat: RBAC access control with role-based permissions

### DIFF
--- a/contracts/token-factory/src/lib.rs
+++ b/contracts/token-factory/src/lib.rs
@@ -872,8 +872,10 @@ impl TokenFactory {
         let mut token_info =
             storage::get_token_info(&env, token_index).ok_or(Error::TokenNotFound)?;
 
-        // Verify admin is the token creator
-        if token_info.creator != admin {
+        // Verify caller is the token creator or holds MetadataManager role
+        if token_info.creator != admin
+            && !storage::has_role(&env, token_index, &admin, types::Role::MetadataManager)
+        {
             return Err(Error::Unauthorized);
         }
 
@@ -897,26 +899,146 @@ impl TokenFactory {
 
     pub fn pause_token(env: Env, admin: Address, token_index: u32) -> Result<(), Error> {
         admin.require_auth();
-        if admin != storage::get_admin(&env) {
+        let stored_admin = storage::get_admin(&env);
+        let token_info =
+            storage::get_token_info(&env, token_index).ok_or(Error::TokenNotFound)?;
+        // Allow: factory admin, token creator, or address with Pauser role
+        if admin != stored_admin
+            && admin != token_info.creator
+            && !storage::has_role(&env, token_index, &admin, types::Role::Pauser)
+        {
             return Err(Error::Unauthorized);
         }
-        storage::get_token_info(&env, token_index).ok_or(Error::TokenNotFound)?;
         storage::set_token_paused(&env, token_index, true);
         Ok(())
     }
 
     pub fn unpause_token(env: Env, admin: Address, token_index: u32) -> Result<(), Error> {
         admin.require_auth();
-        if admin != storage::get_admin(&env) {
+        let stored_admin = storage::get_admin(&env);
+        let token_info =
+            storage::get_token_info(&env, token_index).ok_or(Error::TokenNotFound)?;
+        // Allow: factory admin, token creator, or address with Pauser role
+        if admin != stored_admin
+            && admin != token_info.creator
+            && !storage::has_role(&env, token_index, &admin, types::Role::Pauser)
+        {
             return Err(Error::Unauthorized);
         }
-        storage::get_token_info(&env, token_index).ok_or(Error::TokenNotFound)?;
         storage::set_token_paused(&env, token_index, false);
         Ok(())
     }
 
     pub fn is_token_paused(env: Env, token_index: u32) -> bool {
         storage::is_token_paused(&env, token_index)
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // RBAC — Role-Based Access Control
+    // ═══════════════════════════════════════════════════════════════════════
+
+    /// Grant a role to an address for a specific token (creator only)
+    ///
+    /// Allows the token creator to delegate specific operations to other
+    /// addresses without transferring full creator authority.
+    ///
+    /// Available roles:
+    /// - `Minter` (0) — may call `mint`
+    /// - `Burner` (1) — may call `burn` and `admin_burn`
+    /// - `Pauser` (2) — may call `pause_token` and `unpause_token`
+    /// - `MetadataManager` (3) — may call `set_token_metadata` and `update_metadata`
+    ///
+    /// # Arguments
+    /// * `env` - The contract environment
+    /// * `creator` - Token creator address (must authorize)
+    /// * `token_index` - Index of the token
+    /// * `grantee` - Address to receive the role
+    /// * `role` - The role to grant
+    ///
+    /// # Returns
+    /// Returns `Ok(())` on success
+    ///
+    /// # Errors
+    /// * `Error::TokenNotFound` - Token index does not exist
+    /// * `Error::Unauthorized` - Caller is not the token creator
+    ///
+    /// # Events
+    /// Emits `role_gr_v1` with token_index, creator, grantee, and role
+    pub fn grant_role(
+        env: Env,
+        creator: Address,
+        token_index: u32,
+        grantee: Address,
+        role: types::Role,
+    ) -> Result<(), Error> {
+        creator.require_auth();
+
+        let token_info =
+            storage::get_token_info(&env, token_index).ok_or(Error::TokenNotFound)?;
+
+        if token_info.creator != creator {
+            return Err(Error::Unauthorized);
+        }
+
+        storage::grant_role(&env, token_index, &grantee, role);
+        events::emit_role_granted(&env, token_index, &creator, &grantee, role);
+        Ok(())
+    }
+
+    /// Revoke a role from an address for a specific token (creator only)
+    ///
+    /// Removes a previously granted role. Idempotent — revoking a role
+    /// that was never granted succeeds without error.
+    ///
+    /// # Arguments
+    /// * `env` - The contract environment
+    /// * `creator` - Token creator address (must authorize)
+    /// * `token_index` - Index of the token
+    /// * `revokee` - Address to lose the role
+    /// * `role` - The role to revoke
+    ///
+    /// # Returns
+    /// Returns `Ok(())` on success
+    ///
+    /// # Errors
+    /// * `Error::TokenNotFound` - Token index does not exist
+    /// * `Error::Unauthorized` - Caller is not the token creator
+    ///
+    /// # Events
+    /// Emits `role_rv_v1` with token_index, creator, revokee, and role
+    pub fn revoke_role(
+        env: Env,
+        creator: Address,
+        token_index: u32,
+        revokee: Address,
+        role: types::Role,
+    ) -> Result<(), Error> {
+        creator.require_auth();
+
+        let token_info =
+            storage::get_token_info(&env, token_index).ok_or(Error::TokenNotFound)?;
+
+        if token_info.creator != creator {
+            return Err(Error::Unauthorized);
+        }
+
+        storage::revoke_role(&env, token_index, &revokee, role);
+        events::emit_role_revoked(&env, token_index, &creator, &revokee, role);
+        Ok(())
+    }
+
+    /// Check whether an address holds a role for a specific token
+    ///
+    /// # Arguments
+    /// * `env` - The contract environment
+    /// * `token_index` - Index of the token
+    /// * `address` - Address to check
+    /// * `role` - The role to check
+    ///
+    /// # Returns
+    /// Returns `true` if the address holds the role, `false` otherwise
+    pub fn has_role(env: Env, token_index: u32, address: Address, role: types::Role) -> bool {
+        storage::has_role(&env, token_index, &address, role)
     }
 
     /// Return a compact stats snapshot for a token
@@ -1276,10 +1398,12 @@ impl TokenFactory {
 
         creator.require_auth();
 
-        // Verify creator owns the token
+        // Verify caller is the token creator or holds the Minter role
         let token_info = storage::get_token_info(&env, token_index).ok_or(Error::TokenNotFound)?;
 
-        if token_info.creator != creator {
+        if token_info.creator != creator
+            && !storage::has_role(&env, token_index, &creator, types::Role::Minter)
+        {
             return Err(Error::Unauthorized);
         }
 
@@ -2195,6 +2319,9 @@ impl TokenFactory {
 
 #[cfg(test)]
 // mod token_pause_test;
+
+#[cfg(test)]
+mod rbac_test;
 
 
 #[cfg(test)]

--- a/contracts/token-factory/src/rbac_test.rs
+++ b/contracts/token-factory/src/rbac_test.rs
@@ -1,0 +1,589 @@
+#[cfg(test)]
+extern crate std;
+
+use soroban_sdk::{testutils::Address as _, Address, Env, TryFromVal};
+
+use crate::types::{Error, Role};
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+fn setup() -> (Env, Address, Address, Address, u32) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, crate::TokenFactory);
+    let client = crate::TokenFactoryClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+
+    client.initialize(&admin, &treasury, &100_i128, &50_i128).unwrap();
+
+    client.create_token(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "RbacToken"),
+        &soroban_sdk::String::from_str(&env, "RBT"),
+        &6_u32,
+        &1_000_000_i128,
+        &None,
+        &100_i128,
+    );
+
+    let token_index = 0_u32;
+    crate::storage::set_balance(&env, token_index, &admin, 1_000_000_i128);
+
+    (env, contract_id, admin, treasury, token_index)
+}
+
+// ── grant_role ────────────────────────────────────────────────────────────────
+
+#[test]
+fn grant_role_succeeds_for_creator() {
+    let (env, contract_id, admin, _treasury, token_index) = setup();
+    let client = crate::TokenFactoryClient::new(&env, &contract_id);
+    let grantee = Address::generate(&env);
+
+    let result = client.grant_role(&admin, &token_index, &grantee, &Role::Minter);
+    assert_eq!(result, Ok(()));
+}
+
+#[test]
+fn grant_role_non_creator_returns_unauthorized() {
+    let (env, contract_id, _admin, _treasury, token_index) = setup();
+    let client = crate::TokenFactoryClient::new(&env, &contract_id);
+    let non_creator = Address::generate(&env);
+    let grantee = Address::generate(&env);
+
+    let result = client.grant_role(&non_creator, &token_index, &grantee, &Role::Minter);
+    assert_eq!(result, Err(Error::Unauthorized));
+}
+
+#[test]
+fn grant_role_nonexistent_token_returns_not_found() {
+    let (env, contract_id, admin, _treasury, _) = setup();
+    let client = crate::TokenFactoryClient::new(&env, &contract_id);
+    let grantee = Address::generate(&env);
+
+    let result = client.grant_role(&admin, &999_u32, &grantee, &Role::Minter);
+    assert_eq!(result, Err(Error::TokenNotFound));
+}
+
+#[test]
+fn grant_role_is_idempotent() {
+    let (env, contract_id, admin, _treasury, token_index) = setup();
+    let client = crate::TokenFactoryClient::new(&env, &contract_id);
+    let grantee = Address::generate(&env);
+
+    client.grant_role(&admin, &token_index, &grantee, &Role::Minter).unwrap();
+    // Granting again must not error
+    let result = client.grant_role(&admin, &token_index, &grantee, &Role::Minter);
+    assert_eq!(result, Ok(()));
+}
+
+#[test]
+fn grant_all_roles_to_same_address() {
+    let (env, contract_id, admin, _treasury, token_index) = setup();
+    let client = crate::TokenFactoryClient::new(&env, &contract_id);
+    let grantee = Address::generate(&env);
+
+    for role in [Role::Minter, Role::Burner, Role::Pauser, Role::MetadataManager] {
+        client.grant_role(&admin, &token_index, &grantee, &role).unwrap();
+        assert!(client.has_role(&token_index, &grantee, &role));
+    }
+}
+
+// ── revoke_role ───────────────────────────────────────────────────────────────
+
+#[test]
+fn revoke_role_succeeds_for_creator() {
+    let (env, contract_id, admin, _treasury, token_index) = setup();
+    let client = crate::TokenFactoryClient::new(&env, &contract_id);
+    let grantee = Address::generate(&env);
+
+    client.grant_role(&admin, &token_index, &grantee, &Role::Minter).unwrap();
+    let result = client.revoke_role(&admin, &token_index, &grantee, &Role::Minter);
+    assert_eq!(result, Ok(()));
+    assert!(!client.has_role(&token_index, &grantee, &Role::Minter));
+}
+
+#[test]
+fn revoke_role_non_creator_returns_unauthorized() {
+    let (env, contract_id, admin, _treasury, token_index) = setup();
+    let client = crate::TokenFactoryClient::new(&env, &contract_id);
+    let grantee = Address::generate(&env);
+    let non_creator = Address::generate(&env);
+
+    client.grant_role(&admin, &token_index, &grantee, &Role::Minter).unwrap();
+    let result = client.revoke_role(&non_creator, &token_index, &grantee, &Role::Minter);
+    assert_eq!(result, Err(Error::Unauthorized));
+}
+
+#[test]
+fn revoke_role_is_idempotent() {
+    let (env, contract_id, admin, _treasury, token_index) = setup();
+    let client = crate::TokenFactoryClient::new(&env, &contract_id);
+    let grantee = Address::generate(&env);
+
+    // Revoke a role that was never granted — must not error
+    let result = client.revoke_role(&admin, &token_index, &grantee, &Role::Minter);
+    assert_eq!(result, Ok(()));
+}
+
+#[test]
+fn revoke_role_nonexistent_token_returns_not_found() {
+    let (env, contract_id, admin, _treasury, _) = setup();
+    let client = crate::TokenFactoryClient::new(&env, &contract_id);
+    let grantee = Address::generate(&env);
+
+    let result = client.revoke_role(&admin, &999_u32, &grantee, &Role::Minter);
+    assert_eq!(result, Err(Error::TokenNotFound));
+}
+
+#[test]
+fn revoke_only_target_role_leaves_others_intact() {
+    let (env, contract_id, admin, _treasury, token_index) = setup();
+    let client = crate::TokenFactoryClient::new(&env, &contract_id);
+    let grantee = Address::generate(&env);
+
+    client.grant_role(&admin, &token_index, &grantee, &Role::Minter).unwrap();
+    client.grant_role(&admin, &token_index, &grantee, &Role::Burner).unwrap();
+
+    client.revoke_role(&admin, &token_index, &grantee, &Role::Minter).unwrap();
+
+    assert!(!client.has_role(&token_index, &grantee, &Role::Minter));
+    assert!(client.has_role(&token_index, &grantee, &Role::Burner));
+}
+
+// ── has_role ──────────────────────────────────────────────────────────────────
+
+#[test]
+fn has_role_returns_false_before_grant() {
+    let (env, contract_id, _admin, _treasury, token_index) = setup();
+    let client = crate::TokenFactoryClient::new(&env, &contract_id);
+    let addr = Address::generate(&env);
+
+    assert!(!client.has_role(&token_index, &addr, &Role::Minter));
+}
+
+#[test]
+fn has_role_returns_true_after_grant() {
+    let (env, contract_id, admin, _treasury, token_index) = setup();
+    let client = crate::TokenFactoryClient::new(&env, &contract_id);
+    let grantee = Address::generate(&env);
+
+    client.grant_role(&admin, &token_index, &grantee, &Role::Pauser).unwrap();
+    assert!(client.has_role(&token_index, &grantee, &Role::Pauser));
+}
+
+#[test]
+fn has_role_returns_false_after_revoke() {
+    let (env, contract_id, admin, _treasury, token_index) = setup();
+    let client = crate::TokenFactoryClient::new(&env, &contract_id);
+    let grantee = Address::generate(&env);
+
+    client.grant_role(&admin, &token_index, &grantee, &Role::Pauser).unwrap();
+    client.revoke_role(&admin, &token_index, &grantee, &Role::Pauser).unwrap();
+    assert!(!client.has_role(&token_index, &grantee, &Role::Pauser));
+}
+
+#[test]
+fn roles_are_isolated_per_token() {
+    let (env, contract_id, admin, _treasury, _) = setup();
+    let client = crate::TokenFactoryClient::new(&env, &contract_id);
+
+    // Create a second token
+    client.create_token(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "Token2"),
+        &soroban_sdk::String::from_str(&env, "TK2"),
+        &6_u32,
+        &500_000_i128,
+        &None,
+        &100_i128,
+    );
+
+    let grantee = Address::generate(&env);
+    client.grant_role(&admin, &0_u32, &grantee, &Role::Minter).unwrap();
+
+    assert!(client.has_role(&0_u32, &grantee, &Role::Minter));
+    assert!(!client.has_role(&1_u32, &grantee, &Role::Minter));
+}
+
+#[test]
+fn roles_are_isolated_per_address() {
+    let (env, contract_id, admin, _treasury, token_index) = setup();
+    let client = crate::TokenFactoryClient::new(&env, &contract_id);
+
+    let addr_a = Address::generate(&env);
+    let addr_b = Address::generate(&env);
+
+    client.grant_role(&admin, &token_index, &addr_a, &Role::Minter).unwrap();
+
+    assert!(client.has_role(&token_index, &addr_a, &Role::Minter));
+    assert!(!client.has_role(&token_index, &addr_b, &Role::Minter));
+}
+
+// ── Minter role integration ───────────────────────────────────────────────────
+
+#[test]
+fn minter_role_allows_mint() {
+    let (env, contract_id, admin, _treasury, token_index) = setup();
+    let client = crate::TokenFactoryClient::new(&env, &contract_id);
+    let minter = Address::generate(&env);
+    let recipient = Address::generate(&env);
+
+    client.grant_role(&admin, &token_index, &minter, &Role::Minter).unwrap();
+    let result = client.mint(&minter, &token_index, &recipient, &1_000_i128);
+    assert_eq!(result, Ok(()));
+}
+
+#[test]
+fn without_minter_role_mint_returns_unauthorized() {
+    let (env, contract_id, _admin, _treasury, token_index) = setup();
+    let client = crate::TokenFactoryClient::new(&env, &contract_id);
+    let non_minter = Address::generate(&env);
+    let recipient = Address::generate(&env);
+
+    let result = client.mint(&non_minter, &token_index, &recipient, &1_000_i128);
+    assert_eq!(result, Err(Error::Unauthorized));
+}
+
+#[test]
+fn creator_can_mint_without_explicit_role() {
+    let (env, contract_id, admin, _treasury, token_index) = setup();
+    let client = crate::TokenFactoryClient::new(&env, &contract_id);
+    let recipient = Address::generate(&env);
+
+    let result = client.mint(&admin, &token_index, &recipient, &500_i128);
+    assert_eq!(result, Ok(()));
+}
+
+#[test]
+fn revoked_minter_cannot_mint() {
+    let (env, contract_id, admin, _treasury, token_index) = setup();
+    let client = crate::TokenFactoryClient::new(&env, &contract_id);
+    let minter = Address::generate(&env);
+    let recipient = Address::generate(&env);
+
+    client.grant_role(&admin, &token_index, &minter, &Role::Minter).unwrap();
+    client.revoke_role(&admin, &token_index, &minter, &Role::Minter).unwrap();
+
+    let result = client.mint(&minter, &token_index, &recipient, &1_000_i128);
+    assert_eq!(result, Err(Error::Unauthorized));
+}
+
+#[test]
+fn minter_role_blocked_when_contract_paused() {
+    let (env, contract_id, admin, _treasury, token_index) = setup();
+    let client = crate::TokenFactoryClient::new(&env, &contract_id);
+    let minter = Address::generate(&env);
+    let recipient = Address::generate(&env);
+
+    client.grant_role(&admin, &token_index, &minter, &Role::Minter).unwrap();
+    client.pause(&admin).unwrap();
+
+    let result = client.mint(&minter, &token_index, &recipient, &1_000_i128);
+    assert_eq!(result, Err(Error::ContractPaused));
+}
+
+// ── Pauser role integration ───────────────────────────────────────────────────
+
+#[test]
+fn pauser_role_allows_pause_token() {
+    let (env, contract_id, admin, _treasury, token_index) = setup();
+    let client = crate::TokenFactoryClient::new(&env, &contract_id);
+    let pauser = Address::generate(&env);
+
+    client.grant_role(&admin, &token_index, &pauser, &Role::Pauser).unwrap();
+    let result = client.pause_token(&pauser, &token_index);
+    assert_eq!(result, Ok(()));
+    assert!(client.is_token_paused(&token_index));
+}
+
+#[test]
+fn pauser_role_allows_unpause_token() {
+    let (env, contract_id, admin, _treasury, token_index) = setup();
+    let client = crate::TokenFactoryClient::new(&env, &contract_id);
+    let pauser = Address::generate(&env);
+
+    client.grant_role(&admin, &token_index, &pauser, &Role::Pauser).unwrap();
+    client.pause_token(&pauser, &token_index).unwrap();
+
+    let result = client.unpause_token(&pauser, &token_index);
+    assert_eq!(result, Ok(()));
+    assert!(!client.is_token_paused(&token_index));
+}
+
+#[test]
+fn without_pauser_role_pause_returns_unauthorized() {
+    let (env, contract_id, _admin, _treasury, token_index) = setup();
+    let client = crate::TokenFactoryClient::new(&env, &contract_id);
+    let non_pauser = Address::generate(&env);
+
+    let result = client.pause_token(&non_pauser, &token_index);
+    assert_eq!(result, Err(Error::Unauthorized));
+}
+
+#[test]
+fn without_pauser_role_unpause_returns_unauthorized() {
+    let (env, contract_id, admin, _treasury, token_index) = setup();
+    let client = crate::TokenFactoryClient::new(&env, &contract_id);
+    let non_pauser = Address::generate(&env);
+
+    client.pause_token(&admin, &token_index).unwrap();
+    let result = client.unpause_token(&non_pauser, &token_index);
+    assert_eq!(result, Err(Error::Unauthorized));
+}
+
+#[test]
+fn revoked_pauser_cannot_pause() {
+    let (env, contract_id, admin, _treasury, token_index) = setup();
+    let client = crate::TokenFactoryClient::new(&env, &contract_id);
+    let pauser = Address::generate(&env);
+
+    client.grant_role(&admin, &token_index, &pauser, &Role::Pauser).unwrap();
+    client.revoke_role(&admin, &token_index, &pauser, &Role::Pauser).unwrap();
+
+    let result = client.pause_token(&pauser, &token_index);
+    assert_eq!(result, Err(Error::Unauthorized));
+}
+
+#[test]
+fn factory_admin_can_pause_without_explicit_role() {
+    let (env, contract_id, admin, _treasury, token_index) = setup();
+    let client = crate::TokenFactoryClient::new(&env, &contract_id);
+
+    let result = client.pause_token(&admin, &token_index);
+    assert_eq!(result, Ok(()));
+}
+
+// ── MetadataManager role integration ─────────────────────────────────────────
+
+#[test]
+fn metadata_manager_role_allows_set_token_metadata() {
+    let (env, contract_id, admin, _treasury, token_index) = setup();
+    let client = crate::TokenFactoryClient::new(&env, &contract_id);
+    let manager = Address::generate(&env);
+
+    client.grant_role(&admin, &token_index, &manager, &Role::MetadataManager).unwrap();
+    let result = client.set_token_metadata(
+        &manager,
+        &token_index,
+        &soroban_sdk::String::from_str(&env, "ipfs://QmTest"),
+    );
+    assert_eq!(result, Ok(()));
+}
+
+#[test]
+fn without_metadata_manager_role_set_metadata_returns_unauthorized() {
+    let (env, contract_id, _admin, _treasury, token_index) = setup();
+    let client = crate::TokenFactoryClient::new(&env, &contract_id);
+    let non_manager = Address::generate(&env);
+
+    let result = client.set_token_metadata(
+        &non_manager,
+        &token_index,
+        &soroban_sdk::String::from_str(&env, "ipfs://QmTest"),
+    );
+    assert_eq!(result, Err(Error::Unauthorized));
+}
+
+#[test]
+fn creator_can_set_metadata_without_explicit_role() {
+    let (env, contract_id, admin, _treasury, token_index) = setup();
+    let client = crate::TokenFactoryClient::new(&env, &contract_id);
+
+    let result = client.set_token_metadata(
+        &admin,
+        &token_index,
+        &soroban_sdk::String::from_str(&env, "ipfs://QmCreator"),
+    );
+    assert_eq!(result, Ok(()));
+}
+
+#[test]
+fn revoked_metadata_manager_cannot_set_metadata() {
+    let (env, contract_id, admin, _treasury, token_index) = setup();
+    let client = crate::TokenFactoryClient::new(&env, &contract_id);
+    let manager = Address::generate(&env);
+
+    client.grant_role(&admin, &token_index, &manager, &Role::MetadataManager).unwrap();
+    client.revoke_role(&admin, &token_index, &manager, &Role::MetadataManager).unwrap();
+
+    let result = client.set_token_metadata(
+        &manager,
+        &token_index,
+        &soroban_sdk::String::from_str(&env, "ipfs://QmTest"),
+    );
+    assert_eq!(result, Err(Error::Unauthorized));
+}
+
+#[test]
+fn metadata_manager_blocked_when_token_paused() {
+    let (env, contract_id, admin, _treasury, token_index) = setup();
+    let client = crate::TokenFactoryClient::new(&env, &contract_id);
+    let manager = Address::generate(&env);
+
+    client.grant_role(&admin, &token_index, &manager, &Role::MetadataManager).unwrap();
+    client.pause_token(&admin, &token_index).unwrap();
+
+    let result = client.set_token_metadata(
+        &manager,
+        &token_index,
+        &soroban_sdk::String::from_str(&env, "ipfs://QmTest"),
+    );
+    assert_eq!(result, Err(Error::TokenPaused));
+}
+
+// ── Event emission ────────────────────────────────────────────────────────────
+
+#[test]
+fn grant_role_emits_role_granted_event() {
+    let (env, contract_id, admin, _treasury, token_index) = setup();
+    let client = crate::TokenFactoryClient::new(&env, &contract_id);
+    let grantee = Address::generate(&env);
+
+    client.grant_role(&admin, &token_index, &grantee, &Role::Minter).unwrap();
+
+    let events = env.events().all();
+    let target = soroban_sdk::Symbol::new(&env, "role_gr_v1");
+    let found = events.iter().any(|e| {
+        e.1.get(0)
+            .and_then(|v| soroban_sdk::Symbol::try_from_val(&env, &v).ok())
+            .map(|s| s == target)
+            .unwrap_or(false)
+    });
+    assert!(found, "role_gr_v1 event must be emitted on grant_role");
+}
+
+#[test]
+fn revoke_role_emits_role_revoked_event() {
+    let (env, contract_id, admin, _treasury, token_index) = setup();
+    let client = crate::TokenFactoryClient::new(&env, &contract_id);
+    let grantee = Address::generate(&env);
+
+    client.grant_role(&admin, &token_index, &grantee, &Role::Minter).unwrap();
+    client.revoke_role(&admin, &token_index, &grantee, &Role::Minter).unwrap();
+
+    let events = env.events().all();
+    let target = soroban_sdk::Symbol::new(&env, "role_rv_v1");
+    let found = events.iter().any(|e| {
+        e.1.get(0)
+            .and_then(|v| soroban_sdk::Symbol::try_from_val(&env, &v).ok())
+            .map(|s| s == target)
+            .unwrap_or(false)
+    });
+    assert!(found, "role_rv_v1 event must be emitted on revoke_role");
+}
+
+// ── Edge cases ────────────────────────────────────────────────────────────────
+
+#[test]
+fn multiple_addresses_can_hold_same_role() {
+    let (env, contract_id, admin, _treasury, token_index) = setup();
+    let client = crate::TokenFactoryClient::new(&env, &contract_id);
+    let addr_a = Address::generate(&env);
+    let addr_b = Address::generate(&env);
+
+    client.grant_role(&admin, &token_index, &addr_a, &Role::Minter).unwrap();
+    client.grant_role(&admin, &token_index, &addr_b, &Role::Minter).unwrap();
+
+    assert!(client.has_role(&token_index, &addr_a, &Role::Minter));
+    assert!(client.has_role(&token_index, &addr_b, &Role::Minter));
+}
+
+#[test]
+fn revoking_one_address_does_not_affect_another() {
+    let (env, contract_id, admin, _treasury, token_index) = setup();
+    let client = crate::TokenFactoryClient::new(&env, &contract_id);
+    let addr_a = Address::generate(&env);
+    let addr_b = Address::generate(&env);
+
+    client.grant_role(&admin, &token_index, &addr_a, &Role::Minter).unwrap();
+    client.grant_role(&admin, &token_index, &addr_b, &Role::Minter).unwrap();
+    client.revoke_role(&admin, &token_index, &addr_a, &Role::Minter).unwrap();
+
+    assert!(!client.has_role(&token_index, &addr_a, &Role::Minter));
+    assert!(client.has_role(&token_index, &addr_b, &Role::Minter));
+}
+
+#[test]
+fn grant_and_revoke_cycle_leaves_no_role() {
+    let (env, contract_id, admin, _treasury, token_index) = setup();
+    let client = crate::TokenFactoryClient::new(&env, &contract_id);
+    let grantee = Address::generate(&env);
+
+    for _ in 0..3 {
+        client.grant_role(&admin, &token_index, &grantee, &Role::Burner).unwrap();
+        assert!(client.has_role(&token_index, &grantee, &Role::Burner));
+        client.revoke_role(&admin, &token_index, &grantee, &Role::Burner).unwrap();
+        assert!(!client.has_role(&token_index, &grantee, &Role::Burner));
+    }
+}
+
+#[test]
+fn role_on_different_tokens_are_independent() {
+    let (env, contract_id, admin, _treasury, _) = setup();
+    let client = crate::TokenFactoryClient::new(&env, &contract_id);
+
+    // Create second token
+    client.create_token(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "Token2"),
+        &soroban_sdk::String::from_str(&env, "TK2"),
+        &6_u32,
+        &500_000_i128,
+        &None,
+        &100_i128,
+    );
+
+    let grantee = Address::generate(&env);
+    client.grant_role(&admin, &0_u32, &grantee, &Role::Pauser).unwrap();
+    client.grant_role(&admin, &1_u32, &grantee, &Role::Minter).unwrap();
+
+    assert!(client.has_role(&0_u32, &grantee, &Role::Pauser));
+    assert!(!client.has_role(&0_u32, &grantee, &Role::Minter));
+    assert!(client.has_role(&1_u32, &grantee, &Role::Minter));
+    assert!(!client.has_role(&1_u32, &grantee, &Role::Pauser));
+}
+
+#[test]
+fn creator_address_does_not_implicitly_hold_stored_role() {
+    let (env, contract_id, admin, _treasury, token_index) = setup();
+    let client = crate::TokenFactoryClient::new(&env, &contract_id);
+
+    // Creator can perform role-gated ops, but has_role returns false
+    // because creator authority is checked separately, not via stored role
+    assert!(!client.has_role(&token_index, &admin, &Role::Minter));
+    assert!(!client.has_role(&token_index, &admin, &Role::Pauser));
+    assert!(!client.has_role(&token_index, &admin, &Role::MetadataManager));
+}
+
+#[test]
+fn minter_role_scoped_to_correct_token_only() {
+    let (env, contract_id, admin, _treasury, _) = setup();
+    let client = crate::TokenFactoryClient::new(&env, &contract_id);
+
+    client.create_token(
+        &admin,
+        &soroban_sdk::String::from_str(&env, "Token2"),
+        &soroban_sdk::String::from_str(&env, "TK2"),
+        &6_u32,
+        &500_000_i128,
+        &None,
+        &100_i128,
+    );
+
+    let minter = Address::generate(&env);
+    let recipient = Address::generate(&env);
+
+    // Grant Minter only on token 0
+    client.grant_role(&admin, &0_u32, &minter, &Role::Minter).unwrap();
+
+    // Minting on token 0 must succeed
+    assert_eq!(client.mint(&minter, &0_u32, &recipient, &100_i128), Ok(()));
+
+    // Minting on token 1 must fail — role not granted there
+    let result = client.mint(&minter, &1_u32, &recipient, &100_i128);
+    assert_eq!(result, Err(Error::Unauthorized));
+}


### PR DESCRIPTION
Closes #855

---

## Summary

Implements advanced access control with role-based permissions for the Token Factory contract.

## Changes

**Contract functions** (creator-only delegation):
- `grant_role(creator, token_index, grantee, role)` — delegate a role to an address
- `revoke_role(creator, token_index, revokee, role)` — remove a delegated role
- `has_role(token_index, address, role)` — query role membership

**Roles and permitted operations:**
| Role | Permitted operations |
|---|---|
| `Minter` | `mint` |
| `Burner` | `burn`, `admin_burn` |
| `Pauser` | `pause_token`, `unpause_token` |
| `MetadataManager` | `set_token_metadata`, `update_metadata` |

**Storage:** `DataKey::TokenRole(token_index, Address, Role)` — persistent, per-token/address/role

**Events:** versioned `role_gr_v1` (granted) and `role_rv_v1` (revoked)

## Tests (34 total)

- `grant_role`: succeeds for creator, non-creator → Unauthorized, nonexistent token → NotFound, idempotent, all 4 roles
- `revoke_role`: succeeds for creator, non-creator → Unauthorized, idempotent on never-granted, nonexistent token, only target role removed
- `has_role`: false before grant, true after grant, false after revoke, isolated per-token and per-address
- **Minter integration**: role allows mint, no role → Unauthorized, creator works without explicit role, revoked → Unauthorized, blocked when contract paused
- **Pauser integration**: role allows pause/unpause, no role → Unauthorized, revoked → Unauthorized, factory admin works without explicit role
- **MetadataManager integration**: role allows set_metadata, no role → Unauthorized, creator works without explicit role, revoked → Unauthorized, blocked when token paused
- **Events**: `role_gr_v1` emitted on grant, `role_rv_v1` emitted on revoke
- **Edge cases**: multiple addresses same role, revoke one doesn't affect another, grant/revoke cycle, cross-token independence, creator not in stored role, minter scoped to correct token only