### PR TITLE
feat(contracts): build oracle integration for external price feeds

### DIFF
--- a/contracts/token-factory/src/lib.rs
+++ b/contracts/token-factory/src/lib.rs
@@ -13,6 +13,7 @@ mod differential_engine;
 mod event_versions;
 mod events;
 mod milestone_verification;
+mod oracle;
 #[cfg(all(test, feature = "legacy-tests"))]
 mod milestone_verification_test;
 #[cfg(all(test, feature = "legacy-tests"))]
@@ -63,6 +64,10 @@ mod vault_funding_overflow_property_test; // Property 73
 #[cfg(test)]
 mod vault_concurrent_claims_chaos_test;
 
+// Oracle integration tests
+#[cfg(test)]
+mod oracle_integration_test;
+
 // Temporarily disabled due to pre-existing compilation errors
 // #[cfg(test)]
 // mod two_step_admin_security_test;
@@ -75,9 +80,9 @@ mod vault_concurrent_claims_chaos_test;
 
 use soroban_sdk::{contract, contractimpl, symbol_short, Address, Bytes, BytesN, Env, String, Vec};
 use types::{
-    BuybackCampaign, CampaignStatus, ContractMetadata, Error, FactoryState, PaginationCursor,
-    StreamInfo, StreamPage, StreamParams, TokenCreationParams, TokenInfo, TokenStats, Vault,
-    VaultStatus,
+    BuybackCampaign, CampaignStatus, ContractMetadata, Error, FactoryState, OracleConfig,
+    PaginationCursor, PriceData, StreamInfo, StreamPage, StreamParams, TokenCreationParams,
+    TokenInfo, TokenStats, Vault, VaultStatus,
 };
 use crate::milestone_verification::MilestoneVerifier;
 
@@ -2121,6 +2126,91 @@ impl TokenFactory {
 
     pub fn get_vote_counts(env: Env, proposal_id: u64) -> Option<(i128, i128, i128)> {
         timelock::get_vote_counts(&env, proposal_id)
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Oracle Functions — External Price Feeds
+    // ═══════════════════════════════════════════════════════════════════════
+
+    /// Configure the oracle parameters (admin only).
+    ///
+    /// # Arguments
+    /// * `admin` - Contract admin address (must authorize).
+    /// * `max_age_seconds` - Prices older than this are considered stale (must be > 0).
+    /// * `min_sources` - Minimum authorized sources required (informational).
+    ///
+    /// # Errors
+    /// * `Error::Unauthorized` - Caller is not the admin.
+    /// * `Error::InvalidParameters` - `max_age_seconds` is zero.
+    pub fn configure_oracle(
+        env: Env,
+        admin: Address,
+        max_age_seconds: u64,
+        min_sources: u32,
+    ) -> Result<(), Error> {
+        oracle::configure_oracle(&env, &admin, max_age_seconds, min_sources)
+    }
+
+    /// Authorize or deauthorize an oracle price source (admin only).
+    ///
+    /// # Arguments
+    /// * `admin` - Contract admin address (must authorize).
+    /// * `source` - Oracle source address to update.
+    /// * `authorized` - `true` to authorize, `false` to revoke.
+    ///
+    /// # Errors
+    /// * `Error::Unauthorized` - Caller is not the admin.
+    pub fn set_oracle_authorized(
+        env: Env,
+        admin: Address,
+        source: Address,
+        authorized: bool,
+    ) -> Result<(), Error> {
+        oracle::set_oracle_authorized(&env, &admin, &source, authorized)
+    }
+
+    /// Submit a new price observation (authorized oracle sources only).
+    ///
+    /// # Arguments
+    /// * `source` - Authorized oracle source address (must authorize).
+    /// * `price` - Raw price value (must be > 0).
+    /// * `decimals` - Decimal places for `price`.
+    ///
+    /// # Errors
+    /// * `Error::OracleUnauthorized` - `source` is not authorized.
+    /// * `Error::OraclePriceInvalid` - `price` is zero or negative.
+    pub fn submit_price(
+        env: Env,
+        source: Address,
+        price: i128,
+        decimals: u32,
+    ) -> Result<(), Error> {
+        oracle::submit_price(&env, &source, price, decimals)
+    }
+
+    /// Retrieve and validate the latest price from `source`.
+    ///
+    /// # Arguments
+    /// * `source` - Oracle source address whose price to read.
+    ///
+    /// # Returns
+    /// The latest `PriceData` if present and within the staleness window.
+    ///
+    /// # Errors
+    /// * `Error::OracleNotFound` - No price submitted by `source`.
+    /// * `Error::OraclePriceStale` - Price is older than `max_age_seconds`.
+    pub fn get_oracle_price(env: Env, source: Address) -> Result<PriceData, Error> {
+        oracle::get_price(&env, &source)
+    }
+
+    /// Return the current oracle configuration.
+    pub fn get_oracle_config(env: Env) -> OracleConfig {
+        oracle::get_config(&env)
+    }
+
+    /// Return whether `source` is an authorized oracle.
+    pub fn is_oracle_authorized(env: Env, source: Address) -> bool {
+        oracle::is_authorized(&env, &source)
     }
 }
 

--- a/contracts/token-factory/src/oracle.rs
+++ b/contracts/token-factory/src/oracle.rs
@@ -1,0 +1,204 @@
+//! Oracle Integration — External Price Feeds
+//!
+//! Provides a lightweight, permissioned price-feed mechanism for the token factory.
+//! Authorized oracle sources push `PriceData` on-chain; consumers read the latest
+//! price and validate it against a configurable staleness window.
+//!
+//! # Architecture
+//! - **Admin** configures the oracle (max age, authorized sources) via `configure_oracle`
+//!   and `set_oracle_authorized`.
+//! - **Authorized sources** push prices via `submit_price`.
+//! - **Consumers** read prices via `get_price`, which enforces staleness checks.
+//!
+//! # Security
+//! - Only the contract admin can authorize/deauthorize oracle sources.
+//! - Price values must be strictly positive.
+//! - Stale prices (older than `max_age_seconds`) are rejected at read time.
+//! - All mutations emit versioned events for off-chain indexing.
+
+use soroban_sdk::{symbol_short, Address, Env};
+
+use crate::storage;
+use crate::types::{DataKey, Error, OracleConfig, PriceData};
+
+// ─── Storage helpers ─────────────────────────────────────────────────────────
+
+/// Persist the global oracle configuration.
+pub fn set_config(env: &Env, config: &OracleConfig) {
+    env.storage()
+        .instance()
+        .set(&DataKey::OracleConfig, config);
+}
+
+/// Retrieve the global oracle configuration, or a safe default if not yet set.
+pub fn get_config(env: &Env) -> OracleConfig {
+    env.storage()
+        .instance()
+        .get(&DataKey::OracleConfig)
+        .unwrap_or(OracleConfig {
+            max_age_seconds: 3600, // 1 hour default
+            min_sources: 1,
+        })
+}
+
+/// Mark `source` as authorized (true) or deauthorized (false).
+pub fn set_authorized(env: &Env, source: &Address, authorized: bool) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::OracleAuthorized(source.clone()), &authorized);
+}
+
+/// Returns `true` if `source` is an authorized oracle.
+pub fn is_authorized(env: &Env, source: &Address) -> bool {
+    env.storage()
+        .persistent()
+        .get(&DataKey::OracleAuthorized(source.clone()))
+        .unwrap_or(false)
+}
+
+/// Store the latest price submitted by `source`.
+pub fn set_price(env: &Env, source: &Address, data: &PriceData) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::OraclePrice(source.clone()), data);
+}
+
+/// Retrieve the latest price submitted by `source`, if any.
+pub fn get_price_raw(env: &Env, source: &Address) -> Option<PriceData> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::OraclePrice(source.clone()))
+}
+
+// ─── Core logic ──────────────────────────────────────────────────────────────
+
+/// Configure the oracle parameters (admin only).
+///
+/// # Arguments
+/// * `admin` - Must be the contract admin and must authorize.
+/// * `max_age_seconds` - Prices older than this are considered stale.
+/// * `min_sources` - Minimum authorized sources required (currently informational).
+///
+/// # Errors
+/// * `Error::Unauthorized` - Caller is not the contract admin.
+/// * `Error::InvalidParameters` - `max_age_seconds` is zero.
+pub fn configure_oracle(
+    env: &Env,
+    admin: &Address,
+    max_age_seconds: u64,
+    min_sources: u32,
+) -> Result<(), Error> {
+    admin.require_auth();
+    if *admin != storage::get_admin(env) {
+        return Err(Error::Unauthorized);
+    }
+    if max_age_seconds == 0 {
+        return Err(Error::InvalidParameters);
+    }
+
+    set_config(env, &OracleConfig { max_age_seconds, min_sources });
+
+    env.events().publish(
+        (symbol_short!("orc_cf_v1"),),
+        (max_age_seconds, min_sources),
+    );
+    Ok(())
+}
+
+/// Authorize or deauthorize an oracle price source (admin only).
+///
+/// # Arguments
+/// * `admin` - Must be the contract admin and must authorize.
+/// * `source` - The oracle source address to update.
+/// * `authorized` - `true` to authorize, `false` to revoke.
+///
+/// # Errors
+/// * `Error::Unauthorized` - Caller is not the contract admin.
+pub fn set_oracle_authorized(
+    env: &Env,
+    admin: &Address,
+    source: &Address,
+    authorized: bool,
+) -> Result<(), Error> {
+    admin.require_auth();
+    if *admin != storage::get_admin(env) {
+        return Err(Error::Unauthorized);
+    }
+
+    set_authorized(env, source, authorized);
+
+    env.events().publish(
+        (symbol_short!("orc_au_v1"), source.clone()),
+        (authorized,),
+    );
+    Ok(())
+}
+
+/// Submit a new price observation (authorized oracle sources only).
+///
+/// The price is stored keyed by the caller's address. Consumers call
+/// `get_price` to retrieve and validate it.
+///
+/// # Arguments
+/// * `source` - The oracle source address (must be authorized, must authorize).
+/// * `price` - Raw price value (must be > 0).
+/// * `decimals` - Decimal places for `price`.
+///
+/// # Errors
+/// * `Error::OracleUnauthorized` - `source` is not an authorized oracle.
+/// * `Error::OraclePriceInvalid` - `price` is zero or negative.
+pub fn submit_price(
+    env: &Env,
+    source: &Address,
+    price: i128,
+    decimals: u32,
+) -> Result<(), Error> {
+    source.require_auth();
+
+    if !is_authorized(env, source) {
+        return Err(Error::OracleUnauthorized);
+    }
+    if price <= 0 {
+        return Err(Error::OraclePriceInvalid);
+    }
+
+    let data = PriceData {
+        price,
+        decimals,
+        timestamp: env.ledger().timestamp(),
+    };
+    set_price(env, source, &data);
+
+    env.events().publish(
+        (symbol_short!("orc_pr_v1"), source.clone()),
+        (price, decimals, data.timestamp),
+    );
+    Ok(())
+}
+
+/// Retrieve and validate the latest price from `source`.
+///
+/// Enforces the staleness window configured via `configure_oracle`.
+///
+/// # Arguments
+/// * `source` - The oracle source address whose price to read.
+///
+/// # Returns
+/// The latest `PriceData` if present and fresh.
+///
+/// # Errors
+/// * `Error::OracleNotFound` - No price has been submitted by `source`.
+/// * `Error::OraclePriceStale` - The price is older than `max_age_seconds`.
+pub fn get_price(env: &Env, source: &Address) -> Result<PriceData, Error> {
+    let data = get_price_raw(env, source).ok_or(Error::OracleNotFound)?;
+
+    let config = get_config(env);
+    let now = env.ledger().timestamp();
+    let age = now.saturating_sub(data.timestamp);
+
+    if age > config.max_age_seconds {
+        return Err(Error::OraclePriceStale);
+    }
+
+    Ok(data)
+}

--- a/contracts/token-factory/src/oracle_integration_test.rs
+++ b/contracts/token-factory/src/oracle_integration_test.rs
@@ -1,0 +1,317 @@
+//! Oracle Integration Tests
+//!
+//! Covers the full lifecycle of the oracle price-feed feature:
+//! configuration, authorization, price submission, price retrieval,
+//! staleness enforcement, and all error paths.
+
+#![cfg(test)]
+
+use crate::{TokenFactory, TokenFactoryClient};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    Address, Env,
+};
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+fn setup() -> (Env, TokenFactoryClient<'static>, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, TokenFactory);
+    let client = TokenFactoryClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    client.initialize(&admin, &treasury, &70_000_000, &30_000_000);
+
+    (env, client, admin, treasury)
+}
+
+// ─── Error code stability ────────────────────────────────────────────────────
+
+#[test]
+fn test_oracle_error_codes_are_stable() {
+    assert_eq!(crate::types::Error::OracleNotFound.0, 55);
+    assert_eq!(crate::types::Error::OraclePriceStale.0, 56);
+    assert_eq!(crate::types::Error::OracleUnauthorized.0, 57);
+    assert_eq!(crate::types::Error::OraclePriceInvalid.0, 58);
+}
+
+// ─── configure_oracle ────────────────────────────────────────────────────────
+
+#[test]
+fn test_configure_oracle_success() {
+    let (_env, client, admin, _) = setup();
+    client.configure_oracle(&admin, &7200, &2);
+
+    let cfg = client.get_oracle_config();
+    assert_eq!(cfg.max_age_seconds, 7200);
+    assert_eq!(cfg.min_sources, 2);
+}
+
+#[test]
+fn test_configure_oracle_default_before_setup() {
+    let (_env, client, _admin, _) = setup();
+    // Default config should be returned before any explicit configuration
+    let cfg = client.get_oracle_config();
+    assert_eq!(cfg.max_age_seconds, 3600);
+    assert_eq!(cfg.min_sources, 1);
+}
+
+#[test]
+fn test_configure_oracle_unauthorized() {
+    let (_env, client, _admin, _) = setup();
+    let attacker = Address::generate(&_env);
+    let result = client.try_configure_oracle(&attacker, &3600, &1);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_configure_oracle_zero_max_age_rejected() {
+    let (_env, client, admin, _) = setup();
+    let result = client.try_configure_oracle(&admin, &0, &1);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_configure_oracle_can_be_updated() {
+    let (_env, client, admin, _) = setup();
+    client.configure_oracle(&admin, &3600, &1);
+    client.configure_oracle(&admin, &1800, &3);
+
+    let cfg = client.get_oracle_config();
+    assert_eq!(cfg.max_age_seconds, 1800);
+    assert_eq!(cfg.min_sources, 3);
+}
+
+// ─── set_oracle_authorized ───────────────────────────────────────────────────
+
+#[test]
+fn test_authorize_oracle_source() {
+    let (env, client, admin, _) = setup();
+    let source = Address::generate(&env);
+
+    assert!(!client.is_oracle_authorized(&source));
+    client.set_oracle_authorized(&admin, &source, &true);
+    assert!(client.is_oracle_authorized(&source));
+}
+
+#[test]
+fn test_deauthorize_oracle_source() {
+    let (env, client, admin, _) = setup();
+    let source = Address::generate(&env);
+
+    client.set_oracle_authorized(&admin, &source, &true);
+    client.set_oracle_authorized(&admin, &source, &false);
+    assert!(!client.is_oracle_authorized(&source));
+}
+
+#[test]
+fn test_authorize_oracle_unauthorized_caller() {
+    let (env, client, _admin, _) = setup();
+    let attacker = Address::generate(&env);
+    let source = Address::generate(&env);
+
+    let result = client.try_set_oracle_authorized(&attacker, &source, &true);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_multiple_sources_can_be_authorized() {
+    let (env, client, admin, _) = setup();
+    let s1 = Address::generate(&env);
+    let s2 = Address::generate(&env);
+    let s3 = Address::generate(&env);
+
+    client.set_oracle_authorized(&admin, &s1, &true);
+    client.set_oracle_authorized(&admin, &s2, &true);
+
+    assert!(client.is_oracle_authorized(&s1));
+    assert!(client.is_oracle_authorized(&s2));
+    assert!(!client.is_oracle_authorized(&s3));
+}
+
+// ─── submit_price ────────────────────────────────────────────────────────────
+
+#[test]
+fn test_submit_price_success() {
+    let (env, client, admin, _) = setup();
+    let source = Address::generate(&env);
+
+    client.set_oracle_authorized(&admin, &source, &true);
+    client.submit_price(&source, &1_000_000, &7);
+
+    let data = client.get_oracle_price(&source);
+    assert_eq!(data.price, 1_000_000);
+    assert_eq!(data.decimals, 7);
+}
+
+#[test]
+fn test_submit_price_unauthorized_source() {
+    let (env, client, _admin, _) = setup();
+    let source = Address::generate(&env);
+
+    let result = client.try_submit_price(&source, &1_000_000, &7);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_submit_price_zero_rejected() {
+    let (env, client, admin, _) = setup();
+    let source = Address::generate(&env);
+
+    client.set_oracle_authorized(&admin, &source, &true);
+    let result = client.try_submit_price(&source, &0, &7);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_submit_price_negative_rejected() {
+    let (env, client, admin, _) = setup();
+    let source = Address::generate(&env);
+
+    client.set_oracle_authorized(&admin, &source, &true);
+    let result = client.try_submit_price(&source, &-1, &7);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_submit_price_updates_existing() {
+    let (env, client, admin, _) = setup();
+    let source = Address::generate(&env);
+
+    client.set_oracle_authorized(&admin, &source, &true);
+    client.submit_price(&source, &1_000_000, &7);
+    client.submit_price(&source, &2_000_000, &7);
+
+    let data = client.get_oracle_price(&source);
+    assert_eq!(data.price, 2_000_000);
+}
+
+#[test]
+fn test_submit_price_deauthorized_source_rejected() {
+    let (env, client, admin, _) = setup();
+    let source = Address::generate(&env);
+
+    client.set_oracle_authorized(&admin, &source, &true);
+    client.submit_price(&source, &1_000_000, &7);
+
+    // Revoke authorization
+    client.set_oracle_authorized(&admin, &source, &false);
+
+    let result = client.try_submit_price(&source, &2_000_000, &7);
+    assert!(result.is_err());
+}
+
+// ─── get_oracle_price ────────────────────────────────────────────────────────
+
+#[test]
+fn test_get_price_not_found() {
+    let (env, client, _admin, _) = setup();
+    let source = Address::generate(&env);
+
+    let result = client.try_get_oracle_price(&source);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_get_price_fresh() {
+    let (env, client, admin, _) = setup();
+    let source = Address::generate(&env);
+
+    client.configure_oracle(&admin, &3600, &1);
+    client.set_oracle_authorized(&admin, &source, &true);
+    client.submit_price(&source, &5_000_000, &7);
+
+    let data = client.get_oracle_price(&source);
+    assert_eq!(data.price, 5_000_000);
+    assert_eq!(data.decimals, 7);
+}
+
+#[test]
+fn test_get_price_stale_rejected() {
+    let (env, client, admin, _) = setup();
+    let source = Address::generate(&env);
+
+    client.configure_oracle(&admin, &60, &1); // 60-second window
+    client.set_oracle_authorized(&admin, &source, &true);
+    client.submit_price(&source, &1_000_000, &7);
+
+    // Advance ledger time past the staleness window
+    env.ledger().with_mut(|l| l.timestamp += 61);
+
+    let result = client.try_get_oracle_price(&source);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_get_price_exactly_at_boundary_is_fresh() {
+    let (env, client, admin, _) = setup();
+    let source = Address::generate(&env);
+
+    client.configure_oracle(&admin, &60, &1);
+    client.set_oracle_authorized(&admin, &source, &true);
+    client.submit_price(&source, &1_000_000, &7);
+
+    // Advance to exactly the boundary — should still be valid (age == max_age)
+    env.ledger().with_mut(|l| l.timestamp += 60);
+
+    let data = client.get_oracle_price(&source);
+    assert_eq!(data.price, 1_000_000);
+}
+
+#[test]
+fn test_get_price_independent_per_source() {
+    let (env, client, admin, _) = setup();
+    let s1 = Address::generate(&env);
+    let s2 = Address::generate(&env);
+
+    client.configure_oracle(&admin, &3600, &1);
+    client.set_oracle_authorized(&admin, &s1, &true);
+    client.set_oracle_authorized(&admin, &s2, &true);
+
+    client.submit_price(&s1, &1_000_000, &7);
+    client.submit_price(&s2, &2_000_000, &6);
+
+    assert_eq!(client.get_oracle_price(&s1).price, 1_000_000);
+    assert_eq!(client.get_oracle_price(&s2).price, 2_000_000);
+    assert_eq!(client.get_oracle_price(&s1).decimals, 7);
+    assert_eq!(client.get_oracle_price(&s2).decimals, 6);
+}
+
+// ─── Integration: full lifecycle ─────────────────────────────────────────────
+
+#[test]
+fn test_full_oracle_lifecycle() {
+    let (env, client, admin, _) = setup();
+    let source = Address::generate(&env);
+
+    // 1. Configure
+    client.configure_oracle(&admin, &300, &1);
+    assert_eq!(client.get_oracle_config().max_age_seconds, 300);
+
+    // 2. Authorize
+    client.set_oracle_authorized(&admin, &source, &true);
+    assert!(client.is_oracle_authorized(&source));
+
+    // 3. Submit
+    client.submit_price(&source, &42_000_000, &7);
+
+    // 4. Read fresh price
+    let data = client.get_oracle_price(&source);
+    assert_eq!(data.price, 42_000_000);
+
+    // 5. Advance time past window → stale
+    env.ledger().with_mut(|l| l.timestamp += 301);
+    assert!(client.try_get_oracle_price(&source).is_err());
+
+    // 6. Re-submit refreshes the price
+    client.submit_price(&source, &43_000_000, &7);
+    let data = client.get_oracle_price(&source);
+    assert_eq!(data.price, 43_000_000);
+
+    // 7. Deauthorize → further submissions rejected
+    client.set_oracle_authorized(&admin, &source, &false);
+    assert!(client.try_submit_price(&source, &44_000_000, &7).is_err());
+}

--- a/contracts/token-factory/src/types.rs
+++ b/contracts/token-factory/src/types.rs
@@ -237,6 +237,32 @@ pub struct TokenStats {
     pub freeze_enabled: bool,
 }
 
+/// A single price observation submitted by an authorized oracle source.
+///
+/// # Fields
+/// * `price` - Raw price value (must be > 0)
+/// * `decimals` - Number of decimal places in `price` (e.g. 7 means price / 10^7)
+/// * `timestamp` - Ledger timestamp when the price was recorded
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PriceData {
+    pub price: i128,
+    pub decimals: u32,
+    pub timestamp: u64,
+}
+
+/// Global oracle configuration stored in instance storage.
+///
+/// # Fields
+/// * `max_age_seconds` - Maximum acceptable age of a price before it is considered stale
+/// * `min_sources` - Minimum number of authorized sources that must have submitted a price
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct OracleConfig {
+    pub max_age_seconds: u64,
+    pub min_sources: u32,
+}
+
 /// Batch fee update structure for Phase 2 optimization
 ///
 /// Allows updating both fees in a single operation, providing
@@ -307,6 +333,12 @@ pub enum DataKey {
     CampaignByCreator(Address, u32),
     CreatorCampaignCount(Address),
     ActiveCampaigns,
+    /// Latest price data submitted by an authorized oracle source.
+    OraclePrice(Address),
+    /// Whether an address is an authorized oracle price submitter.
+    OracleAuthorized(Address),
+    /// Global oracle configuration (max_age_seconds, min_sources).
+    OracleConfig,
 }
 
 #[contracttype]
@@ -368,6 +400,14 @@ impl Error {
     pub const CampaignNotFound: Self = Self(51);
     pub const InvalidBudget: Self = Self(52);
     pub const InsufficientBudget: Self = Self(53);
+    /// No price data found for the requested oracle address.
+    pub const OracleNotFound: Self = Self(55);
+    /// The most recent price is older than `max_age_seconds`.
+    pub const OraclePriceStale: Self = Self(56);
+    /// Caller is not an authorized oracle source.
+    pub const OracleUnauthorized: Self = Self(57);
+    /// Submitted price value is zero or negative.
+    pub const OraclePriceInvalid: Self = Self(58);
 }
 
 impl From<Error> for soroban_sdk::Error {


### PR DESCRIPTION
- Add PriceData and OracleConfig types to types.rs
- Add OraclePrice/OracleAuthorized/OracleConfig DataKey variants
- Add oracle error codes 55-58 (OracleNotFound, OraclePriceStale, OracleUnauthorized, OraclePriceInvalid)
- Implement oracle.rs with configure_oracle, set_oracle_authorized, submit_price, get_price
- Expose 6 public oracle functions in lib.rs contractimpl
- Add 22 comprehensive integration tests in oracle_integration_test.rs

closes #872 