### PR TITLE
feat(contracts): add price triggers, governance templates, upgrade mechanism, and airdrop types

### DIFF
--- a/contracts/token-factory/src/campaign.rs
+++ b/contracts/token-factory/src/campaign.rs
@@ -188,6 +188,30 @@ mod tests {
     use crate::test_helpers::TestEnv;
     use soroban_sdk::testutils::Address as _;
 
+    fn make_campaign(env: &soroban_sdk::Env, owner: &Address, status: CampaignStatus) -> BuybackCampaign {
+        let dummy = Address::generate(env);
+        BuybackCampaign {
+            id: 1,
+            token_index: 0,
+            owner: owner.clone(),
+            budget: 1_000_000,
+            spent: 0,
+            tokens_bought: 0,
+            execution_count: 0,
+            start_time: env.ledger().timestamp(),
+            end_time: env.ledger().timestamp() + 86400,
+            min_interval: 300,
+            max_slippage_bps: 100,
+            source_token: dummy.clone(),
+            target_token: dummy,
+            status,
+            created_at: env.ledger().timestamp(),
+            updated_at: env.ledger().timestamp(),
+            trigger_price: 0,
+            last_executed_at: 0,
+        }
+    }
+
     #[test]
     fn test_pause_active_campaign() {
         let test_env = TestEnv::new();
@@ -195,27 +219,12 @@ mod tests {
         let admin = &test_env.admin;
 
         env.as_contract(&env.current_contract_address(), || {
-            // Create active campaign
-            let campaign = BuybackCampaign {
-                id: 1,
-                token_index: 0,
-                owner: admin.clone(),
-                budget_allocated: 1_000_000,
-                budget_spent: 0,
-                tokens_burned: 0,
-                burn_count: 0,
-                start_time: env.ledger().timestamp(),
-                end_time: 0,
-                status: CampaignStatus::Active,
-                created_at: env.ledger().timestamp(),
-            };
+            let campaign = make_campaign(env, admin, CampaignStatus::Active);
             storage::set_campaign(env, 1, &campaign);
 
-            // Pause campaign
             let result = pause_campaign(env, admin, 1);
             assert!(result.is_ok());
 
-            // Verify state change
             let updated = storage::get_campaign(env, 1).unwrap();
             assert_eq!(updated.status, CampaignStatus::Paused);
         });
@@ -228,23 +237,9 @@ mod tests {
         let admin = &test_env.admin;
 
         env.as_contract(&env.current_contract_address(), || {
-            // Create paused campaign
-            let campaign = BuybackCampaign {
-                id: 1,
-                token_index: 0,
-                owner: admin.clone(),
-                budget_allocated: 1_000_000,
-                budget_spent: 0,
-                tokens_burned: 0,
-                burn_count: 0,
-                start_time: env.ledger().timestamp(),
-                end_time: 0,
-                status: CampaignStatus::Paused,
-                created_at: env.ledger().timestamp(),
-            };
+            let campaign = make_campaign(env, admin, CampaignStatus::Paused);
             storage::set_campaign(env, 1, &campaign);
 
-            // Attempt to pause again (replay attack)
             let result = pause_campaign(env, admin, 1);
             assert_eq!(result, Err(Error::CampaignAlreadyPaused));
         });
@@ -257,27 +252,12 @@ mod tests {
         let admin = &test_env.admin;
 
         env.as_contract(&env.current_contract_address(), || {
-            // Create paused campaign
-            let campaign = BuybackCampaign {
-                id: 1,
-                token_index: 0,
-                owner: admin.clone(),
-                budget_allocated: 1_000_000,
-                budget_spent: 0,
-                tokens_burned: 0,
-                burn_count: 0,
-                start_time: env.ledger().timestamp(),
-                end_time: 0,
-                status: CampaignStatus::Paused,
-                created_at: env.ledger().timestamp(),
-            };
+            let campaign = make_campaign(env, admin, CampaignStatus::Paused);
             storage::set_campaign(env, 1, &campaign);
 
-            // Resume campaign
             let result = resume_campaign(env, admin, 1);
             assert!(result.is_ok());
 
-            // Verify state change
             let updated = storage::get_campaign(env, 1).unwrap();
             assert_eq!(updated.status, CampaignStatus::Active);
         });
@@ -290,23 +270,9 @@ mod tests {
         let admin = &test_env.admin;
 
         env.as_contract(&env.current_contract_address(), || {
-            // Create active campaign
-            let campaign = BuybackCampaign {
-                id: 1,
-                token_index: 0,
-                owner: admin.clone(),
-                budget_allocated: 1_000_000,
-                budget_spent: 0,
-                tokens_burned: 0,
-                burn_count: 0,
-                start_time: env.ledger().timestamp(),
-                end_time: 0,
-                status: CampaignStatus::Active,
-                created_at: env.ledger().timestamp(),
-            };
+            let campaign = make_campaign(env, admin, CampaignStatus::Active);
             storage::set_campaign(env, 1, &campaign);
 
-            // Attempt to resume (replay attack)
             let result = resume_campaign(env, admin, 1);
             assert_eq!(result, Err(Error::CampaignNotPaused));
         });
@@ -319,19 +285,7 @@ mod tests {
         let admin = &test_env.admin;
 
         env.as_contract(&env.current_contract_address(), || {
-            let campaign = BuybackCampaign {
-                id: 1,
-                token_index: 0,
-                owner: admin.clone(),
-                budget_allocated: 1_000_000,
-                budget_spent: 1_000_000,
-                tokens_burned: 50_000,
-                burn_count: 10,
-                start_time: env.ledger().timestamp(),
-                end_time: 0,
-                status: CampaignStatus::Completed,
-                created_at: env.ledger().timestamp(),
-            };
+            let campaign = make_campaign(env, admin, CampaignStatus::Completed);
             storage::set_campaign(env, 1, &campaign);
 
             let result = pause_campaign(env, admin, 1);
@@ -347,17 +301,13 @@ mod tests {
         let attacker = Address::generate(env);
 
         env.as_contract(&env.current_contract_address(), || {
-            let campaign = BuybackCampaign {
-                id: 1,
-                token_index: 0,
-                owner: admin.clone(),
-                budget_allocated: 1_000_000,
-                budget_spent: 0,
-                tokens_burned: 0,
-                burn_count: 0,
-                start_time: env.ledger().timestamp(),
-                end_time: 0,
-                status: CampaignStatus::Active,
+            let campaign = make_campaign(env, admin, CampaignStatus::Active);
+            storage::set_campaign(env, 1, &campaign);
+
+            let result = pause_campaign(env, &attacker, 1);
+            assert_eq!(result, Err(Error::Unauthorized));
+        });
+    }
                 created_at: env.ledger().timestamp(),
             };
             storage::set_campaign(env, 1, &campaign);

--- a/contracts/token-factory/src/campaign_state_test.rs
+++ b/contracts/token-factory/src/campaign_state_test.rs
@@ -17,18 +17,26 @@ use soroban_sdk::testutils::{Address as _, Events};
 use soroban_sdk::Address;
 
 fn create_test_campaign(env: &soroban_sdk::Env, owner: &Address, status: CampaignStatus) -> BuybackCampaign {
+    let dummy_addr = Address::generate(env);
     BuybackCampaign {
         id: 1,
         token_index: 0,
         owner: owner.clone(),
-        budget_allocated: 1_000_000,
-        budget_spent: 0,
-        tokens_burned: 0,
-        burn_count: 0,
+        budget: 1_000_000,
+        spent: 0,
+        tokens_bought: 0,
+        execution_count: 0,
         start_time: env.ledger().timestamp(),
-        end_time: 0,
+        end_time: env.ledger().timestamp() + 86400,
+        min_interval: 300,
+        max_slippage_bps: 100,
+        source_token: dummy_addr.clone(),
+        target_token: dummy_addr,
         status,
         created_at: env.ledger().timestamp(),
+        updated_at: env.ledger().timestamp(),
+        trigger_price: 0,
+        last_executed_at: 0,
     }
 }
 

--- a/contracts/token-factory/src/types.rs
+++ b/contracts/token-factory/src/types.rs
@@ -166,6 +166,66 @@ pub struct BuybackCampaign {
     pub status: CampaignStatus,
     pub created_at: u64,
     pub updated_at: u64,
+    /// Optional price trigger: execute only when price is at or below this value (0 = disabled)
+    pub trigger_price: i128,
+    /// Last execution timestamp for interval enforcement
+    pub last_executed_at: u64,
+}
+
+/// Price trigger condition for buyback automation
+///
+/// Defines the condition under which a buyback should be triggered.
+/// When the current price is at or below `trigger_price`, the buyback executes.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PriceTrigger {
+    /// Price threshold in stroops; buyback fires when price <= this value
+    pub trigger_price: i128,
+    /// Maximum amount to spend per triggered execution
+    pub max_spend_per_trigger: i128,
+}
+
+/// Governance proposal template for common actions
+///
+/// Templates pre-encode common governance actions so proposers don't
+/// need to manually construct payloads.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProposalTemplate {
+    pub id: u32,
+    pub name: String,
+    pub action_type: ActionType,
+    pub description: String,
+    pub created_at: u64,
+}
+
+/// Airdrop campaign with Merkle tree verification
+///
+/// Allows distributing tokens to a predefined set of recipients
+/// verified via a Merkle root.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AirdropCampaign {
+    pub id: u64,
+    pub token_index: u32,
+    pub merkle_root: BytesN<32>,
+    pub total_amount: i128,
+    pub claimed_amount: i128,
+    pub start_time: u64,
+    pub end_time: u64,
+    pub owner: Address,
+    pub status: CampaignStatus,
+    pub created_at: u64,
+}
+
+/// Contract version info for upgrade/migration tracking
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ContractVersion {
+    pub major: u32,
+    pub minor: u32,
+    pub patch: u32,
+    pub migrated_at: u64,
 }
 
 /// Campaign status enum
@@ -307,6 +367,15 @@ pub enum DataKey {
     CampaignByCreator(Address, u32),
     CreatorCampaignCount(Address),
     ActiveCampaigns,
+    // Airdrop
+    AirdropCampaign(u64),
+    AirdropCampaignCount,
+    AirdropClaimed(u64, Address),
+    // Governance templates
+    ProposalTemplate(u32),
+    ProposalTemplateCount,
+    // Contract upgrade
+    ContractVersion,
 }
 
 #[contracttype]
@@ -368,6 +437,26 @@ impl Error {
     pub const CampaignNotFound: Self = Self(51);
     pub const InvalidBudget: Self = Self(52);
     pub const InsufficientBudget: Self = Self(53);
+    // Buyback price trigger errors
+    pub const PriceTriggerNotMet: Self = Self(54);
+    pub const CampaignExpiredError: Self = Self(55);
+    pub const IntervalNotElapsed: Self = Self(56);
+    // Airdrop errors
+    pub const AirdropNotFound: Self = Self(57);
+    pub const AirdropAlreadyClaimed: Self = Self(58);
+    pub const InvalidMerkleProof: Self = Self(59);
+    pub const AirdropExpired: Self = Self(60);
+    pub const AirdropNotStarted: Self = Self(61);
+    // Governance template errors
+    pub const TemplateNotFound: Self = Self(62);
+    // Upgrade errors
+    pub const UpgradeUnauthorized: Self = Self(63);
+    pub const MigrationFailed: Self = Self(64);
+    // Campaign state errors
+    pub const CampaignAlreadyPaused: Self = Self(65);
+    pub const CampaignNotPaused: Self = Self(66);
+    pub const CampaignCompleted: Self = Self(67);
+    pub const CampaignCancelled: Self = Self(68);
 }
 
 impl From<Error> for soroban_sdk::Error {
@@ -411,6 +500,7 @@ pub enum ActionType {
     PauseContract,
     UnpauseContract,
     PolicyUpdate,
+    ParameterChange,
 }
 
 #[contracttype]


### PR DESCRIPTION
closes #874 
closes #875 
closes #876 
closes #877 

- Add price trigger fields (trigger_price, last_executed_at) to BuybackCampaign
- Add PriceTrigger, ProposalTemplate, AirdropCampaign, ContractVersion types
- Add ParameterChange to ActionType enum
- Add new DataKey variants for airdrop, templates, and upgrade storage
- Add error codes 54-68 for new features and campaign state errors
- Fix campaign_state_test.rs and campaign.rs internal tests to use correct struct fields