### PR TITLE
feat(contracts): implement governance quorum adjustment based on part…

### DIFF
--- a/contracts/token-factory/src/events.rs
+++ b/contracts/token-factory/src/events.rs
@@ -466,6 +466,33 @@ pub fn emit_token_unpaused(env: &Env, token_index: u32, admin: &Address) {
     );
 }
 
+/// Emit dynamic quorum adjusted event
+///
+/// **Event Name**: dyn_qrm
+///
+/// **Topics** (indexed):
+/// - Event name: "dyn_qrm"
+///
+/// **Payload** (non-indexed):
+/// - proposal_id: u64 - The proposal whose participation triggered the adjustment
+/// - old_quorum: u32 - Previous effective quorum percent
+/// - new_quorum: u32 - New effective quorum percent
+/// - avg_participation_bps: u32 - Rolling average participation in basis points
+///
+/// Emitted when the dynamic quorum is recalculated after a proposal concludes.
+pub fn emit_dynamic_quorum_adjusted(
+    env: &Env,
+    proposal_id: u64,
+    old_quorum: u32,
+    new_quorum: u32,
+    avg_participation_bps: u32,
+) {
+    env.events().publish(
+        (symbol_short!("dyn_qrm"),),
+        (proposal_id, old_quorum, new_quorum, avg_participation_bps),
+    );
+}
+
 /// Emit metadata set event
 ///
 /// **Event Name**: meta_set

--- a/contracts/token-factory/src/governance.rs
+++ b/contracts/token-factory/src/governance.rs
@@ -1,6 +1,8 @@
 use crate::events;
 use crate::storage;
-use crate::types::{Error, GovernanceConfig};
+use crate::types::{
+    DynamicQuorumConfig, Error, GovernanceConfig, ParticipationRecord,
+};
 use soroban_sdk::{Address, Env};
 
 /// Default quorum percentage (30%)
@@ -150,6 +152,186 @@ fn validate_percentages(quorum_percent: u32, approval_percent: u32) -> Result<()
         return Err(Error::InvalidParameters);
     }
 
+    Ok(())
+}
+
+// ── Dynamic quorum ────────────────────────────────────────────────────────────
+
+/// Configure dynamic quorum adjustment.
+///
+/// Only the admin may call this. Setting `enabled = false` disables dynamic
+/// adjustment without erasing the configuration.
+///
+/// # Validation
+/// * `min_quorum_percent` ≤ `max_quorum_percent`
+/// * Both bounds must be ≤ 100
+/// * `target_participation` must be ≤ 100
+/// * `window_size` must be ≥ 1
+///
+/// # Errors
+/// * `Error::Unauthorized`        – Caller is not the admin.
+/// * `Error::InvalidQuorumBounds` – Bounds are invalid.
+/// * `Error::InvalidParameters`   – Other parameter violations.
+pub fn configure_dynamic_quorum(
+    env: &Env,
+    admin: &Address,
+    config: DynamicQuorumConfig,
+) -> Result<(), Error> {
+    admin.require_auth();
+    let stored_admin = storage::get_admin(env);
+    if *admin != stored_admin {
+        return Err(Error::Unauthorized);
+    }
+
+    validate_dynamic_quorum_config(&config)?;
+
+    storage::set_dynamic_quorum_config(env, &config);
+    Ok(())
+}
+
+/// Get the current dynamic quorum configuration.
+pub fn get_dynamic_quorum_config(env: &Env) -> DynamicQuorumConfig {
+    storage::get_dynamic_quorum_config(env)
+}
+
+/// Record participation data for a concluded proposal and, if dynamic quorum
+/// is enabled, recompute and persist the effective quorum.
+///
+/// This should be called once per proposal after voting closes.
+///
+/// # Arguments
+/// * `env`            – Contract environment.
+/// * `proposal_id`    – ID of the concluded proposal.
+/// * `total_votes`    – Votes cast during the proposal.
+/// * `total_eligible` – Eligible voters at the time of the proposal.
+///
+/// # Returns
+/// The new effective quorum percent (unchanged if dynamic quorum is disabled).
+///
+/// # Errors
+/// * `Error::InvalidParameters` – `total_eligible` is zero.
+/// * `Error::ArithmeticError`   – Overflow in participation calculation.
+pub fn record_participation_and_adjust(
+    env: &Env,
+    proposal_id: u64,
+    total_votes: u32,
+    total_eligible: u32,
+) -> Result<u32, Error> {
+    if total_eligible == 0 {
+        return Err(Error::InvalidParameters);
+    }
+
+    // Compute participation in basis points (0–10 000) to preserve precision.
+    let participation_bps = (total_votes as u64)
+        .checked_mul(10_000)
+        .and_then(|v| v.checked_div(total_eligible as u64))
+        .ok_or(Error::ArithmeticError)? as u32;
+
+    let record = ParticipationRecord {
+        proposal_id,
+        total_votes,
+        total_eligible,
+        participation_bps,
+        recorded_at: env.ledger().timestamp(),
+    };
+    storage::set_participation_record(env, proposal_id, &record);
+
+    let dq_config = storage::get_dynamic_quorum_config(env);
+    if !dq_config.enabled {
+        return Ok(storage::get_governance_config(env).quorum_percent);
+    }
+
+    let new_quorum = compute_adjusted_quorum(env, proposal_id, &dq_config)?;
+    let mut gov_config = storage::get_governance_config(env);
+    let old_quorum = gov_config.quorum_percent;
+
+    gov_config.quorum_percent = new_quorum;
+    storage::set_governance_config(env, &gov_config);
+
+    // Compute rolling average for the event payload.
+    let avg_bps = rolling_average_participation_bps(env, proposal_id, dq_config.window_size);
+    events::emit_dynamic_quorum_adjusted(env, proposal_id, old_quorum, new_quorum, avg_bps);
+
+    Ok(new_quorum)
+}
+
+/// Compute the effective quorum percent from recent participation history.
+///
+/// Formula:
+///   avg_participation_percent = rolling_avg_bps / 100   (integer, floor)
+///   adjusted = clamp(avg_participation_percent, min, max)
+///
+/// The intuition: if recent participation has been high, the quorum can be
+/// raised toward `max_quorum_percent`; if participation has been low, it
+/// relaxes toward `min_quorum_percent`.  The `target_participation` field is
+/// reserved for future weighted formulas and is not used in this version.
+///
+/// # Errors
+/// * `Error::InsufficientParticipationHistory` – No records exist yet.
+fn compute_adjusted_quorum(
+    env: &Env,
+    latest_proposal_id: u64,
+    config: &DynamicQuorumConfig,
+) -> Result<u32, Error> {
+    let avg_bps = rolling_average_participation_bps(env, latest_proposal_id, config.window_size);
+    if avg_bps == u32::MAX {
+        // Sentinel: no history available.
+        return Err(Error::InsufficientParticipationHistory);
+    }
+
+    // Convert BPS to percent (floor division).
+    let avg_percent = avg_bps / 100;
+
+    // Clamp to configured bounds.
+    let adjusted = avg_percent.max(config.min_quorum_percent).min(config.max_quorum_percent);
+    Ok(adjusted)
+}
+
+/// Compute the rolling average participation in basis points over the last
+/// `window_size` proposals ending at `latest_proposal_id`.
+///
+/// Returns `u32::MAX` as a sentinel when no records are found.
+fn rolling_average_participation_bps(env: &Env, latest_proposal_id: u64, window_size: u32) -> u32 {
+    let mut sum: u64 = 0;
+    let mut count: u32 = 0;
+
+    // Walk backwards from latest_proposal_id, collecting up to window_size records.
+    let mut id = latest_proposal_id;
+    loop {
+        if let Some(record) = storage::get_participation_record(env, id) {
+            sum = sum.saturating_add(record.participation_bps as u64);
+            count += 1;
+        }
+        if count >= window_size {
+            break;
+        }
+        if id == 0 {
+            break;
+        }
+        id -= 1;
+    }
+
+    if count == 0 {
+        return u32::MAX; // sentinel: no history
+    }
+
+    (sum / count as u64) as u32
+}
+
+/// Validate a `DynamicQuorumConfig` before persisting.
+fn validate_dynamic_quorum_config(config: &DynamicQuorumConfig) -> Result<(), Error> {
+    if config.min_quorum_percent > config.max_quorum_percent {
+        return Err(Error::InvalidQuorumBounds);
+    }
+    if config.max_quorum_percent > 100 {
+        return Err(Error::InvalidQuorumBounds);
+    }
+    if config.target_participation > 100 {
+        return Err(Error::InvalidParameters);
+    }
+    if config.window_size == 0 {
+        return Err(Error::InvalidParameters);
+    }
     Ok(())
 }
 

--- a/contracts/token-factory/src/governance_dynamic_quorum_test.rs
+++ b/contracts/token-factory/src/governance_dynamic_quorum_test.rs
@@ -1,0 +1,374 @@
+//! Tests for dynamic governance quorum adjustment (Issue #880).
+//!
+//! Covers:
+//! - Happy-path configuration and retrieval
+//! - Authorization enforcement
+//! - Participation recording and quorum adjustment
+//! - Rolling-window averaging
+//! - Boundary / edge cases (window_size=1, zero votes, full participation)
+//! - Error paths (disabled, no history, invalid config)
+//! - Monotonicity and clamping invariants
+
+use crate::{
+    governance::{
+        configure_dynamic_quorum, get_dynamic_quorum_config, get_governance_config,
+        initialize_governance, record_participation_and_adjust,
+    },
+    storage,
+    types::{DynamicQuorumConfig, Error},
+    TokenFactory,
+};
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+fn setup(env: &Env) -> (Address, Address) {
+    let contract_id = env.register_contract(None, TokenFactory);
+    let admin = Address::generate(env);
+    env.as_contract(&contract_id, || {
+        storage::set_admin(env, &admin);
+        initialize_governance(env, Some(30), Some(51)).unwrap();
+    });
+    (admin, contract_id)
+}
+
+fn default_dq_config() -> DynamicQuorumConfig {
+    DynamicQuorumConfig {
+        enabled: true,
+        min_quorum_percent: 10,
+        max_quorum_percent: 60,
+        target_participation: 30,
+        window_size: 3,
+    }
+}
+
+// ── configure_dynamic_quorum ──────────────────────────────────────────────────
+
+#[test]
+fn test_configure_dynamic_quorum_success() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, contract_id) = setup(&env);
+
+    env.as_contract(&contract_id, || {
+        configure_dynamic_quorum(&env, &admin, default_dq_config()).unwrap();
+        let stored = get_dynamic_quorum_config(&env);
+        assert!(stored.enabled);
+        assert_eq!(stored.min_quorum_percent, 10);
+        assert_eq!(stored.max_quorum_percent, 60);
+        assert_eq!(stored.window_size, 3);
+    });
+}
+
+#[test]
+fn test_configure_dynamic_quorum_unauthorized() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_admin, contract_id) = setup(&env);
+    let non_admin = Address::generate(&env);
+
+    let result = env.as_contract(&contract_id, || {
+        configure_dynamic_quorum(&env, &non_admin, default_dq_config())
+    });
+    assert_eq!(result, Err(Error::Unauthorized));
+}
+
+#[test]
+fn test_configure_dynamic_quorum_invalid_bounds_min_gt_max() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, contract_id) = setup(&env);
+
+    let bad_config = DynamicQuorumConfig {
+        min_quorum_percent: 70,
+        max_quorum_percent: 40, // min > max
+        ..default_dq_config()
+    };
+    let result = env.as_contract(&contract_id, || {
+        configure_dynamic_quorum(&env, &admin, bad_config)
+    });
+    assert_eq!(result, Err(Error::InvalidQuorumBounds));
+}
+
+#[test]
+fn test_configure_dynamic_quorum_max_exceeds_100() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, contract_id) = setup(&env);
+
+    let bad_config = DynamicQuorumConfig {
+        max_quorum_percent: 101,
+        ..default_dq_config()
+    };
+    let result = env.as_contract(&contract_id, || {
+        configure_dynamic_quorum(&env, &admin, bad_config)
+    });
+    assert_eq!(result, Err(Error::InvalidQuorumBounds));
+}
+
+#[test]
+fn test_configure_dynamic_quorum_zero_window_size() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, contract_id) = setup(&env);
+
+    let bad_config = DynamicQuorumConfig {
+        window_size: 0,
+        ..default_dq_config()
+    };
+    let result = env.as_contract(&contract_id, || {
+        configure_dynamic_quorum(&env, &admin, bad_config)
+    });
+    assert_eq!(result, Err(Error::InvalidParameters));
+}
+
+#[test]
+fn test_configure_dynamic_quorum_target_exceeds_100() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, contract_id) = setup(&env);
+
+    let bad_config = DynamicQuorumConfig {
+        target_participation: 101,
+        ..default_dq_config()
+    };
+    let result = env.as_contract(&contract_id, || {
+        configure_dynamic_quorum(&env, &admin, bad_config)
+    });
+    assert_eq!(result, Err(Error::InvalidParameters));
+}
+
+#[test]
+fn test_configure_dynamic_quorum_disabled_flag() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, contract_id) = setup(&env);
+
+    let disabled_config = DynamicQuorumConfig {
+        enabled: false,
+        ..default_dq_config()
+    };
+    env.as_contract(&contract_id, || {
+        configure_dynamic_quorum(&env, &admin, disabled_config).unwrap();
+        let stored = get_dynamic_quorum_config(&env);
+        assert!(!stored.enabled);
+    });
+}
+
+// ── record_participation_and_adjust ──────────────────────────────────────────
+
+#[test]
+fn test_record_participation_disabled_returns_current_quorum() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, contract_id) = setup(&env);
+
+    env.as_contract(&contract_id, || {
+        // Dynamic quorum is disabled by default.
+        let result = record_participation_and_adjust(&env, 0, 30, 100).unwrap();
+        // Should return the static quorum (30).
+        assert_eq!(result, 30);
+    });
+    let _ = admin;
+}
+
+#[test]
+fn test_record_participation_zero_eligible_returns_error() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_admin, contract_id) = setup(&env);
+
+    let result = env.as_contract(&contract_id, || {
+        record_participation_and_adjust(&env, 0, 10, 0)
+    });
+    assert_eq!(result, Err(Error::InvalidParameters));
+}
+
+#[test]
+fn test_record_participation_adjusts_quorum_upward() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, contract_id) = setup(&env);
+
+    env.as_contract(&contract_id, || {
+        configure_dynamic_quorum(&env, &admin, default_dq_config()).unwrap();
+
+        // 80% participation → avg = 80% → clamped to max 60%
+        let new_quorum = record_participation_and_adjust(&env, 0, 80, 100).unwrap();
+        assert_eq!(new_quorum, 60); // clamped to max
+        assert_eq!(get_governance_config(&env).quorum_percent, 60);
+    });
+}
+
+#[test]
+fn test_record_participation_adjusts_quorum_downward() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, contract_id) = setup(&env);
+
+    env.as_contract(&contract_id, || {
+        configure_dynamic_quorum(&env, &admin, default_dq_config()).unwrap();
+
+        // 5% participation → avg = 5% → clamped to min 10%
+        let new_quorum = record_participation_and_adjust(&env, 0, 5, 100).unwrap();
+        assert_eq!(new_quorum, 10); // clamped to min
+    });
+}
+
+#[test]
+fn test_record_participation_within_bounds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, contract_id) = setup(&env);
+
+    env.as_contract(&contract_id, || {
+        configure_dynamic_quorum(&env, &admin, default_dq_config()).unwrap();
+
+        // 35% participation → avg = 35% → within [10, 60] → quorum = 35
+        let new_quorum = record_participation_and_adjust(&env, 0, 35, 100).unwrap();
+        assert_eq!(new_quorum, 35);
+    });
+}
+
+#[test]
+fn test_rolling_window_averages_multiple_proposals() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, contract_id) = setup(&env);
+
+    env.as_contract(&contract_id, || {
+        configure_dynamic_quorum(&env, &admin, default_dq_config()).unwrap();
+
+        // Proposal 0: 20% participation
+        record_participation_and_adjust(&env, 0, 20, 100).unwrap();
+        // Proposal 1: 40% participation
+        record_participation_and_adjust(&env, 1, 40, 100).unwrap();
+        // Proposal 2: 30% participation → rolling avg of [20,40,30] = 30%
+        let new_quorum = record_participation_and_adjust(&env, 2, 30, 100).unwrap();
+        assert_eq!(new_quorum, 30);
+    });
+}
+
+#[test]
+fn test_rolling_window_size_one() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, contract_id) = setup(&env);
+
+    env.as_contract(&contract_id, || {
+        let config = DynamicQuorumConfig {
+            window_size: 1,
+            ..default_dq_config()
+        };
+        configure_dynamic_quorum(&env, &admin, config).unwrap();
+
+        // Only the latest proposal matters.
+        record_participation_and_adjust(&env, 0, 10, 100).unwrap(); // 10%
+        let new_quorum = record_participation_and_adjust(&env, 1, 50, 100).unwrap(); // 50%
+        assert_eq!(new_quorum, 50);
+    });
+}
+
+#[test]
+fn test_full_participation_clamped_to_max() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, contract_id) = setup(&env);
+
+    env.as_contract(&contract_id, || {
+        configure_dynamic_quorum(&env, &admin, default_dq_config()).unwrap();
+        let new_quorum = record_participation_and_adjust(&env, 0, 100, 100).unwrap();
+        assert_eq!(new_quorum, 60); // max_quorum_percent
+    });
+}
+
+#[test]
+fn test_zero_votes_clamped_to_min() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, contract_id) = setup(&env);
+
+    env.as_contract(&contract_id, || {
+        configure_dynamic_quorum(&env, &admin, default_dq_config()).unwrap();
+        let new_quorum = record_participation_and_adjust(&env, 0, 0, 100).unwrap();
+        assert_eq!(new_quorum, 10); // min_quorum_percent
+    });
+}
+
+#[test]
+fn test_quorum_persisted_after_adjustment() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, contract_id) = setup(&env);
+
+    env.as_contract(&contract_id, || {
+        configure_dynamic_quorum(&env, &admin, default_dq_config()).unwrap();
+        record_participation_and_adjust(&env, 0, 45, 100).unwrap();
+        // Verify the governance config was actually updated.
+        let config = get_governance_config(&env);
+        assert_eq!(config.quorum_percent, 45);
+    });
+}
+
+#[test]
+fn test_participation_record_stored() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, contract_id) = setup(&env);
+
+    env.as_contract(&contract_id, || {
+        configure_dynamic_quorum(&env, &admin, default_dq_config()).unwrap();
+        record_participation_and_adjust(&env, 7, 25, 100).unwrap();
+
+        let record = storage::get_participation_record(&env, 7).unwrap();
+        assert_eq!(record.proposal_id, 7);
+        assert_eq!(record.total_votes, 25);
+        assert_eq!(record.total_eligible, 100);
+        // 25/100 = 25% = 2500 bps
+        assert_eq!(record.participation_bps, 2500);
+    });
+}
+
+#[test]
+fn test_min_equals_max_quorum_always_returns_that_value() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, contract_id) = setup(&env);
+
+    env.as_contract(&contract_id, || {
+        let config = DynamicQuorumConfig {
+            min_quorum_percent: 40,
+            max_quorum_percent: 40,
+            ..default_dq_config()
+        };
+        configure_dynamic_quorum(&env, &admin, config).unwrap();
+
+        // Regardless of participation, quorum must always be 40.
+        for votes in [0u32, 10, 50, 90, 100] {
+            let q = record_participation_and_adjust(&env, votes as u64, votes, 100).unwrap();
+            assert_eq!(q, 40, "quorum must be 40 for votes={votes}");
+        }
+    });
+}
+
+// ── property: monotonicity ────────────────────────────────────────────────────
+
+#[test]
+fn test_higher_participation_never_lowers_quorum_below_lower_participation() {
+    // With a single-proposal window, higher participation → higher (or equal) quorum.
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, contract_id) = setup(&env);
+
+    env.as_contract(&contract_id, || {
+        let config = DynamicQuorumConfig {
+            window_size: 1,
+            ..default_dq_config()
+        };
+        configure_dynamic_quorum(&env, &admin, config).unwrap();
+
+        let q_low = record_participation_and_adjust(&env, 0, 10, 100).unwrap();
+        let q_high = record_participation_and_adjust(&env, 1, 80, 100).unwrap();
+        assert!(q_high >= q_low, "higher participation must not lower quorum");
+    });
+}

--- a/contracts/token-factory/src/lib.rs
+++ b/contracts/token-factory/src/lib.rs
@@ -56,6 +56,8 @@ mod governance_quorum_property_test;
 #[cfg(test)]
 mod governance_config_auth_property_test;
 #[cfg(test)]
+mod governance_dynamic_quorum_test;
+#[cfg(test)]
 mod payload_validation_fuzz_test;
 
 #[cfg(test)]
@@ -85,9 +87,9 @@ mod stream_claim_differential_test;
 
 use soroban_sdk::{contract, contractimpl, symbol_short, Address, Bytes, BytesN, Env, String, Symbol, Vec};
 use types::{
-    AuctionStatus, BurnAuction, BuybackCampaign, CampaignStatus, ContractMetadata, Error,
-    FactoryState, PaginationCursor, StreamInfo, StreamPage, StreamParams, TokenCreationParams,
-    TokenInfo, TokenStats, Vault, VaultStatus,
+    AuctionStatus, BurnAuction, BuybackCampaign, CampaignStatus, ContractMetadata,
+    DynamicQuorumConfig, Error, FactoryState, PaginationCursor, StreamInfo, StreamPage,
+    StreamParams, TokenCreationParams, TokenInfo, TokenStats, Vault, VaultStatus,
 };
 use crate::milestone_verification::MilestoneVerifier;
 
@@ -2463,6 +2465,62 @@ impl TokenFactory {
         approval_percent: u32,
     ) -> bool {
         governance::is_approval_met(yes_votes, total_votes, approval_percent)
+    }
+
+    /// Configure dynamic quorum adjustment based on participation history.
+    ///
+    /// When enabled, the effective quorum is automatically recalculated after
+    /// each proposal concludes, using a rolling average of recent participation
+    /// rates clamped to [min_quorum_percent, max_quorum_percent].
+    ///
+    /// # Arguments
+    /// * `env`    – The contract environment.
+    /// * `admin`  – Admin address (must authorize).
+    /// * `config` – The dynamic quorum configuration to apply.
+    ///
+    /// # Errors
+    /// * `Error::Unauthorized`        – Caller is not the admin.
+    /// * `Error::InvalidQuorumBounds` – min > max or max > 100.
+    /// * `Error::InvalidParameters`   – window_size is 0 or target > 100.
+    pub fn configure_dynamic_quorum(
+        env: Env,
+        admin: Address,
+        config: types::DynamicQuorumConfig,
+    ) -> Result<(), Error> {
+        governance::configure_dynamic_quorum(&env, &admin, config)
+    }
+
+    /// Get the current dynamic quorum configuration.
+    pub fn get_dynamic_quorum_config(env: Env) -> types::DynamicQuorumConfig {
+        governance::get_dynamic_quorum_config(&env)
+    }
+
+    /// Record participation for a concluded proposal and adjust the quorum.
+    ///
+    /// Should be called once after a proposal's voting period ends.
+    /// If dynamic quorum is disabled, the quorum is unchanged and the current
+    /// value is returned.
+    ///
+    /// # Arguments
+    /// * `env`            – The contract environment.
+    /// * `proposal_id`    – ID of the concluded proposal.
+    /// * `total_votes`    – Votes cast during the proposal.
+    /// * `total_eligible` – Eligible voters at the time of the proposal.
+    ///
+    /// # Returns
+    /// The new effective quorum percent.
+    ///
+    /// # Errors
+    /// * `Error::InvalidParameters`              – total_eligible is zero.
+    /// * `Error::InsufficientParticipationHistory` – No history to average over.
+    /// * `Error::ArithmeticError`                – Overflow in calculation.
+    pub fn record_participation_and_adjust(
+        env: Env,
+        proposal_id: u64,
+        total_votes: u32,
+        total_eligible: u32,
+    ) -> Result<u32, Error> {
+        governance::record_participation_and_adjust(&env, proposal_id, total_votes, total_eligible)
     }
 
     /// Create a new buyback campaign

--- a/contracts/token-factory/src/storage.rs
+++ b/contracts/token-factory/src/storage.rs
@@ -1280,6 +1280,50 @@ pub fn set_governance_config(env: &Env, config: &crate::types::GovernanceConfig)
         .set(&DataKey::GovernanceConfig, config);
 }
 
+// ── Dynamic quorum storage functions ──────────────────────
+
+/// Get dynamic quorum configuration (defaults to disabled).
+pub fn get_dynamic_quorum_config(env: &Env) -> crate::types::DynamicQuorumConfig {
+    env.storage()
+        .instance()
+        .get(&DataKey::DynamicQuorumConfig)
+        .unwrap_or(crate::types::DynamicQuorumConfig {
+            enabled: false,
+            min_quorum_percent: 10,
+            max_quorum_percent: 80,
+            target_participation: 30,
+            window_size: 5,
+        })
+}
+
+/// Persist dynamic quorum configuration.
+pub fn set_dynamic_quorum_config(env: &Env, config: &crate::types::DynamicQuorumConfig) {
+    env.storage()
+        .instance()
+        .set(&DataKey::DynamicQuorumConfig, config);
+}
+
+/// Store a participation record for a concluded proposal.
+pub fn set_participation_record(
+    env: &Env,
+    proposal_id: u64,
+    record: &crate::types::ParticipationRecord,
+) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::ParticipationRecord(proposal_id), record);
+}
+
+/// Retrieve a participation record by proposal ID.
+pub fn get_participation_record(
+    env: &Env,
+    proposal_id: u64,
+) -> Option<crate::types::ParticipationRecord> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::ParticipationRecord(proposal_id))
+}
+
 // ── Milestone Verification (Stub Testing) ────────────────────────────────────────────────────────────────────
 
 /// Set a valid proof for milestone verification testing

--- a/contracts/token-factory/src/types.rs
+++ b/contracts/token-factory/src/types.rs
@@ -164,6 +164,48 @@ pub struct GovernanceConfig {
     pub voting_period: u64,
 }
 
+/// Configuration for dynamic quorum adjustment based on historical participation.
+///
+/// When enabled, the effective quorum for a proposal is computed from the
+/// rolling average of recent participation rates, clamped to [min_quorum_percent,
+/// max_quorum_percent].
+///
+/// # Fields
+/// * `enabled`              – Whether dynamic adjustment is active.
+/// * `min_quorum_percent`   – Floor for the adjusted quorum (0–100).
+/// * `max_quorum_percent`   – Ceiling for the adjusted quorum (0–100, ≥ min).
+/// * `target_participation` – Ideal participation rate (0–100) used as the
+///                            reference point for the adjustment formula.
+/// * `window_size`          – Number of recent proposals to average over (≥ 1).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DynamicQuorumConfig {
+    pub enabled: bool,
+    pub min_quorum_percent: u32,
+    pub max_quorum_percent: u32,
+    pub target_participation: u32,
+    pub window_size: u32,
+}
+
+/// Participation snapshot recorded after each proposal concludes.
+///
+/// # Fields
+/// * `proposal_id`       – The proposal this record belongs to.
+/// * `total_votes`       – Votes cast during the proposal.
+/// * `total_eligible`    – Eligible voters at the time of the proposal.
+/// * `participation_bps` – Actual participation in basis points (0–10 000).
+///                         Stored as BPS to avoid floating-point arithmetic.
+/// * `recorded_at`       – Ledger timestamp when the record was written.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ParticipationRecord {
+    pub proposal_id: u64,
+    pub total_votes: u32,
+    pub total_eligible: u32,
+    pub participation_bps: u32,
+    pub recorded_at: u64,
+}
+
 /// Buyback campaign structure
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -571,6 +613,9 @@ pub enum DataKey {
     ProposalTemplateCount,
     // Contract upgrade
     ContractVersion,
+    // Dynamic quorum
+    DynamicQuorumConfig,
+    ParticipationRecord(u64), // keyed by proposal_id
 }
 
 #[contracttype]
@@ -652,6 +697,10 @@ impl Error {
     pub const CampaignNotPaused: Self = Self(66);
     pub const CampaignCompleted: Self = Self(67);
     pub const CampaignCancelled: Self = Self(68);
+    // Dynamic quorum errors
+    pub const DynamicQuorumDisabled: Self = Self(69);
+    pub const InsufficientParticipationHistory: Self = Self(70);
+    pub const InvalidQuorumBounds: Self = Self(71);
 }
 
 impl From<Error> for soroban_sdk::Error {

--- a/contracts/token-factory/src/vault_concurrent_claims_chaos_test.rs
+++ b/contracts/token-factory/src/vault_concurrent_claims_chaos_test.rs
@@ -1,0 +1,1 @@
+// Vault concurrent claims chaos test – stub placeholder

--- a/contracts/token-factory/src/vault_funding_overflow_property_test.rs
+++ b/contracts/token-factory/src/vault_funding_overflow_property_test.rs
@@ -1,0 +1,1 @@
+// Property 73 – stub placeholder (tests to be added)


### PR DESCRIPTION
…icipation

- Add DynamicQuorumConfig and ParticipationRecord types to types.rs
- Add DynamicQuorumConfig and ParticipationRecord storage keys to DataKey enum
- Add new error codes: DynamicQuorumDisabled, InsufficientParticipationHistory, InvalidQuorumBounds
- Implement configure_dynamic_quorum, get_dynamic_quorum_config, and record_participation_and_adjust in governance.rs
- Rolling window average of participation BPS clamps effective quorum to [min, max]
- Add get/set_dynamic_quorum_config and get/set_participation_record to storage.rs
- Emit dyn_qrm event on every quorum adjustment in events.rs
- Expose three new contract entry points in lib.rs
- Add 20 unit tests in governance_dynamic_quorum_test.rs covering auth, config validation, quorum adjustment, rolling window, clamping, and monotonicity
- Fix pre-existing inner doc comment errors in gas_compute_thresholds.rs
- Fix pre-existing unexpected closing brace in stream_lifecycle_integration_test.rs
- Add stub files for missing vault_funding_overflow_property_test and vault_concurrent_claims_chaos_test modules
closes #880