### PR TITLE
infra(deployment): develop multi-region deployment with geo-replication

### DIFF
--- a/gateway/.env.example
+++ b/gateway/.env.example
@@ -1,0 +1,6 @@
+GATEWAY_PORT=4000
+BACKEND_URL=http://localhost:3001
+JWT_SECRET=change-me-in-production
+REDIS_URL=redis://localhost:6379
+ALLOWED_ORIGINS=http://localhost:5173
+NODE_ENV=development

--- a/gateway/.gitignore
+++ b/gateway/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+coverage/
+*.env
+.env

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY tsconfig.json ./
+COPY src ./src
+RUN npm run build
+
+FROM node:20-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --omit=dev
+COPY --from=builder /app/dist ./dist
+EXPOSE 4000
+CMD ["node", "dist/index.js"]

--- a/gateway/docker-compose.yml
+++ b/gateway/docker-compose.yml
@@ -1,0 +1,43 @@
+version: "3.8"
+
+services:
+  redis:
+    image: redis:7-alpine
+    container_name: gateway-redis
+    ports:
+      - "6380:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  gateway:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: nova-launch-gateway
+    depends_on:
+      redis:
+        condition: service_healthy
+    environment:
+      NODE_ENV: ${NODE_ENV:-development}
+      GATEWAY_PORT: ${GATEWAY_PORT:-4000}
+      BACKEND_URL: ${BACKEND_URL:-http://host.docker.internal:3001}
+      JWT_SECRET: ${JWT_SECRET:-dev-secret-key-change-me}
+      REDIS_URL: redis://redis:6379
+      ALLOWED_ORIGINS: ${ALLOWED_ORIGINS:-http://localhost:5173}
+    ports:
+      - "${GATEWAY_PORT:-4000}:4000"
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "require('http').get('http://localhost:4000/health', (r) => process.exit(r.statusCode === 200 ? 0 : 1))",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s

--- a/gateway/package.json
+++ b/gateway/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "nova-launch-gateway",
+  "version": "1.0.0",
+  "description": "API Gateway with rate limiting and authentication for Nova Launch",
+  "main": "dist/index.js",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "dotenv": "^16.3.1",
+    "express": "^4.18.2",
+    "helmet": "^7.1.0",
+    "http-proxy-middleware": "^3.0.3",
+    "ioredis": "^5.10.1",
+    "jsonwebtoken": "^9.0.2"
+  },
+  "devDependencies": {
+    "@types/cors": "^2.8.17",
+    "@types/express": "^4.17.21",
+    "@types/http-proxy-middleware": "^0.19.3",
+    "@types/jsonwebtoken": "^9.0.5",
+    "@types/node": "^20.10.6",
+    "@types/supertest": "^6.0.3",
+    "@vitest/coverage-v8": "^1.6.1",
+    "supertest": "^7.2.2",
+    "tsx": "^4.7.0",
+    "typescript": "^5.3.3",
+    "vitest": "^1.1.0"
+  }
+}

--- a/gateway/src/__tests__/app.test.ts
+++ b/gateway/src/__tests__/app.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import request from "supertest";
+import jwt from "jsonwebtoken";
+import { createApp } from "../app";
+import { GatewayEnv } from "../config";
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const SECRET = "test-gateway-secret";
+
+const ENV: GatewayEnv = {
+  PORT: 4000,
+  BACKEND_URL: "http://backend:3001",
+  JWT_SECRET: SECRET,
+  REDIS_URL: "redis://localhost:6379",
+  ALLOWED_ORIGINS: ["http://localhost:5173"],
+  NODE_ENV: "test",
+};
+
+/** Mock Redis that always returns count=1 (well under any limit). */
+function mockRedis() {
+  const pipeline = {
+    zremrangebyscore: vi.fn().mockReturnThis(),
+    zadd:             vi.fn().mockReturnThis(),
+    zcard:            vi.fn().mockReturnThis(),
+    expire:           vi.fn().mockReturnThis(),
+    exec: vi.fn().mockResolvedValue([[null, 0], [null, 1], [null, 1], [null, 1]]),
+  };
+  return { pipeline: vi.fn().mockReturnValue(pipeline), on: vi.fn(), _pipeline: pipeline } as any;
+}
+
+function validToken(payload: object = { userId: "u1" }) {
+  return jwt.sign(payload, SECRET);
+}
+
+// ── Health endpoints ──────────────────────────────────────────────────────────
+
+describe("GET /health", () => {
+  const app = createApp({ env: ENV, redis: mockRedis() });
+
+  it("returns 200 with status ok", async () => {
+    const res = await request(app).get("/health");
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("ok");
+    expect(res.body.service).toBe("api-gateway");
+  });
+
+  it("does not require authentication", async () => {
+    const res = await request(app).get("/health");
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("GET /health/live", () => {
+  const app = createApp({ env: ENV, redis: mockRedis() });
+
+  it("returns 200", async () => {
+    const res = await request(app).get("/health/live");
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("GET /health/ready", () => {
+  const app = createApp({ env: ENV, redis: mockRedis() });
+
+  it("returns 200", async () => {
+    const res = await request(app).get("/health/ready");
+    expect(res.status).toBe(200);
+  });
+});
+
+// ── Authentication ────────────────────────────────────────────────────────────
+
+describe("Authentication middleware", () => {
+  // We don't have a real backend, so proxy calls will 502.
+  // We only care about the auth layer (401 vs not-401).
+  const app = createApp({ env: ENV, redis: mockRedis() });
+
+  it("returns 401 for /api/tokens without a token", async () => {
+    const res = await request(app).get("/api/tokens");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 for /api/admin without a token", async () => {
+    const res = await request(app).get("/api/admin");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 for an invalid token", async () => {
+    const res = await request(app)
+      .get("/api/tokens")
+      .set("Authorization", "Bearer invalid.token");
+    expect(res.status).toBe(401);
+  });
+
+  it("passes auth with a valid token (proxy may 502 — that's fine)", async () => {
+    const res = await request(app)
+      .get("/api/tokens")
+      .set("Authorization", `Bearer ${validToken()}`);
+    // Auth passed; proxy to non-existent backend → 502 or ECONNREFUSED → 502
+    expect(res.status).not.toBe(401);
+  });
+});
+
+// ── CORS ──────────────────────────────────────────────────────────────────────
+
+describe("CORS", () => {
+  const app = createApp({ env: ENV, redis: mockRedis() });
+
+  it("allows requests from an allowed origin", async () => {
+    const res = await request(app)
+      .get("/health")
+      .set("Origin", "http://localhost:5173");
+    expect(res.headers["access-control-allow-origin"]).toBe("http://localhost:5173");
+  });
+
+  it("does not set ACAO header for a disallowed origin", async () => {
+    const res = await request(app)
+      .get("/health")
+      .set("Origin", "http://evil.com");
+    expect(res.headers["access-control-allow-origin"]).toBeUndefined();
+  });
+});
+
+// ── 404 fallback ──────────────────────────────────────────────────────────────
+
+describe("404 fallback", () => {
+  const app = createApp({ env: ENV, redis: mockRedis() });
+
+  it("returns 404 for unknown routes", async () => {
+    const res = await request(app)
+      .get("/unknown-path")
+      .set("Authorization", `Bearer ${validToken()}`);
+    expect(res.status).toBe(404);
+  });
+});
+
+// ── Rate limiting headers ─────────────────────────────────────────────────────
+
+describe("Rate limiting headers", () => {
+  it("sets X-RateLimit-Limit on proxied routes", async () => {
+    const redis = mockRedis();
+    const app = createApp({ env: ENV, redis });
+
+    const res = await request(app)
+      .get("/api/tokens")
+      .set("Authorization", `Bearer ${validToken()}`);
+
+    // Header is set by rate limiter before proxy runs
+    expect(res.headers["x-ratelimit-limit"]).toBeDefined();
+  });
+
+  it("sets X-RateLimit-Remaining on proxied routes", async () => {
+    const redis = mockRedis();
+    const app = createApp({ env: ENV, redis });
+
+    const res = await request(app)
+      .get("/api/tokens")
+      .set("Authorization", `Bearer ${validToken()}`);
+
+    expect(res.headers["x-ratelimit-remaining"]).toBeDefined();
+  });
+});
+
+// ── validateGatewayEnv ────────────────────────────────────────────────────────
+
+describe("validateGatewayEnv", () => {
+  it("throws when JWT_SECRET is missing in production", async () => {
+    const original = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+    process.env.JWT_SECRET = "";
+
+    const { validateGatewayEnv } = await import("../config");
+    expect(() => validateGatewayEnv()).toThrow("JWT_SECRET");
+
+    process.env.NODE_ENV = original;
+  });
+
+  it("returns defaults in development", async () => {
+    process.env.NODE_ENV = "development";
+    delete process.env.JWT_SECRET;
+
+    const { validateGatewayEnv } = await import("../config");
+    const env = validateGatewayEnv();
+    expect(env.JWT_SECRET).toBeTruthy();
+    expect(env.PORT).toBeGreaterThan(0);
+  });
+});

--- a/gateway/src/__tests__/auth.test.ts
+++ b/gateway/src/__tests__/auth.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi } from "vitest";
+import { Request, NextFunction } from "express";
+import jwt from "jsonwebtoken";
+import { createAuthMiddleware } from "../auth";
+
+const next = (): NextFunction => vi.fn() as unknown as NextFunction;
+
+const SECRET = "test-secret";
+
+function mockReq(overrides: Partial<Request> = {}): Request {
+  return { headers: {}, path: "/api/tokens", ...overrides } as any;
+}
+
+function mockRes() {
+  let statusCode = 200;
+  let body: any;
+  const res: any = {
+    status: vi.fn((c: number) => { statusCode = c; return res; }),
+    json:   vi.fn((b: any)   => { body = b; return res; }),
+    get statusCode() { return statusCode; },
+    get body()       { return body; },
+  };
+  return res;
+}
+
+describe("createAuthMiddleware", () => {
+  const auth = createAuthMiddleware(SECRET);
+
+  it("calls next() for /health without a token", () => {
+    const n = next();
+    auth(mockReq({ path: "/health" }), mockRes(), n);
+    expect(n).toHaveBeenCalledOnce();
+  });
+
+  it("calls next() for /health/live without a token", () => {
+    const n = next();
+    auth(mockReq({ path: "/health/live" }), mockRes(), n);
+    expect(n).toHaveBeenCalledOnce();
+  });
+
+  it("calls next() for /health/ready without a token", () => {
+    const n = next();
+    auth(mockReq({ path: "/health/ready" }), mockRes(), n);
+    expect(n).toHaveBeenCalledOnce();
+  });
+
+  it("returns 401 when Authorization header is missing", () => {
+    const res = mockRes();
+    auth(mockReq(), res, next());
+    expect(res.statusCode).toBe(401);
+    expect(res.body.error).toMatch(/authentication required/i);
+  });
+
+  it("returns 401 when Authorization header is not Bearer", () => {
+    const res = mockRes();
+    auth(mockReq({ headers: { authorization: "Basic abc" } }), res, next());
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("returns 401 for an invalid token", () => {
+    const res = mockRes();
+    auth(
+      mockReq({ headers: { authorization: "Bearer invalid.token.here" } }),
+      res,
+      next()
+    );
+    expect(res.statusCode).toBe(401);
+    expect(res.body.error).toMatch(/invalid or expired/i);
+  });
+
+  it("returns 401 for an expired token", () => {
+    const expired = jwt.sign({ userId: "u1" }, SECRET, { expiresIn: -1 });
+    const res = mockRes();
+    auth(
+      mockReq({ headers: { authorization: `Bearer ${expired}` } }),
+      res,
+      next()
+    );
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("calls next() and attaches user for a valid token", () => {
+    const token = jwt.sign({ userId: "u1", role: "admin" }, SECRET);
+    const n = next();
+    const req = mockReq({ headers: { authorization: `Bearer ${token}` } });
+    auth(req, mockRes(), n);
+    expect(n).toHaveBeenCalledOnce();
+    expect((req as any).user?.userId).toBe("u1");
+  });
+
+  it("attaches walletAddress from token payload", () => {
+    const token = jwt.sign({ userId: "u2", walletAddress: "GWALLET" }, SECRET);
+    const req = mockReq({ headers: { authorization: `Bearer ${token}` } });
+    auth(req, mockRes(), next());
+    expect((req as any).user?.walletAddress).toBe("GWALLET");
+  });
+
+  it("does not call next() when token is invalid", () => {
+    const n = next();
+    auth(
+      mockReq({ headers: { authorization: "Bearer bad" } }),
+      mockRes(),
+      n
+    );
+    expect(n).not.toHaveBeenCalled();
+  });
+});

--- a/gateway/src/__tests__/rateLimiter.test.ts
+++ b/gateway/src/__tests__/rateLimiter.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, vi } from "vitest";
+import { Request, NextFunction } from "express";
+import {
+  createRateLimiter,
+  incrementSlidingWindow,
+  resolveRateLimitKey,
+} from "../rateLimiter";
+
+const next = (): NextFunction => vi.fn() as unknown as NextFunction;
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function mockRedis(count = 1) {
+  const pipeline = {
+    zremrangebyscore: vi.fn().mockReturnThis(),
+    zadd:             vi.fn().mockReturnThis(),
+    zcard:            vi.fn().mockReturnThis(),
+    expire:           vi.fn().mockReturnThis(),
+    exec: vi.fn().mockResolvedValue([
+      [null, 0],
+      [null, 1],
+      [null, count],
+      [null, 1],
+    ]),
+  };
+  return { pipeline: vi.fn().mockReturnValue(pipeline), on: vi.fn(), _pipeline: pipeline } as any;
+}
+
+function mockReq(overrides: Partial<Request> = {}): Request {
+  return { ip: "127.0.0.1", socket: { remoteAddress: "127.0.0.1" }, headers: {}, ...overrides } as any;
+}
+
+function mockRes() {
+  const headers: Record<string, any> = {};
+  let statusCode = 200;
+  let body: any;
+  const res: any = {
+    headers,
+    setHeader: vi.fn((k: string, v: any) => { headers[k] = v; }),
+    status:    vi.fn((c: number) => { statusCode = c; return res; }),
+    json:      vi.fn((b: any)   => { body = b; return res; }),
+    get statusCode() { return statusCode; },
+    get body()       { return body; },
+  };
+  return res;
+}
+
+// ── resolveRateLimitKey ───────────────────────────────────────────────────────
+
+describe("resolveRateLimitKey", () => {
+  it("uses IP when no user is attached", () => {
+    expect(resolveRateLimitKey(mockReq({ ip: "1.2.3.4" }), "gw")).toBe("gw:ip:1.2.3.4");
+  });
+
+  it("uses walletAddress when user is authenticated", () => {
+    const req = mockReq({ user: { walletAddress: "GWALLET" } } as any);
+    expect(resolveRateLimitKey(req, "gw")).toBe("gw:wallet:GWALLET");
+  });
+
+  it("falls back to socket.remoteAddress when req.ip is undefined", () => {
+    const req = mockReq({ ip: undefined, socket: { remoteAddress: "5.6.7.8" } as any });
+    expect(resolveRateLimitKey(req, "gw")).toBe("gw:ip:5.6.7.8");
+  });
+
+  it("uses 'unknown' when no address is available", () => {
+    const req = mockReq({ ip: undefined, socket: undefined as any });
+    expect(resolveRateLimitKey(req, "gw")).toBe("gw:ip:unknown");
+  });
+});
+
+// ── incrementSlidingWindow ────────────────────────────────────────────────────
+
+describe("incrementSlidingWindow", () => {
+  it("executes the correct pipeline commands", async () => {
+    const redis = mockRedis();
+    await incrementSlidingWindow(redis, "key", 60_000);
+    const p = redis._pipeline;
+    expect(p.zremrangebyscore).toHaveBeenCalledOnce();
+    expect(p.zadd).toHaveBeenCalledOnce();
+    expect(p.zcard).toHaveBeenCalledOnce();
+    expect(p.expire).toHaveBeenCalledOnce();
+  });
+
+  it("returns the zcard count", async () => {
+    const redis = mockRedis(7);
+    expect(await incrementSlidingWindow(redis, "key", 60_000)).toBe(7);
+  });
+
+  it("falls back to 1 when exec returns null", async () => {
+    const redis = mockRedis();
+    redis._pipeline.exec.mockResolvedValue(null);
+    expect(await incrementSlidingWindow(redis, "key", 60_000)).toBe(1);
+  });
+
+  it("sets TTL to ceil(windowMs/1000)+1", async () => {
+    const redis = mockRedis();
+    await incrementSlidingWindow(redis, "key", 60_000);
+    const [, ttl] = redis._pipeline.expire.mock.calls[0];
+    expect(ttl).toBe(61);
+  });
+});
+
+// ── createRateLimiter — allows ────────────────────────────────────────────────
+
+describe("createRateLimiter — allows requests under the limit", () => {
+  it("calls next() when count ≤ max", async () => {
+    const n = next();
+    await createRateLimiter(mockRedis(1), { windowMs: 60_000, max: 10 })(mockReq(), mockRes(), n);
+    expect(n).toHaveBeenCalledOnce();
+  });
+
+  it("sets X-RateLimit-Limit header", async () => {
+    const res = mockRes();
+    await createRateLimiter(mockRedis(1), { windowMs: 60_000, max: 10 })(mockReq(), res, next());
+    expect(res.headers["X-RateLimit-Limit"]).toBe(10);
+  });
+
+  it("sets X-RateLimit-Remaining header", async () => {
+    const res = mockRes();
+    await createRateLimiter(mockRedis(3), { windowMs: 60_000, max: 10 })(mockReq(), res, next());
+    expect(res.headers["X-RateLimit-Remaining"]).toBe(7);
+  });
+
+  it("sets X-RateLimit-Reset as a future Unix timestamp", async () => {
+    const res = mockRes();
+    const before = Math.floor(Date.now() / 1000);
+    await createRateLimiter(mockRedis(1), { windowMs: 60_000, max: 10 })(mockReq(), res, next());
+    expect(res.headers["X-RateLimit-Reset"]).toBeGreaterThanOrEqual(before + 60);
+  });
+
+  it("allows exactly max requests (count === max)", async () => {
+    const n = next();
+    await createRateLimiter(mockRedis(10), { windowMs: 60_000, max: 10 })(mockReq(), mockRes(), n);
+    expect(n).toHaveBeenCalledOnce();
+  });
+});
+
+// ── createRateLimiter — blocks ────────────────────────────────────────────────
+
+describe("createRateLimiter — blocks requests over the limit", () => {
+  it("responds 429 when count > max", async () => {
+    const res = mockRes();
+    await createRateLimiter(mockRedis(11), { windowMs: 60_000, max: 10 })(mockReq(), res, next());
+    expect(res.statusCode).toBe(429);
+  });
+
+  it("does not call next() on 429", async () => {
+    const n = next();
+    await createRateLimiter(mockRedis(11), { windowMs: 60_000, max: 10 })(mockReq(), mockRes(), n);
+    expect(n).not.toHaveBeenCalled();
+  });
+
+  it("uses custom message when provided", async () => {
+    const res = mockRes();
+    await createRateLimiter(mockRedis(11), { windowMs: 60_000, max: 10, message: "Custom" })(
+      mockReq(), res, next()
+    );
+    expect(res.body.error).toBe("Custom");
+  });
+
+  it("sets Retry-After header on 429", async () => {
+    const res = mockRes();
+    await createRateLimiter(mockRedis(11), { windowMs: 60_000, max: 10 })(mockReq(), res, next());
+    expect(res.headers["Retry-After"]).toBeGreaterThan(0);
+  });
+
+  it("sets X-RateLimit-Remaining to 0 when over limit", async () => {
+    const res = mockRes();
+    await createRateLimiter(mockRedis(20), { windowMs: 60_000, max: 10 })(mockReq(), res, next());
+    expect(res.headers["X-RateLimit-Remaining"]).toBe(0);
+  });
+});
+
+// ── createRateLimiter — fail-open ─────────────────────────────────────────────
+
+describe("createRateLimiter — Redis unavailable (fail-open)", () => {
+  it("calls next() when Redis throws", async () => {
+    const redis = mockRedis();
+    redis._pipeline.exec.mockRejectedValue(new Error("ECONNREFUSED"));
+    const n = next();
+    await createRateLimiter(redis, { windowMs: 60_000, max: 10 })(mockReq(), mockRes(), n);
+    expect(n).toHaveBeenCalledOnce();
+  });
+
+  it("does not set rate-limit headers when Redis is down", async () => {
+    const redis = mockRedis();
+    redis._pipeline.exec.mockRejectedValue(new Error("timeout"));
+    const res = mockRes();
+    await createRateLimiter(redis, { windowMs: 60_000, max: 10 })(mockReq(), res, next());
+    expect(res.headers["X-RateLimit-Limit"]).toBeUndefined();
+  });
+});
+
+// ── Key prefix isolation ──────────────────────────────────────────────────────
+
+describe("createRateLimiter — key prefix", () => {
+  it("uses the configured keyPrefix in the Redis key", async () => {
+    const redis = mockRedis();
+    await createRateLimiter(redis, { windowMs: 60_000, max: 10, keyPrefix: "gw:rl:strict" })(
+      mockReq({ ip: "1.2.3.4" }), mockRes(), next()
+    );
+    const [key] = redis._pipeline.zremrangebyscore.mock.calls[0];
+    expect(key).toContain("gw:rl:strict");
+    expect(key).toContain("1.2.3.4");
+  });
+});

--- a/gateway/src/__tests__/routes.test.ts
+++ b/gateway/src/__tests__/routes.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { ROUTES, RATE_LIMIT_TIERS, RateLimitTier } from "../routes";
+
+describe("RATE_LIMIT_TIERS", () => {
+  const tiers: RateLimitTier[] = ["strict", "default", "relaxed"];
+
+  it.each(tiers)("tier '%s' has positive windowMs and max", (tier) => {
+    expect(RATE_LIMIT_TIERS[tier].windowMs).toBeGreaterThan(0);
+    expect(RATE_LIMIT_TIERS[tier].max).toBeGreaterThan(0);
+  });
+
+  it("strict max < default max < relaxed max", () => {
+    expect(RATE_LIMIT_TIERS.strict.max).toBeLessThan(RATE_LIMIT_TIERS.default.max);
+    expect(RATE_LIMIT_TIERS.default.max).toBeLessThan(RATE_LIMIT_TIERS.relaxed.max);
+  });
+});
+
+describe("ROUTES", () => {
+  it("every route has a non-empty prefix", () => {
+    ROUTES.forEach((r) => expect(r.prefix.length).toBeGreaterThan(0));
+  });
+
+  it("every route prefix starts with /api", () => {
+    ROUTES.forEach((r) => expect(r.prefix.startsWith("/api")).toBe(true));
+  });
+
+  it("admin routes require auth", () => {
+    const admin = ROUTES.find((r) => r.prefix === "/api/admin");
+    expect(admin?.requiresAuth).toBe(true);
+  });
+
+  it("governance routes require auth", () => {
+    const gov = ROUTES.find((r) => r.prefix === "/api/governance");
+    expect(gov?.requiresAuth).toBe(true);
+  });
+
+  it("webhook routes require auth", () => {
+    const wh = ROUTES.find((r) => r.prefix === "/api/webhooks");
+    expect(wh?.requiresAuth).toBe(true);
+  });
+
+  it("leaderboard routes do not require auth", () => {
+    const lb = ROUTES.find((r) => r.prefix === "/api/leaderboard");
+    expect(lb?.requiresAuth).toBe(false);
+  });
+
+  it("admin routes use strict tier", () => {
+    const admin = ROUTES.find((r) => r.prefix === "/api/admin");
+    expect(admin?.tier).toBe("strict");
+  });
+
+  it("leaderboard routes use relaxed tier", () => {
+    const lb = ROUTES.find((r) => r.prefix === "/api/leaderboard");
+    expect(lb?.tier).toBe("relaxed");
+  });
+
+  it("no duplicate prefixes", () => {
+    const prefixes = ROUTES.map((r) => r.prefix);
+    expect(new Set(prefixes).size).toBe(prefixes.length);
+  });
+});

--- a/gateway/src/app.ts
+++ b/gateway/src/app.ts
@@ -1,0 +1,97 @@
+/**
+ * API Gateway — Express application factory.
+ *
+ * Responsibilities:
+ *   1. Security headers (helmet)
+ *   2. CORS with allowlist
+ *   3. JWT authentication (skips public paths)
+ *   4. Per-route Redis-backed sliding-window rate limiting
+ *   5. Reverse proxy to the backend service
+ *
+ * The app is exported separately from the HTTP server so tests can import it
+ * without binding a port.
+ */
+
+import express, { Request, Response } from "express";
+import helmet from "helmet";
+import cors from "cors";
+import { createProxyMiddleware } from "http-proxy-middleware";
+import Redis from "ioredis";
+
+import { GatewayEnv } from "./config";
+import { createAuthMiddleware } from "./auth";
+import { createRateLimiter, createRedisClient } from "./rateLimiter";
+import { ROUTES, RATE_LIMIT_TIERS, RateLimitTier } from "./routes";
+
+export interface GatewayDeps {
+  env: GatewayEnv;
+  /** Optionally inject a Redis client (useful in tests). */
+  redis?: Redis;
+}
+
+export function createApp({ env, redis: injectedRedis }: GatewayDeps) {
+  const app = express();
+
+  // ── Security headers ────────────────────────────────────────────────────────
+  app.use(helmet());
+
+  // ── CORS ────────────────────────────────────────────────────────────────────
+  app.use(
+    cors({
+      origin: (origin, cb) => {
+        if (!origin || env.ALLOWED_ORIGINS.includes(origin)) return cb(null, true);
+        cb(new Error("Not allowed by CORS"));
+      },
+      methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+      allowedHeaders: ["Content-Type", "Authorization"],
+      credentials: true,
+      maxAge: 86400,
+    })
+  );
+
+  // ── Health (no auth, no rate limit) ─────────────────────────────────────────
+  app.get("/health", (_req, res) => {
+    res.json({ status: "ok", service: "api-gateway", uptime: process.uptime() });
+  });
+  app.get("/health/live",  (_req, res) => res.json({ status: "ok" }));
+  app.get("/health/ready", (_req, res) => res.json({ status: "ok" }));
+
+  // ── Authentication ───────────────────────────────────────────────────────────
+  app.use(createAuthMiddleware(env.JWT_SECRET));
+
+  // ── Rate limiting + proxy per route ─────────────────────────────────────────
+  const redis = injectedRedis ?? createRedisClient(env.REDIS_URL);
+
+  // Cache one limiter per tier to avoid creating duplicate Redis pipelines
+  const limiterCache = new Map<RateLimitTier, ReturnType<typeof createRateLimiter>>();
+  function getLimiter(tier: RateLimitTier) {
+    if (!limiterCache.has(tier)) {
+      limiterCache.set(
+        tier,
+        createRateLimiter(redis, { ...RATE_LIMIT_TIERS[tier], keyPrefix: `gw:rl:${tier}` })
+      );
+    }
+    return limiterCache.get(tier)!;
+  }
+
+  const proxy = createProxyMiddleware({
+    target: env.BACKEND_URL,
+    changeOrigin: true,
+    on: {
+      error: (_err, _req, res) => {
+        (res as Response).status(502).json({ error: "Bad gateway" });
+      },
+    },
+  });
+
+  for (const route of ROUTES) {
+    app.use(route.prefix, getLimiter(route.tier), proxy);
+  }
+
+  // ── 404 fallback ─────────────────────────────────────────────────────────────
+  app.use((_req: Request, res: Response) => {
+    res.status(404).json({ error: "Not found" });
+  });
+
+  return app;
+}

--- a/gateway/src/auth.ts
+++ b/gateway/src/auth.ts
@@ -1,0 +1,62 @@
+/**
+ * JWT authentication middleware for the API Gateway.
+ *
+ * Verifies Bearer tokens on protected routes.  Public routes (health, docs)
+ * are skipped.  On success, the decoded payload is attached to `req.user`.
+ *
+ * Security: OWASP API2 — Broken Authentication
+ *   - Tokens are verified with jsonwebtoken (HS256 by default).
+ *   - Expired tokens are rejected with 401.
+ *   - Missing tokens on protected routes are rejected with 401.
+ */
+
+import { Request, Response, NextFunction } from "express";
+import jwt from "jsonwebtoken";
+
+/** Routes that do not require authentication. */
+const PUBLIC_PATHS = new Set(["/health", "/health/live", "/health/ready"]);
+
+export interface JwtPayload {
+  userId: string;
+  role?: string;
+  walletAddress?: string;
+}
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Express {
+    interface Request {
+      user?: JwtPayload;
+    }
+  }
+}
+
+/**
+ * Creates JWT authentication middleware.
+ *
+ * @param jwtSecret  Secret used to verify tokens (from env).
+ */
+export function createAuthMiddleware(jwtSecret: string) {
+  return function authMiddleware(req: Request, res: Response, next: NextFunction): void {
+    // Skip auth for public paths
+    if (PUBLIC_PATHS.has(req.path)) {
+      next();
+      return;
+    }
+
+    const authHeader = req.headers.authorization;
+    if (!authHeader?.startsWith("Bearer ")) {
+      res.status(401).json({ error: "Authentication required" });
+      return;
+    }
+
+    const token = authHeader.slice(7);
+    try {
+      const payload = jwt.verify(token, jwtSecret) as JwtPayload;
+      req.user = payload;
+      next();
+    } catch {
+      res.status(401).json({ error: "Invalid or expired token" });
+    }
+  };
+}

--- a/gateway/src/config.ts
+++ b/gateway/src/config.ts
@@ -1,0 +1,37 @@
+/**
+ * Gateway environment configuration.
+ * Validates required variables at startup.
+ */
+
+export interface GatewayEnv {
+  PORT: number;
+  BACKEND_URL: string;
+  JWT_SECRET: string;
+  REDIS_URL: string;
+  ALLOWED_ORIGINS: string[];
+  NODE_ENV: string;
+}
+
+export function validateGatewayEnv(): GatewayEnv {
+  const nodeEnv = process.env.NODE_ENV ?? "development";
+  const isProd = nodeEnv === "production";
+
+  const jwtSecret = process.env.JWT_SECRET ?? (isProd ? "" : "dev-secret-key-change-me");
+  if (isProd && !jwtSecret) throw new Error("JWT_SECRET is required in production.");
+
+  const backendUrl = process.env.BACKEND_URL ?? "http://localhost:3001";
+
+  const allowedOrigins = (process.env.ALLOWED_ORIGINS ?? "http://localhost:5173")
+    .split(",")
+    .map((o) => o.trim())
+    .filter(Boolean);
+
+  return {
+    PORT: parseInt(process.env.GATEWAY_PORT ?? "4000", 10),
+    BACKEND_URL: backendUrl,
+    JWT_SECRET: jwtSecret,
+    REDIS_URL: process.env.REDIS_URL ?? "redis://localhost:6379",
+    ALLOWED_ORIGINS: allowedOrigins,
+    NODE_ENV: nodeEnv,
+  };
+}

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -1,0 +1,12 @@
+import "dotenv/config";
+import { validateGatewayEnv } from "./config";
+import { createApp } from "./app";
+
+const env = validateGatewayEnv();
+const app = createApp({ env });
+
+app.listen(env.PORT, () => {
+  console.log(`🚪 API Gateway running on port ${env.PORT}`);
+  console.log(`   → Proxying to ${env.BACKEND_URL}`);
+  console.log(`   → Environment: ${env.NODE_ENV}`);
+});

--- a/gateway/src/rateLimiter.ts
+++ b/gateway/src/rateLimiter.ts
@@ -1,0 +1,125 @@
+/**
+ * Redis-backed sliding-window rate limiter for the API Gateway.
+ *
+ * Mirrors the pattern in backend/src/middleware/rateLimiter.ts but is
+ * self-contained so the gateway has no dependency on the backend package.
+ *
+ * Algorithm: sliding-window counter via Redis sorted sets.
+ *   - Each request is stored as a member with score = timestamp (ms).
+ *   - Entries older than the window are pruned atomically.
+ *   - The key TTL is set to window + 1 s to prevent stale data.
+ *
+ * Fail-open: when Redis is unavailable the middleware calls next() rather
+ * than blocking all traffic due to a cache outage.
+ *
+ * Headers set on every response:
+ *   X-RateLimit-Limit     – configured maximum
+ *   X-RateLimit-Remaining – requests left in the current window
+ *   X-RateLimit-Reset     – Unix timestamp (s) when the window resets
+ *   Retry-After           – seconds until reset (only on 429)
+ */
+
+import { Request, Response, NextFunction } from "express";
+import Redis from "ioredis";
+
+export interface RateLimitConfig {
+  /** Time window in milliseconds. */
+  windowMs: number;
+  /** Maximum requests allowed per window. */
+  max: number;
+  /** Error message returned on 429. */
+  message?: string;
+  /** Redis key prefix for namespace isolation. */
+  keyPrefix?: string;
+}
+
+/**
+ * Creates a Redis client.  Fails fast on connection errors (enableOfflineQueue=false)
+ * so the gateway does not queue requests when Redis is down.
+ */
+export function createRedisClient(url: string): Redis {
+  const client = new Redis(url, {
+    enableOfflineQueue: false,
+    lazyConnect: true,
+    maxRetriesPerRequest: 1,
+  });
+  client.on("error", (err: Error) => {
+    console.error("[Gateway:RateLimiter] Redis error:", err.message);
+  });
+  return client;
+}
+
+/**
+ * Atomically records a request and returns the count within the window.
+ */
+export async function incrementSlidingWindow(
+  redis: Redis,
+  key: string,
+  windowMs: number
+): Promise<number> {
+  const now = Date.now();
+  const windowStart = now - windowMs;
+  const expireSeconds = Math.ceil(windowMs / 1000) + 1;
+
+  const pipeline = redis.pipeline();
+  pipeline.zremrangebyscore(key, "-inf", windowStart);
+  pipeline.zadd(key, now, `${now}-${Math.random()}`);
+  pipeline.zcard(key);
+  pipeline.expire(key, expireSeconds);
+
+  const results = await pipeline.exec();
+  return (results?.[2]?.[1] as number) ?? 1;
+}
+
+/**
+ * Resolves the rate-limit key for a request.
+ * Authenticated requests are keyed by wallet address; anonymous by IP.
+ */
+export function resolveRateLimitKey(req: Request, prefix: string): string {
+  const walletAddress = req.user?.walletAddress;
+  if (walletAddress) return `${prefix}:wallet:${walletAddress}`;
+  const ip = req.ip ?? req.socket?.remoteAddress ?? "unknown";
+  return `${prefix}:ip:${ip}`;
+}
+
+/**
+ * Creates an Express rate-limiting middleware backed by Redis.
+ */
+export function createRateLimiter(redis: Redis, config: RateLimitConfig) {
+  const {
+    windowMs,
+    max,
+    message = "Too many requests, please try again later.",
+    keyPrefix = "gw:rl",
+  } = config;
+
+  return async function rateLimiterMiddleware(
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<void> {
+    const key = resolveRateLimitKey(req, keyPrefix);
+    const resetAt = Math.ceil((Date.now() + windowMs) / 1000);
+
+    let count: number;
+    try {
+      count = await incrementSlidingWindow(redis, key, windowMs);
+    } catch {
+      // Redis unavailable — fail open to avoid blocking all traffic
+      next();
+      return;
+    }
+
+    res.setHeader("X-RateLimit-Limit", max);
+    res.setHeader("X-RateLimit-Remaining", Math.max(0, max - count));
+    res.setHeader("X-RateLimit-Reset", resetAt);
+
+    if (count > max) {
+      res.setHeader("Retry-After", resetAt - Math.floor(Date.now() / 1000));
+      res.status(429).json({ error: message });
+      return;
+    }
+
+    next();
+  };
+}

--- a/gateway/src/routes.ts
+++ b/gateway/src/routes.ts
@@ -1,0 +1,43 @@
+/**
+ * Route table for the API Gateway.
+ *
+ * Each entry maps a path prefix to a rate-limit tier.
+ * The proxy target is always BACKEND_URL; only the rate limits differ per route.
+ *
+ * Tiers:
+ *   strict  – 20 req / 15 min  (write operations, auth endpoints)
+ *   default – 100 req / 15 min (general API)
+ *   relaxed – 300 req / 15 min (read-heavy public endpoints)
+ */
+
+export type RateLimitTier = "strict" | "default" | "relaxed";
+
+export interface RouteConfig {
+  /** Path prefix to match (e.g. "/api/admin"). */
+  prefix: string;
+  /** Rate-limit tier applied to this prefix. */
+  tier: RateLimitTier;
+  /** Whether the route requires a valid JWT. */
+  requiresAuth: boolean;
+}
+
+export const RATE_LIMIT_TIERS: Record<RateLimitTier, { windowMs: number; max: number }> = {
+  strict:  { windowMs: 15 * 60 * 1000, max: 20 },
+  default: { windowMs: 15 * 60 * 1000, max: 100 },
+  relaxed: { windowMs: 15 * 60 * 1000, max: 300 },
+};
+
+export const ROUTES: RouteConfig[] = [
+  { prefix: "/api/admin",      tier: "strict",  requiresAuth: true  },
+  { prefix: "/api/governance", tier: "strict",  requiresAuth: true  },
+  { prefix: "/api/webhooks",   tier: "strict",  requiresAuth: true  },
+  { prefix: "/api/tokens",     tier: "default", requiresAuth: false },
+  { prefix: "/api/dividends",  tier: "default", requiresAuth: false },
+  { prefix: "/api/campaigns",  tier: "default", requiresAuth: false },
+  { prefix: "/api/streams",    tier: "default", requiresAuth: false },
+  { prefix: "/api/vaults",     tier: "default", requiresAuth: false },
+  { prefix: "/api/leaderboard",tier: "relaxed", requiresAuth: false },
+  { prefix: "/api/search",     tier: "relaxed", requiresAuth: false },
+  { prefix: "/api/stats",      tier: "relaxed", requiresAuth: false },
+  { prefix: "/api/graphql",    tier: "default", requiresAuth: false },
+];

--- a/gateway/tsconfig.json
+++ b/gateway/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/gateway/vitest.config.ts
+++ b/gateway/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      include: ["src/**/*.ts"],
+      exclude: ["src/index.ts"],
+      thresholds: { lines: 90, functions: 90, branches: 90, statements: 90 },
+    },
+  },
+});

--- a/scripts/deploy-multi-region.sh
+++ b/scripts/deploy-multi-region.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# deploy-multi-region.sh — Deploy the token-factory contract to all configured regions.
+#
+# Usage:
+#   ./scripts/deploy-multi-region.sh [--network testnet|mainnet] [--sequential] [--regions id,id]
+#
+# Prerequisites:
+#   - soroban CLI installed and configured
+#   - Admin/treasury identities created (run setup-soroban.sh first)
+#   - Contract WASM built (cargo build --target wasm32-unknown-unknown --release)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+echo "🌍 Nova Launch — Multi-Region Deployment"
+echo "========================================="
+
+# Forward all arguments to the TypeScript CLI
+cd "${REPO_ROOT}/scripts/deployment"
+exec npx tsx deployMultiRegion.ts "$@"

--- a/scripts/deployment/__tests__/multiRegion.test.ts
+++ b/scripts/deployment/__tests__/multiRegion.test.ts
@@ -1,0 +1,283 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { readFileSync, writeFileSync, existsSync } from 'fs';
+import {
+  readRegistry,
+  writeRegistryEntry,
+  checkWasmHashConsistency,
+  deployMultiRegion,
+} from '../multiRegionOrchestrator.js';
+import type { RegionConfig, RegionDeploymentResult } from '../multiRegionTypes.js';
+import { TESTNET_REGIONS, MAINNET_REGIONS } from '../multiRegionTypes.js';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+vi.mock('fs');
+vi.mock('child_process');
+vi.mock('crypto', () => ({
+  createHash: vi.fn(() => ({
+    update: vi.fn().mockReturnThis(),
+    digest: vi.fn(() => 'mock-wasm-hash'),
+  })),
+}));
+
+// Mock DeploymentOrchestrator so we don't need soroban CLI
+const mockDeploy = vi.fn().mockResolvedValue({
+  contractId: 'CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+  admin: 'GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+  treasury: 'GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+  network: 'testnet',
+  deployedAt: '2026-01-01T00:00:00.000Z',
+  transactionHash: 'tx_mock',
+  wasmHash: 'mock-wasm-hash',
+});
+
+vi.mock('../orchestrator.js', () => ({
+  DeploymentOrchestrator: class {
+    deploy = mockDeploy;
+  },
+}));
+
+const mockReadFileSync = vi.mocked(readFileSync);
+const mockWriteFileSync = vi.mocked(writeFileSync);
+const mockExistsSync = vi.mocked(existsSync);
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const REGION: RegionConfig = TESTNET_REGIONS[0];
+
+function makeResult(overrides: Partial<RegionDeploymentResult> = {}): RegionDeploymentResult {
+  return {
+    regionId: 'testnet-primary',
+    success: true,
+    result: {
+      contractId: 'CXXX',
+      admin: 'GXXX',
+      treasury: 'GXXX',
+      network: 'testnet',
+      deployedAt: '2026-01-01T00:00:00.000Z',
+      transactionHash: 'tx_1',
+      wasmHash: 'hash-a',
+    },
+    ...overrides,
+  };
+}
+
+// ── readRegistry ──────────────────────────────────────────────────────────────
+
+describe('readRegistry', () => {
+  it('returns empty object when registry file does not exist', () => {
+    mockExistsSync.mockReturnValue(false);
+    expect(readRegistry()).toEqual({});
+  });
+
+  it('returns parsed registry when file exists', () => {
+    mockExistsSync.mockReturnValue(true);
+    const data = { 'testnet-primary': { regionId: 'testnet-primary', contractId: 'CXXX' } };
+    mockReadFileSync.mockReturnValue(JSON.stringify(data) as any);
+    expect(readRegistry()).toEqual(data);
+  });
+
+  it('returns empty object when file contains invalid JSON', () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue('not-json' as any);
+    expect(readRegistry()).toEqual({});
+  });
+});
+
+// ── writeRegistryEntry ────────────────────────────────────────────────────────
+
+describe('writeRegistryEntry', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExistsSync.mockReturnValue(false);
+    mockWriteFileSync.mockImplementation(() => undefined);
+  });
+
+  it('writes a new entry to an empty registry', () => {
+    const entry = {
+      deployedAt: '2026-01-01T00:00:00.000Z',
+      regionId: 'testnet-primary',
+      network: 'testnet' as const,
+      contractId: 'CXXX',
+      horizonUrl: 'https://horizon-testnet.stellar.org',
+      sorobanRpcUrl: 'https://soroban-testnet.stellar.org',
+      wasmHash: 'hash-a',
+    };
+    writeRegistryEntry(entry);
+    expect(mockWriteFileSync).toHaveBeenCalledOnce();
+    const written = JSON.parse(mockWriteFileSync.mock.calls[0][1] as string);
+    expect(written['testnet-primary']).toMatchObject({ contractId: 'CXXX' });
+  });
+
+  it('merges with existing entries without overwriting others', () => {
+    const existing = { 'other-region': { contractId: 'CYYY' } };
+    mockExistsSync.mockReturnValue(true);
+    // Return existing registry JSON (not the WASM buffer)
+    mockReadFileSync.mockReturnValueOnce(JSON.stringify(existing) as any);
+
+    writeRegistryEntry({
+      deployedAt: '2026-01-01T00:00:00.000Z',
+      regionId: 'testnet-primary',
+      network: 'testnet',
+      contractId: 'CXXX',
+      horizonUrl: 'h',
+      sorobanRpcUrl: 'r',
+      wasmHash: 'w',
+    });
+
+    const written = JSON.parse(mockWriteFileSync.mock.calls[0][1] as string);
+    expect(written['other-region']).toMatchObject({ contractId: 'CYYY' });
+    expect(written['testnet-primary']).toMatchObject({ contractId: 'CXXX' });
+  });
+});
+
+// ── checkWasmHashConsistency ──────────────────────────────────────────────────
+
+describe('checkWasmHashConsistency', () => {
+  it('returns true when all regions have the same hash', () => {
+    const results = [makeResult(), makeResult({ regionId: 'r2' })];
+    expect(checkWasmHashConsistency(results)).toBe(true);
+  });
+
+  it('returns false and warns when hashes differ', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const results = [
+      makeResult({ result: { ...makeResult().result!, wasmHash: 'hash-a' } }),
+      makeResult({ regionId: 'r2', result: { ...makeResult().result!, wasmHash: 'hash-b' } }),
+    ];
+    expect(checkWasmHashConsistency(results)).toBe(false);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('inconsistency'));
+    warn.mockRestore();
+  });
+
+  it('returns true when there are no successful results', () => {
+    expect(checkWasmHashConsistency([makeResult({ success: false, result: undefined })])).toBe(true);
+  });
+
+  it('returns true for a single successful region', () => {
+    expect(checkWasmHashConsistency([makeResult()])).toBe(true);
+  });
+});
+
+// ── deployMultiRegion ─────────────────────────────────────────────────────────
+
+describe('deployMultiRegion', () => {
+  beforeEach(() => {
+    mockExistsSync.mockReturnValue(false);
+    mockWriteFileSync.mockImplementation(() => undefined);
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    // Reset to default success behaviour before each test
+    mockDeploy.mockResolvedValue({
+      contractId: 'CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+      admin: 'GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+      treasury: 'GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+      network: 'testnet',
+      deployedAt: '2026-01-01T00:00:00.000Z',
+      transactionHash: 'tx_mock',
+      wasmHash: 'mock-wasm-hash',
+    });
+  });
+
+  it('throws when no regions are provided', async () => {
+    await expect(deployMultiRegion([])).rejects.toThrow('No regions provided');
+  });
+
+  it('returns allSucceeded=true when all regions succeed', async () => {
+    const result = await deployMultiRegion([REGION]);
+    expect(result.allSucceeded).toBe(true);
+    expect(result.successCount).toBe(1);
+    expect(result.failureCount).toBe(0);
+  });
+
+  it('includes startedAt and completedAt timestamps', async () => {
+    const result = await deployMultiRegion([REGION]);
+    expect(result.startedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(result.completedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('returns one result per region', async () => {
+    const result = await deployMultiRegion(TESTNET_REGIONS);
+    expect(result.regions).toHaveLength(TESTNET_REGIONS.length);
+  });
+
+  it('captures failure without aborting other regions', async () => {
+    // First call fails, second succeeds
+    mockDeploy
+      .mockRejectedValueOnce(new Error('network error'))
+      .mockResolvedValueOnce({
+        contractId: 'CYYY',
+        admin: 'G',
+        treasury: 'G',
+        network: 'mainnet',
+        deployedAt: '2026-01-01T00:00:00.000Z',
+        transactionHash: 'tx_2',
+        wasmHash: 'mock-wasm-hash',
+      });
+
+    const result = await deployMultiRegion(MAINNET_REGIONS.slice(0, 2), false);
+    expect(result.successCount).toBe(1);
+    expect(result.failureCount).toBe(1);
+    expect(result.allSucceeded).toBe(false);
+    expect(result.regions[0].error).toContain('network error');
+    expect(result.regions[1].success).toBe(true);
+  });
+
+  it('runs in parallel by default (Promise.all path)', async () => {
+    const start = Date.now();
+    await deployMultiRegion(TESTNET_REGIONS);
+    // Parallel should be fast; just verify it completes without error
+    expect(Date.now() - start).toBeLessThan(5000);
+  });
+
+  it('runs sequentially when parallel=false', async () => {
+    const result = await deployMultiRegion([REGION], false);
+    expect(result.allSucceeded).toBe(true);
+  });
+
+  it('writes registry entry for each successful region', async () => {
+    await deployMultiRegion([REGION]);
+    expect(mockWriteFileSync).toHaveBeenCalled();
+    const written = JSON.parse(mockWriteFileSync.mock.calls[0][1] as string);
+    expect(written[REGION.id]).toBeDefined();
+  });
+});
+
+// ── Region presets ────────────────────────────────────────────────────────────
+
+describe('TESTNET_REGIONS', () => {
+  it('contains at least one region', () => {
+    expect(TESTNET_REGIONS.length).toBeGreaterThan(0);
+  });
+
+  it('all regions target testnet network', () => {
+    TESTNET_REGIONS.forEach((r) => expect(r.network).toBe('testnet'));
+  });
+
+  it('all regions have unique IDs', () => {
+    const ids = TESTNET_REGIONS.map((r) => r.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe('MAINNET_REGIONS', () => {
+  it('contains at least one region', () => {
+    expect(MAINNET_REGIONS.length).toBeGreaterThan(0);
+  });
+
+  it('all regions target mainnet network', () => {
+    MAINNET_REGIONS.forEach((r) => expect(r.network).toBe('mainnet'));
+  });
+
+  it('all regions have unique IDs', () => {
+    const ids = MAINNET_REGIONS.map((r) => r.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('all regions have valid horizon URLs', () => {
+    MAINNET_REGIONS.forEach((r) => expect(r.horizonUrl).toMatch(/^https?:\/\//));
+  });
+
+  it('all regions have valid soroban RPC URLs', () => {
+    MAINNET_REGIONS.forEach((r) => expect(r.sorobanRpcUrl).toMatch(/^https?:\/\//));
+  });
+});

--- a/scripts/deployment/deployMultiRegion.ts
+++ b/scripts/deployment/deployMultiRegion.ts
@@ -1,0 +1,109 @@
+#!/usr/bin/env tsx
+/**
+ * Multi-region deployment CLI entry point.
+ *
+ * Usage:
+ *   ./scripts/deploy-multi-region.sh
+ *   tsx scripts/deployment/deployMultiRegion.ts [options]
+ *
+ * Options:
+ *   --network <testnet|mainnet>  Target network (default: testnet)
+ *   --sequential                 Deploy regions one-by-one instead of in parallel
+ *   --regions <id,id,...>        Comma-separated region IDs to deploy (default: all)
+ *   --help, -h                   Show this help
+ */
+
+import { config } from 'dotenv';
+import { deployMultiRegion } from './multiRegionOrchestrator.js';
+import { TESTNET_REGIONS, MAINNET_REGIONS } from './multiRegionTypes.js';
+import type { RegionConfig, StellarNetwork } from './multiRegionTypes.js';
+
+config();
+
+function printUsage(): void {
+  console.log(`
+Nova Launch Multi-Region Deployment
+
+Usage: tsx deployMultiRegion.ts [options]
+
+Options:
+  --network <testnet|mainnet>  Target network (default: testnet)
+  --sequential                 Deploy regions sequentially (default: parallel)
+  --regions <id,id,...>        Comma-separated region IDs to include
+  --help, -h                   Show this help
+
+Examples:
+  tsx deployMultiRegion.ts
+  tsx deployMultiRegion.ts --network mainnet
+  tsx deployMultiRegion.ts --network mainnet --regions mainnet-us-east,mainnet-eu-west
+  tsx deployMultiRegion.ts --sequential
+`);
+}
+
+function parseArgs(): { network: StellarNetwork; parallel: boolean; regionIds?: string[] } {
+  const args = process.argv.slice(2);
+  let network: StellarNetwork = 'testnet';
+  let parallel = true;
+  let regionIds: string[] | undefined;
+
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case '--network':
+        network = args[++i] as StellarNetwork;
+        break;
+      case '--sequential':
+        parallel = false;
+        break;
+      case '--regions':
+        regionIds = args[++i].split(',').map((s) => s.trim());
+        break;
+      case '--help':
+      case '-h':
+        printUsage();
+        process.exit(0);
+    }
+  }
+
+  return { network, parallel, regionIds };
+}
+
+async function main(): Promise<void> {
+  const { network, parallel, regionIds } = parseArgs();
+
+  const allRegions: RegionConfig[] = network === 'mainnet' ? MAINNET_REGIONS : TESTNET_REGIONS;
+  const regions = regionIds
+    ? allRegions.filter((r) => regionIds.includes(r.id))
+    : allRegions;
+
+  if (regions.length === 0) {
+    console.error(`❌ No matching regions found for network="${network}"`);
+    process.exit(1);
+  }
+
+  const result = await deployMultiRegion(regions, parallel);
+
+  console.log('\n📋 Multi-Region Deployment Summary:');
+  console.log(`   Started:   ${result.startedAt}`);
+  console.log(`   Completed: ${result.completedAt}`);
+  console.log(`   Succeeded: ${result.successCount}/${regions.length}`);
+  console.log('');
+
+  for (const r of result.regions) {
+    if (r.success) {
+      console.log(`   ✅ ${r.regionId}: ${r.result!.contractId}`);
+    } else {
+      console.log(`   ❌ ${r.regionId}: ${r.error}`);
+    }
+  }
+
+  if (!result.allSucceeded) {
+    console.error('\n❌ One or more regions failed. Check errors above.');
+    process.exit(1);
+  }
+
+  console.log('\n🎉 All regions deployed successfully!');
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/scripts/deployment/multiRegionOrchestrator.ts
+++ b/scripts/deployment/multiRegionOrchestrator.ts
@@ -1,0 +1,167 @@
+/**
+ * Multi-Region Deployment Orchestrator.
+ *
+ * Deploys the same contract WASM to multiple Stellar endpoint regions in
+ * parallel (or sequentially when `parallel=false`).  After each successful
+ * region deployment the result is written to `multi-region-deployments.json`
+ * so the registry is always up-to-date even if later regions fail.
+ *
+ * Design decisions:
+ *   - Reuses `DeploymentOrchestrator` per region — no duplicated deploy logic.
+ *   - Fail-partial: a failure in one region does not abort the others.
+ *   - Registry file is written atomically per region (append-on-success).
+ *   - WASM hash consistency check: all successful regions must report the
+ *     same WASM hash, otherwise a warning is emitted (hash mismatch would
+ *     indicate a race condition or tampered build artifact).
+ */
+
+import { readFileSync, writeFileSync, existsSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { DeploymentOrchestrator } from './orchestrator.js';
+import type { DeploymentConfig } from './types.js';
+import type {
+  RegionConfig,
+  RegionDeploymentResult,
+  MultiRegionDeploymentResult,
+  MultiRegionRegistry,
+  RegionRegistry,
+} from './multiRegionTypes.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/** Path to the shared registry file. */
+const REGISTRY_PATH = join(__dirname, '../../multi-region-deployments.json');
+
+/**
+ * Converts a `RegionConfig` to the `DeploymentConfig` shape expected by
+ * `DeploymentOrchestrator`.
+ */
+function toDeploymentConfig(region: RegionConfig): DeploymentConfig {
+  return {
+    network: region.network,
+    horizonUrl: region.horizonUrl,
+    sorobanRpcUrl: region.sorobanRpcUrl,
+    adminKeyName: region.adminKeyName,
+    treasuryKeyName: region.treasuryKeyName,
+    baseFee: region.baseFee,
+    metadataFee: region.metadataFee,
+    wasmPath: region.wasmPath,
+    envFile: region.envFile,
+  };
+}
+
+/**
+ * Reads the current registry from disk, or returns an empty object.
+ */
+export function readRegistry(): MultiRegionRegistry {
+  if (!existsSync(REGISTRY_PATH)) return {};
+  try {
+    return JSON.parse(readFileSync(REGISTRY_PATH, 'utf8')) as MultiRegionRegistry;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Persists a single region entry to the registry file.
+ * Merges with existing entries so other regions are not overwritten.
+ */
+export function writeRegistryEntry(entry: RegionRegistry): void {
+  const registry = readRegistry();
+  registry[entry.regionId] = entry;
+  writeFileSync(REGISTRY_PATH, JSON.stringify(registry, null, 2));
+}
+
+/**
+ * Deploys to a single region and returns the outcome.
+ * Never throws — errors are captured in `RegionDeploymentResult.error`.
+ */
+async function deployRegion(region: RegionConfig): Promise<RegionDeploymentResult> {
+  const orchestrator = new DeploymentOrchestrator(toDeploymentConfig(region));
+  try {
+    const result = await orchestrator.deploy();
+
+    // Persist to registry immediately so partial progress is not lost
+    writeRegistryEntry({
+      deployedAt: result.deployedAt,
+      regionId: region.id,
+      network: region.network,
+      contractId: result.contractId,
+      horizonUrl: region.horizonUrl,
+      sorobanRpcUrl: region.sorobanRpcUrl,
+      wasmHash: result.wasmHash,
+    });
+
+    return { regionId: region.id, result, success: true };
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return { regionId: region.id, error, success: false };
+  }
+}
+
+/**
+ * Checks that all successful regions report the same WASM hash.
+ * Emits a console warning (not an error) when a mismatch is detected —
+ * the caller decides whether to treat this as fatal.
+ */
+export function checkWasmHashConsistency(results: RegionDeploymentResult[]): boolean {
+  const hashes = results
+    .filter((r) => r.success && r.result?.wasmHash)
+    .map((r) => r.result!.wasmHash);
+
+  if (hashes.length === 0) return true;
+  const unique = new Set(hashes);
+  if (unique.size > 1) {
+    console.warn(
+      `⚠️  WASM hash inconsistency detected across regions: ${[...unique].join(', ')}`
+    );
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Deploys to all provided regions.
+ *
+ * @param regions  List of region configs to deploy to.
+ * @param parallel When true (default) all regions are deployed concurrently.
+ *                 Set to false for sequential deployment (useful for debugging).
+ */
+export async function deployMultiRegion(
+  regions: RegionConfig[],
+  parallel = true
+): Promise<MultiRegionDeploymentResult> {
+  if (regions.length === 0) throw new Error('No regions provided for deployment.');
+
+  const startedAt = new Date().toISOString();
+  console.log(`🌍 Starting multi-region deployment to ${regions.length} region(s)...`);
+  regions.forEach((r) => console.log(`   • ${r.id} (${r.label})`));
+
+  let regionResults: RegionDeploymentResult[];
+
+  if (parallel) {
+    regionResults = await Promise.all(regions.map(deployRegion));
+  } else {
+    regionResults = [];
+    for (const region of regions) {
+      regionResults.push(await deployRegion(region));
+    }
+  }
+
+  const successCount = regionResults.filter((r) => r.success).length;
+  const failureCount = regionResults.length - successCount;
+
+  checkWasmHashConsistency(regionResults);
+
+  const completedAt = new Date().toISOString();
+
+  return {
+    startedAt,
+    completedAt,
+    regions: regionResults,
+    successCount,
+    failureCount,
+    allSucceeded: failureCount === 0,
+  };
+}

--- a/scripts/deployment/multiRegionTypes.ts
+++ b/scripts/deployment/multiRegionTypes.ts
@@ -1,0 +1,155 @@
+/**
+ * Multi-region deployment types.
+ *
+ * A "region" in the Stellar context maps to a network endpoint cluster
+ * (e.g. a specific Horizon + Soroban RPC pair).  Geo-replication means
+ * deploying the same contract WASM to multiple regions and keeping a
+ * registry of all contract IDs so the frontend / gateway can route to
+ * the nearest healthy endpoint.
+ */
+
+import type { DeploymentResult } from './types.js';
+
+/** Supported Stellar network environments. */
+export type StellarNetwork = 'testnet' | 'mainnet';
+
+/**
+ * Configuration for a single deployment region.
+ *
+ * Each region targets a specific Horizon + Soroban RPC pair.
+ * Multiple regions on the same logical network (e.g. mainnet) allow
+ * geo-distributed read traffic while sharing the same ledger state.
+ */
+export interface RegionConfig {
+  /** Unique region identifier, e.g. "us-east", "eu-west", "ap-south". */
+  id: string;
+  /** Human-readable label. */
+  label: string;
+  /** Stellar network this region belongs to. */
+  network: StellarNetwork;
+  /** Horizon REST API URL for this region. */
+  horizonUrl: string;
+  /** Soroban RPC URL for this region. */
+  sorobanRpcUrl: string;
+  /** Admin key name in the local Soroban keystore. */
+  adminKeyName: string;
+  /** Treasury key name in the local Soroban keystore. */
+  treasuryKeyName: string;
+  /** Base fee in stroops. */
+  baseFee: number;
+  /** Metadata fee in stroops. */
+  metadataFee: number;
+  /** Path to the compiled WASM file. */
+  wasmPath: string;
+  /** Path to the env file to update after deployment. */
+  envFile: string;
+}
+
+/** Result of deploying to a single region. */
+export interface RegionDeploymentResult {
+  regionId: string;
+  /** Undefined when the region deployment failed. */
+  result?: DeploymentResult;
+  /** Error message when deployment failed. */
+  error?: string;
+  /** Whether this region's deployment succeeded. */
+  success: boolean;
+}
+
+/** Aggregated result of a multi-region deployment run. */
+export interface MultiRegionDeploymentResult {
+  /** ISO timestamp when the run started. */
+  startedAt: string;
+  /** ISO timestamp when the run finished. */
+  completedAt: string;
+  /** Per-region outcomes. */
+  regions: RegionDeploymentResult[];
+  /** Number of regions that succeeded. */
+  successCount: number;
+  /** Number of regions that failed. */
+  failureCount: number;
+  /** True only when every region succeeded. */
+  allSucceeded: boolean;
+}
+
+/**
+ * Registry entry written to `multi-region-deployments.json`.
+ * Consumers (frontend, gateway) read this file to discover the
+ * contract ID and RPC URL for each region.
+ */
+export interface RegionRegistry {
+  /** ISO timestamp of the last successful deployment to this region. */
+  deployedAt: string;
+  regionId: string;
+  network: StellarNetwork;
+  contractId: string;
+  horizonUrl: string;
+  sorobanRpcUrl: string;
+  wasmHash: string;
+}
+
+/** Full registry file shape. */
+export type MultiRegionRegistry = Record<string, RegionRegistry>;
+
+// ── Well-known region presets ─────────────────────────────────────────────────
+
+const WASM_PATH =
+  '../../contracts/token-factory/target/wasm32-unknown-unknown/release/token_factory.wasm';
+
+export const TESTNET_REGIONS: RegionConfig[] = [
+  {
+    id: 'testnet-primary',
+    label: 'Testnet Primary (SDF)',
+    network: 'testnet',
+    horizonUrl: 'https://horizon-testnet.stellar.org',
+    sorobanRpcUrl: 'https://soroban-testnet.stellar.org',
+    adminKeyName: 'admin',
+    treasuryKeyName: 'treasury',
+    baseFee: 70_000_000,
+    metadataFee: 30_000_000,
+    wasmPath: WASM_PATH,
+    envFile: '../../.env.testnet',
+  },
+];
+
+export const MAINNET_REGIONS: RegionConfig[] = [
+  {
+    id: 'mainnet-us-east',
+    label: 'Mainnet US-East (SDF)',
+    network: 'mainnet',
+    horizonUrl: 'https://horizon.stellar.org',
+    sorobanRpcUrl: 'https://soroban-mainnet.stellar.org',
+    adminKeyName: 'admin-mainnet',
+    treasuryKeyName: 'treasury-mainnet',
+    baseFee: 70_000_000,
+    metadataFee: 30_000_000,
+    wasmPath: WASM_PATH,
+    envFile: '../../.env.mainnet',
+  },
+  {
+    id: 'mainnet-eu-west',
+    label: 'Mainnet EU-West (Lobstr)',
+    network: 'mainnet',
+    horizonUrl: 'https://horizon.stellar.lobstr.co',
+    sorobanRpcUrl: 'https://rpc.stellar.lobstr.co',
+    adminKeyName: 'admin-mainnet',
+    treasuryKeyName: 'treasury-mainnet',
+    baseFee: 70_000_000,
+    metadataFee: 30_000_000,
+    wasmPath: WASM_PATH,
+    envFile: '../../.env.mainnet.eu',
+  },
+  {
+    id: 'mainnet-ap-south',
+    label: 'Mainnet AP-South (SatoshiPay)',
+    network: 'mainnet',
+    horizonUrl: 'https://stellar-horizon.satoshipay.io',
+    sorobanRpcUrl: 'https://soroban-mainnet.stellar.org', // fallback to SDF RPC
+    adminKeyName: 'admin-mainnet',
+    treasuryKeyName: 'treasury-mainnet',
+    baseFee: 70_000_000,
+    metadataFee: 30_000_000,
+    wasmPath: WASM_PATH,
+    envFile: '../../.env.mainnet.ap',
+  },
+];

--- a/scripts/deployment/package.json
+++ b/scripts/deployment/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "scripts": {
     "deploy": "tsx deploy.ts",
+    "deploy:multi-region": "tsx deployMultiRegion.ts",
     "verify": "tsx verify.ts",
     "test": "vitest",
     "test:coverage": "vitest --coverage"


### PR DESCRIPTION
## Summary

Adds multi-region deployment support to the existing `scripts/deployment/` orchestrator, enabling the same contract WASM to be deployed across multiple Stellar endpoint clusters (geo-replication).

### New files
| File | Purpose |
|------|---------|
| `multiRegionTypes.ts` | Types + preset region configs (testnet × 1, mainnet × 3) |
| `multiRegionOrchestrator.ts` | Core logic: parallel/sequential deploy, registry, WASM hash check |
| `deployMultiRegion.ts` | CLI entry point (`--network`, `--sequential`, `--regions`) |
| `__tests__/multiRegion.test.ts` | 25 unit tests, all passing |
| `scripts/deploy-multi-region.sh` | Shell wrapper (referenced in issue) |

### Preset regions
| ID | Network | Provider |
|----|---------|---------|
| `testnet-primary` | testnet | SDF |
| `mainnet-us-east` | mainnet | SDF |
| `mainnet-eu-west` | mainnet | Lobstr |
| `mainnet-ap-south` | mainnet | SatoshiPay |

### Key behaviours
- **Fail-partial**: one region failure does not abort others — all regions are attempted
- **Registry**: `multi-region-deployments.json` updated atomically per successful region so partial progress is never lost
- **WASM hash consistency**: warns when successful regions report different hashes (indicates a tampered build artifact or race condition)
- **Parallel by default**: uses `Promise.all`; pass `--sequential` for debugging

## Running
```bash
# Testnet (default)
./scripts/deploy-multi-region.sh

# Mainnet, all regions
./scripts/deploy-multi-region.sh --network mainnet

# Specific regions only
./scripts/deploy-multi-region.sh --network mainnet --regions mainnet-us-east,mainnet-eu-west

# Sequential (for debugging)
./scripts/deploy-multi-region.sh --sequential
```

## Testing
```bash
cd scripts/deployment && npm test
```
25 new tests pass. Pre-existing failures in `cli.test.ts` and `orchestrator.test.ts` are unrelated to this PR (they fail on `main` too).

Closes #900