### PR TITLE
infra(kubernetes): create service mesh with Istio for microservice communication

### DIFF
--- a/.github/workflows/load-testing.yml
+++ b/.github/workflows/load-testing.yml
@@ -1,0 +1,155 @@
+name: Load Testing
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+  # Allow manual runs with custom parameters
+  workflow_dispatch:
+    inputs:
+      vus:
+        description: 'Virtual users (steady state)'
+        required: false
+        default: '10'
+      duration:
+        description: 'Steady-state duration in seconds'
+        required: false
+        default: '60'
+
+jobs:
+  load-test:
+    name: k6 CI Load Test
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: nova_launch_test
+          POSTGRES_USER: nova_user
+          POSTGRES_PASSWORD: nova_password
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+      redis:
+        image: redis:7-alpine
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6379:6379
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Install backend dependencies
+        run: npm ci
+        working-directory: backend
+
+      - name: Start backend
+        run: npm run dev &
+        working-directory: backend
+        env:
+          NODE_ENV: test
+          PORT: 3001
+          DATABASE_URL: postgresql://nova_user:nova_password@localhost:5432/nova_launch_test
+          JWT_SECRET: ci-test-secret-not-for-production
+          REDIS_URL: redis://localhost:6379
+          STELLAR_NETWORK: testnet
+          FACTORY_CONTRACT_ID: ''
+
+      - name: Wait for backend to be ready
+        run: |
+          echo "Waiting for backend..."
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:3001/health > /dev/null 2>&1; then
+              echo "Backend is ready"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "Backend did not start in time"
+          exit 1
+
+      - name: Install k6
+        run: |
+          sudo gpg -k
+          sudo gpg --no-default-keyring \
+            --keyring /usr/share/keyrings/k6-archive-keyring.gpg \
+            --keyserver hkp://keyserver.ubuntu.com:80 \
+            --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69
+          echo "deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main" \
+            | sudo tee /etc/apt/sources.list.d/k6.list
+          sudo apt-get update
+          sudo apt-get install -y k6
+
+      - name: Create results directory
+        run: mkdir -p load-tests/results
+
+      - name: Run CI load test
+        run: |
+          k6 run \
+            --env BASE_URL=http://localhost:3001 \
+            --env CI_VUS=${{ github.event.inputs.vus || '10' }} \
+            --env CI_DURATION=${{ github.event.inputs.duration || '60' }} \
+            --out json=load-tests/results/ci-load-raw.json \
+            load-tests/scenarios/ci-load.js
+        # k6 exits non-zero when thresholds fail — that's intentional
+
+      - name: Upload load test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: load-test-results-${{ github.run_number }}
+          path: load-tests/results/
+          retention-days: 30
+
+      - name: Comment PR with load test results
+        if: github.event_name == 'pull_request' && always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = 'load-tests/results/ci-load-summary.json';
+            if (!fs.existsSync(path)) {
+              console.log('No summary file found, skipping comment');
+              return;
+            }
+            const s = JSON.parse(fs.readFileSync(path, 'utf8'));
+            const m = s.metrics;
+            const status = s.passed ? '✅ PASSED' : '❌ FAILED';
+            const body = [
+              `## 🔥 Load Test Results — ${status}`,
+              '',
+              `| Metric | Value |`,
+              `|--------|-------|`,
+              `| p95 latency | ${m.http_req_duration_p95?.toFixed(1) ?? 'n/a'} ms |`,
+              `| p99 latency | ${m.http_req_duration_p99?.toFixed(1) ?? 'n/a'} ms |`,
+              `| HTTP error rate | ${((m.http_req_failed_rate ?? 0) * 100).toFixed(2)} % |`,
+              `| Total requests | ${m.ci_total_requests ?? 0} |`,
+              `| VUs | ${s.vus} |`,
+              `| Duration | ${s.duration}s |`,
+              '',
+              `> Thresholds: p95 < 1000 ms · p99 < 2000 ms · error rate < 1 %`,
+            ].join('\n');
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body,
+            });

--- a/gateway/.env.example
+++ b/gateway/.env.example
@@ -1,0 +1,6 @@
+GATEWAY_PORT=4000
+BACKEND_URL=http://localhost:3001
+JWT_SECRET=change-me-in-production
+REDIS_URL=redis://localhost:6379
+ALLOWED_ORIGINS=http://localhost:5173
+NODE_ENV=development

--- a/gateway/.gitignore
+++ b/gateway/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+coverage/
+*.env
+.env

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY tsconfig.json ./
+COPY src ./src
+RUN npm run build
+
+FROM node:20-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --omit=dev
+COPY --from=builder /app/dist ./dist
+EXPOSE 4000
+CMD ["node", "dist/index.js"]

--- a/gateway/docker-compose.yml
+++ b/gateway/docker-compose.yml
@@ -1,0 +1,43 @@
+version: "3.8"
+
+services:
+  redis:
+    image: redis:7-alpine
+    container_name: gateway-redis
+    ports:
+      - "6380:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  gateway:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: nova-launch-gateway
+    depends_on:
+      redis:
+        condition: service_healthy
+    environment:
+      NODE_ENV: ${NODE_ENV:-development}
+      GATEWAY_PORT: ${GATEWAY_PORT:-4000}
+      BACKEND_URL: ${BACKEND_URL:-http://host.docker.internal:3001}
+      JWT_SECRET: ${JWT_SECRET:-dev-secret-key-change-me}
+      REDIS_URL: redis://redis:6379
+      ALLOWED_ORIGINS: ${ALLOWED_ORIGINS:-http://localhost:5173}
+    ports:
+      - "${GATEWAY_PORT:-4000}:4000"
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "require('http').get('http://localhost:4000/health', (r) => process.exit(r.statusCode === 200 ? 0 : 1))",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s

--- a/gateway/package.json
+++ b/gateway/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "nova-launch-gateway",
+  "version": "1.0.0",
+  "description": "API Gateway with rate limiting and authentication for Nova Launch",
+  "main": "dist/index.js",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "dotenv": "^16.3.1",
+    "express": "^4.18.2",
+    "helmet": "^7.1.0",
+    "http-proxy-middleware": "^3.0.3",
+    "ioredis": "^5.10.1",
+    "jsonwebtoken": "^9.0.2"
+  },
+  "devDependencies": {
+    "@types/cors": "^2.8.17",
+    "@types/express": "^4.17.21",
+    "@types/http-proxy-middleware": "^0.19.3",
+    "@types/jsonwebtoken": "^9.0.5",
+    "@types/node": "^20.10.6",
+    "@types/supertest": "^6.0.3",
+    "@vitest/coverage-v8": "^1.6.1",
+    "supertest": "^7.2.2",
+    "tsx": "^4.7.0",
+    "typescript": "^5.3.3",
+    "vitest": "^1.1.0"
+  }
+}

--- a/gateway/src/__tests__/app.test.ts
+++ b/gateway/src/__tests__/app.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import request from "supertest";
+import jwt from "jsonwebtoken";
+import { createApp } from "../app";
+import { GatewayEnv } from "../config";
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const SECRET = "test-gateway-secret";
+
+const ENV: GatewayEnv = {
+  PORT: 4000,
+  BACKEND_URL: "http://backend:3001",
+  JWT_SECRET: SECRET,
+  REDIS_URL: "redis://localhost:6379",
+  ALLOWED_ORIGINS: ["http://localhost:5173"],
+  NODE_ENV: "test",
+};
+
+/** Mock Redis that always returns count=1 (well under any limit). */
+function mockRedis() {
+  const pipeline = {
+    zremrangebyscore: vi.fn().mockReturnThis(),
+    zadd:             vi.fn().mockReturnThis(),
+    zcard:            vi.fn().mockReturnThis(),
+    expire:           vi.fn().mockReturnThis(),
+    exec: vi.fn().mockResolvedValue([[null, 0], [null, 1], [null, 1], [null, 1]]),
+  };
+  return { pipeline: vi.fn().mockReturnValue(pipeline), on: vi.fn(), _pipeline: pipeline } as any;
+}
+
+function validToken(payload: object = { userId: "u1" }) {
+  return jwt.sign(payload, SECRET);
+}
+
+// ── Health endpoints ──────────────────────────────────────────────────────────
+
+describe("GET /health", () => {
+  const app = createApp({ env: ENV, redis: mockRedis() });
+
+  it("returns 200 with status ok", async () => {
+    const res = await request(app).get("/health");
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("ok");
+    expect(res.body.service).toBe("api-gateway");
+  });
+
+  it("does not require authentication", async () => {
+    const res = await request(app).get("/health");
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("GET /health/live", () => {
+  const app = createApp({ env: ENV, redis: mockRedis() });
+
+  it("returns 200", async () => {
+    const res = await request(app).get("/health/live");
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("GET /health/ready", () => {
+  const app = createApp({ env: ENV, redis: mockRedis() });
+
+  it("returns 200", async () => {
+    const res = await request(app).get("/health/ready");
+    expect(res.status).toBe(200);
+  });
+});
+
+// ── Authentication ────────────────────────────────────────────────────────────
+
+describe("Authentication middleware", () => {
+  // We don't have a real backend, so proxy calls will 502.
+  // We only care about the auth layer (401 vs not-401).
+  const app = createApp({ env: ENV, redis: mockRedis() });
+
+  it("returns 401 for /api/tokens without a token", async () => {
+    const res = await request(app).get("/api/tokens");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 for /api/admin without a token", async () => {
+    const res = await request(app).get("/api/admin");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 for an invalid token", async () => {
+    const res = await request(app)
+      .get("/api/tokens")
+      .set("Authorization", "Bearer invalid.token");
+    expect(res.status).toBe(401);
+  });
+
+  it("passes auth with a valid token (proxy may 502 — that's fine)", async () => {
+    const res = await request(app)
+      .get("/api/tokens")
+      .set("Authorization", `Bearer ${validToken()}`);
+    // Auth passed; proxy to non-existent backend → 502 or ECONNREFUSED → 502
+    expect(res.status).not.toBe(401);
+  });
+});
+
+// ── CORS ──────────────────────────────────────────────────────────────────────
+
+describe("CORS", () => {
+  const app = createApp({ env: ENV, redis: mockRedis() });
+
+  it("allows requests from an allowed origin", async () => {
+    const res = await request(app)
+      .get("/health")
+      .set("Origin", "http://localhost:5173");
+    expect(res.headers["access-control-allow-origin"]).toBe("http://localhost:5173");
+  });
+
+  it("does not set ACAO header for a disallowed origin", async () => {
+    const res = await request(app)
+      .get("/health")
+      .set("Origin", "http://evil.com");
+    expect(res.headers["access-control-allow-origin"]).toBeUndefined();
+  });
+});
+
+// ── 404 fallback ──────────────────────────────────────────────────────────────
+
+describe("404 fallback", () => {
+  const app = createApp({ env: ENV, redis: mockRedis() });
+
+  it("returns 404 for unknown routes", async () => {
+    const res = await request(app)
+      .get("/unknown-path")
+      .set("Authorization", `Bearer ${validToken()}`);
+    expect(res.status).toBe(404);
+  });
+});
+
+// ── Rate limiting headers ─────────────────────────────────────────────────────
+
+describe("Rate limiting headers", () => {
+  it("sets X-RateLimit-Limit on proxied routes", async () => {
+    const redis = mockRedis();
+    const app = createApp({ env: ENV, redis });
+
+    const res = await request(app)
+      .get("/api/tokens")
+      .set("Authorization", `Bearer ${validToken()}`);
+
+    // Header is set by rate limiter before proxy runs
+    expect(res.headers["x-ratelimit-limit"]).toBeDefined();
+  });
+
+  it("sets X-RateLimit-Remaining on proxied routes", async () => {
+    const redis = mockRedis();
+    const app = createApp({ env: ENV, redis });
+
+    const res = await request(app)
+      .get("/api/tokens")
+      .set("Authorization", `Bearer ${validToken()}`);
+
+    expect(res.headers["x-ratelimit-remaining"]).toBeDefined();
+  });
+});
+
+// ── validateGatewayEnv ────────────────────────────────────────────────────────
+
+describe("validateGatewayEnv", () => {
+  it("throws when JWT_SECRET is missing in production", async () => {
+    const original = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+    process.env.JWT_SECRET = "";
+
+    const { validateGatewayEnv } = await import("../config");
+    expect(() => validateGatewayEnv()).toThrow("JWT_SECRET");
+
+    process.env.NODE_ENV = original;
+  });
+
+  it("returns defaults in development", async () => {
+    process.env.NODE_ENV = "development";
+    delete process.env.JWT_SECRET;
+
+    const { validateGatewayEnv } = await import("../config");
+    const env = validateGatewayEnv();
+    expect(env.JWT_SECRET).toBeTruthy();
+    expect(env.PORT).toBeGreaterThan(0);
+  });
+});

--- a/gateway/src/__tests__/auth.test.ts
+++ b/gateway/src/__tests__/auth.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi } from "vitest";
+import { Request, NextFunction } from "express";
+import jwt from "jsonwebtoken";
+import { createAuthMiddleware } from "../auth";
+
+const next = (): NextFunction => vi.fn() as unknown as NextFunction;
+
+const SECRET = "test-secret";
+
+function mockReq(overrides: Partial<Request> = {}): Request {
+  return { headers: {}, path: "/api/tokens", ...overrides } as any;
+}
+
+function mockRes() {
+  let statusCode = 200;
+  let body: any;
+  const res: any = {
+    status: vi.fn((c: number) => { statusCode = c; return res; }),
+    json:   vi.fn((b: any)   => { body = b; return res; }),
+    get statusCode() { return statusCode; },
+    get body()       { return body; },
+  };
+  return res;
+}
+
+describe("createAuthMiddleware", () => {
+  const auth = createAuthMiddleware(SECRET);
+
+  it("calls next() for /health without a token", () => {
+    const n = next();
+    auth(mockReq({ path: "/health" }), mockRes(), n);
+    expect(n).toHaveBeenCalledOnce();
+  });
+
+  it("calls next() for /health/live without a token", () => {
+    const n = next();
+    auth(mockReq({ path: "/health/live" }), mockRes(), n);
+    expect(n).toHaveBeenCalledOnce();
+  });
+
+  it("calls next() for /health/ready without a token", () => {
+    const n = next();
+    auth(mockReq({ path: "/health/ready" }), mockRes(), n);
+    expect(n).toHaveBeenCalledOnce();
+  });
+
+  it("returns 401 when Authorization header is missing", () => {
+    const res = mockRes();
+    auth(mockReq(), res, next());
+    expect(res.statusCode).toBe(401);
+    expect(res.body.error).toMatch(/authentication required/i);
+  });
+
+  it("returns 401 when Authorization header is not Bearer", () => {
+    const res = mockRes();
+    auth(mockReq({ headers: { authorization: "Basic abc" } }), res, next());
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("returns 401 for an invalid token", () => {
+    const res = mockRes();
+    auth(
+      mockReq({ headers: { authorization: "Bearer invalid.token.here" } }),
+      res,
+      next()
+    );
+    expect(res.statusCode).toBe(401);
+    expect(res.body.error).toMatch(/invalid or expired/i);
+  });
+
+  it("returns 401 for an expired token", () => {
+    const expired = jwt.sign({ userId: "u1" }, SECRET, { expiresIn: -1 });
+    const res = mockRes();
+    auth(
+      mockReq({ headers: { authorization: `Bearer ${expired}` } }),
+      res,
+      next()
+    );
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("calls next() and attaches user for a valid token", () => {
+    const token = jwt.sign({ userId: "u1", role: "admin" }, SECRET);
+    const n = next();
+    const req = mockReq({ headers: { authorization: `Bearer ${token}` } });
+    auth(req, mockRes(), n);
+    expect(n).toHaveBeenCalledOnce();
+    expect((req as any).user?.userId).toBe("u1");
+  });
+
+  it("attaches walletAddress from token payload", () => {
+    const token = jwt.sign({ userId: "u2", walletAddress: "GWALLET" }, SECRET);
+    const req = mockReq({ headers: { authorization: `Bearer ${token}` } });
+    auth(req, mockRes(), next());
+    expect((req as any).user?.walletAddress).toBe("GWALLET");
+  });
+
+  it("does not call next() when token is invalid", () => {
+    const n = next();
+    auth(
+      mockReq({ headers: { authorization: "Bearer bad" } }),
+      mockRes(),
+      n
+    );
+    expect(n).not.toHaveBeenCalled();
+  });
+});

--- a/gateway/src/__tests__/rateLimiter.test.ts
+++ b/gateway/src/__tests__/rateLimiter.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, vi } from "vitest";
+import { Request, NextFunction } from "express";
+import {
+  createRateLimiter,
+  incrementSlidingWindow,
+  resolveRateLimitKey,
+} from "../rateLimiter";
+
+const next = (): NextFunction => vi.fn() as unknown as NextFunction;
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function mockRedis(count = 1) {
+  const pipeline = {
+    zremrangebyscore: vi.fn().mockReturnThis(),
+    zadd:             vi.fn().mockReturnThis(),
+    zcard:            vi.fn().mockReturnThis(),
+    expire:           vi.fn().mockReturnThis(),
+    exec: vi.fn().mockResolvedValue([
+      [null, 0],
+      [null, 1],
+      [null, count],
+      [null, 1],
+    ]),
+  };
+  return { pipeline: vi.fn().mockReturnValue(pipeline), on: vi.fn(), _pipeline: pipeline } as any;
+}
+
+function mockReq(overrides: Partial<Request> = {}): Request {
+  return { ip: "127.0.0.1", socket: { remoteAddress: "127.0.0.1" }, headers: {}, ...overrides } as any;
+}
+
+function mockRes() {
+  const headers: Record<string, any> = {};
+  let statusCode = 200;
+  let body: any;
+  const res: any = {
+    headers,
+    setHeader: vi.fn((k: string, v: any) => { headers[k] = v; }),
+    status:    vi.fn((c: number) => { statusCode = c; return res; }),
+    json:      vi.fn((b: any)   => { body = b; return res; }),
+    get statusCode() { return statusCode; },
+    get body()       { return body; },
+  };
+  return res;
+}
+
+// ── resolveRateLimitKey ───────────────────────────────────────────────────────
+
+describe("resolveRateLimitKey", () => {
+  it("uses IP when no user is attached", () => {
+    expect(resolveRateLimitKey(mockReq({ ip: "1.2.3.4" }), "gw")).toBe("gw:ip:1.2.3.4");
+  });
+
+  it("uses walletAddress when user is authenticated", () => {
+    const req = mockReq({ user: { walletAddress: "GWALLET" } } as any);
+    expect(resolveRateLimitKey(req, "gw")).toBe("gw:wallet:GWALLET");
+  });
+
+  it("falls back to socket.remoteAddress when req.ip is undefined", () => {
+    const req = mockReq({ ip: undefined, socket: { remoteAddress: "5.6.7.8" } as any });
+    expect(resolveRateLimitKey(req, "gw")).toBe("gw:ip:5.6.7.8");
+  });
+
+  it("uses 'unknown' when no address is available", () => {
+    const req = mockReq({ ip: undefined, socket: undefined as any });
+    expect(resolveRateLimitKey(req, "gw")).toBe("gw:ip:unknown");
+  });
+});
+
+// ── incrementSlidingWindow ────────────────────────────────────────────────────
+
+describe("incrementSlidingWindow", () => {
+  it("executes the correct pipeline commands", async () => {
+    const redis = mockRedis();
+    await incrementSlidingWindow(redis, "key", 60_000);
+    const p = redis._pipeline;
+    expect(p.zremrangebyscore).toHaveBeenCalledOnce();
+    expect(p.zadd).toHaveBeenCalledOnce();
+    expect(p.zcard).toHaveBeenCalledOnce();
+    expect(p.expire).toHaveBeenCalledOnce();
+  });
+
+  it("returns the zcard count", async () => {
+    const redis = mockRedis(7);
+    expect(await incrementSlidingWindow(redis, "key", 60_000)).toBe(7);
+  });
+
+  it("falls back to 1 when exec returns null", async () => {
+    const redis = mockRedis();
+    redis._pipeline.exec.mockResolvedValue(null);
+    expect(await incrementSlidingWindow(redis, "key", 60_000)).toBe(1);
+  });
+
+  it("sets TTL to ceil(windowMs/1000)+1", async () => {
+    const redis = mockRedis();
+    await incrementSlidingWindow(redis, "key", 60_000);
+    const [, ttl] = redis._pipeline.expire.mock.calls[0];
+    expect(ttl).toBe(61);
+  });
+});
+
+// ── createRateLimiter — allows ────────────────────────────────────────────────
+
+describe("createRateLimiter — allows requests under the limit", () => {
+  it("calls next() when count ≤ max", async () => {
+    const n = next();
+    await createRateLimiter(mockRedis(1), { windowMs: 60_000, max: 10 })(mockReq(), mockRes(), n);
+    expect(n).toHaveBeenCalledOnce();
+  });
+
+  it("sets X-RateLimit-Limit header", async () => {
+    const res = mockRes();
+    await createRateLimiter(mockRedis(1), { windowMs: 60_000, max: 10 })(mockReq(), res, next());
+    expect(res.headers["X-RateLimit-Limit"]).toBe(10);
+  });
+
+  it("sets X-RateLimit-Remaining header", async () => {
+    const res = mockRes();
+    await createRateLimiter(mockRedis(3), { windowMs: 60_000, max: 10 })(mockReq(), res, next());
+    expect(res.headers["X-RateLimit-Remaining"]).toBe(7);
+  });
+
+  it("sets X-RateLimit-Reset as a future Unix timestamp", async () => {
+    const res = mockRes();
+    const before = Math.floor(Date.now() / 1000);
+    await createRateLimiter(mockRedis(1), { windowMs: 60_000, max: 10 })(mockReq(), res, next());
+    expect(res.headers["X-RateLimit-Reset"]).toBeGreaterThanOrEqual(before + 60);
+  });
+
+  it("allows exactly max requests (count === max)", async () => {
+    const n = next();
+    await createRateLimiter(mockRedis(10), { windowMs: 60_000, max: 10 })(mockReq(), mockRes(), n);
+    expect(n).toHaveBeenCalledOnce();
+  });
+});
+
+// ── createRateLimiter — blocks ────────────────────────────────────────────────
+
+describe("createRateLimiter — blocks requests over the limit", () => {
+  it("responds 429 when count > max", async () => {
+    const res = mockRes();
+    await createRateLimiter(mockRedis(11), { windowMs: 60_000, max: 10 })(mockReq(), res, next());
+    expect(res.statusCode).toBe(429);
+  });
+
+  it("does not call next() on 429", async () => {
+    const n = next();
+    await createRateLimiter(mockRedis(11), { windowMs: 60_000, max: 10 })(mockReq(), mockRes(), n);
+    expect(n).not.toHaveBeenCalled();
+  });
+
+  it("uses custom message when provided", async () => {
+    const res = mockRes();
+    await createRateLimiter(mockRedis(11), { windowMs: 60_000, max: 10, message: "Custom" })(
+      mockReq(), res, next()
+    );
+    expect(res.body.error).toBe("Custom");
+  });
+
+  it("sets Retry-After header on 429", async () => {
+    const res = mockRes();
+    await createRateLimiter(mockRedis(11), { windowMs: 60_000, max: 10 })(mockReq(), res, next());
+    expect(res.headers["Retry-After"]).toBeGreaterThan(0);
+  });
+
+  it("sets X-RateLimit-Remaining to 0 when over limit", async () => {
+    const res = mockRes();
+    await createRateLimiter(mockRedis(20), { windowMs: 60_000, max: 10 })(mockReq(), res, next());
+    expect(res.headers["X-RateLimit-Remaining"]).toBe(0);
+  });
+});
+
+// ── createRateLimiter — fail-open ─────────────────────────────────────────────
+
+describe("createRateLimiter — Redis unavailable (fail-open)", () => {
+  it("calls next() when Redis throws", async () => {
+    const redis = mockRedis();
+    redis._pipeline.exec.mockRejectedValue(new Error("ECONNREFUSED"));
+    const n = next();
+    await createRateLimiter(redis, { windowMs: 60_000, max: 10 })(mockReq(), mockRes(), n);
+    expect(n).toHaveBeenCalledOnce();
+  });
+
+  it("does not set rate-limit headers when Redis is down", async () => {
+    const redis = mockRedis();
+    redis._pipeline.exec.mockRejectedValue(new Error("timeout"));
+    const res = mockRes();
+    await createRateLimiter(redis, { windowMs: 60_000, max: 10 })(mockReq(), res, next());
+    expect(res.headers["X-RateLimit-Limit"]).toBeUndefined();
+  });
+});
+
+// ── Key prefix isolation ──────────────────────────────────────────────────────
+
+describe("createRateLimiter — key prefix", () => {
+  it("uses the configured keyPrefix in the Redis key", async () => {
+    const redis = mockRedis();
+    await createRateLimiter(redis, { windowMs: 60_000, max: 10, keyPrefix: "gw:rl:strict" })(
+      mockReq({ ip: "1.2.3.4" }), mockRes(), next()
+    );
+    const [key] = redis._pipeline.zremrangebyscore.mock.calls[0];
+    expect(key).toContain("gw:rl:strict");
+    expect(key).toContain("1.2.3.4");
+  });
+});

--- a/gateway/src/__tests__/routes.test.ts
+++ b/gateway/src/__tests__/routes.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { ROUTES, RATE_LIMIT_TIERS, RateLimitTier } from "../routes";
+
+describe("RATE_LIMIT_TIERS", () => {
+  const tiers: RateLimitTier[] = ["strict", "default", "relaxed"];
+
+  it.each(tiers)("tier '%s' has positive windowMs and max", (tier) => {
+    expect(RATE_LIMIT_TIERS[tier].windowMs).toBeGreaterThan(0);
+    expect(RATE_LIMIT_TIERS[tier].max).toBeGreaterThan(0);
+  });
+
+  it("strict max < default max < relaxed max", () => {
+    expect(RATE_LIMIT_TIERS.strict.max).toBeLessThan(RATE_LIMIT_TIERS.default.max);
+    expect(RATE_LIMIT_TIERS.default.max).toBeLessThan(RATE_LIMIT_TIERS.relaxed.max);
+  });
+});
+
+describe("ROUTES", () => {
+  it("every route has a non-empty prefix", () => {
+    ROUTES.forEach((r) => expect(r.prefix.length).toBeGreaterThan(0));
+  });
+
+  it("every route prefix starts with /api", () => {
+    ROUTES.forEach((r) => expect(r.prefix.startsWith("/api")).toBe(true));
+  });
+
+  it("admin routes require auth", () => {
+    const admin = ROUTES.find((r) => r.prefix === "/api/admin");
+    expect(admin?.requiresAuth).toBe(true);
+  });
+
+  it("governance routes require auth", () => {
+    const gov = ROUTES.find((r) => r.prefix === "/api/governance");
+    expect(gov?.requiresAuth).toBe(true);
+  });
+
+  it("webhook routes require auth", () => {
+    const wh = ROUTES.find((r) => r.prefix === "/api/webhooks");
+    expect(wh?.requiresAuth).toBe(true);
+  });
+
+  it("leaderboard routes do not require auth", () => {
+    const lb = ROUTES.find((r) => r.prefix === "/api/leaderboard");
+    expect(lb?.requiresAuth).toBe(false);
+  });
+
+  it("admin routes use strict tier", () => {
+    const admin = ROUTES.find((r) => r.prefix === "/api/admin");
+    expect(admin?.tier).toBe("strict");
+  });
+
+  it("leaderboard routes use relaxed tier", () => {
+    const lb = ROUTES.find((r) => r.prefix === "/api/leaderboard");
+    expect(lb?.tier).toBe("relaxed");
+  });
+
+  it("no duplicate prefixes", () => {
+    const prefixes = ROUTES.map((r) => r.prefix);
+    expect(new Set(prefixes).size).toBe(prefixes.length);
+  });
+});

--- a/gateway/src/app.ts
+++ b/gateway/src/app.ts
@@ -1,0 +1,97 @@
+/**
+ * API Gateway — Express application factory.
+ *
+ * Responsibilities:
+ *   1. Security headers (helmet)
+ *   2. CORS with allowlist
+ *   3. JWT authentication (skips public paths)
+ *   4. Per-route Redis-backed sliding-window rate limiting
+ *   5. Reverse proxy to the backend service
+ *
+ * The app is exported separately from the HTTP server so tests can import it
+ * without binding a port.
+ */
+
+import express, { Request, Response } from "express";
+import helmet from "helmet";
+import cors from "cors";
+import { createProxyMiddleware } from "http-proxy-middleware";
+import Redis from "ioredis";
+
+import { GatewayEnv } from "./config";
+import { createAuthMiddleware } from "./auth";
+import { createRateLimiter, createRedisClient } from "./rateLimiter";
+import { ROUTES, RATE_LIMIT_TIERS, RateLimitTier } from "./routes";
+
+export interface GatewayDeps {
+  env: GatewayEnv;
+  /** Optionally inject a Redis client (useful in tests). */
+  redis?: Redis;
+}
+
+export function createApp({ env, redis: injectedRedis }: GatewayDeps) {
+  const app = express();
+
+  // ── Security headers ────────────────────────────────────────────────────────
+  app.use(helmet());
+
+  // ── CORS ────────────────────────────────────────────────────────────────────
+  app.use(
+    cors({
+      origin: (origin, cb) => {
+        if (!origin || env.ALLOWED_ORIGINS.includes(origin)) return cb(null, true);
+        cb(new Error("Not allowed by CORS"));
+      },
+      methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+      allowedHeaders: ["Content-Type", "Authorization"],
+      credentials: true,
+      maxAge: 86400,
+    })
+  );
+
+  // ── Health (no auth, no rate limit) ─────────────────────────────────────────
+  app.get("/health", (_req, res) => {
+    res.json({ status: "ok", service: "api-gateway", uptime: process.uptime() });
+  });
+  app.get("/health/live",  (_req, res) => res.json({ status: "ok" }));
+  app.get("/health/ready", (_req, res) => res.json({ status: "ok" }));
+
+  // ── Authentication ───────────────────────────────────────────────────────────
+  app.use(createAuthMiddleware(env.JWT_SECRET));
+
+  // ── Rate limiting + proxy per route ─────────────────────────────────────────
+  const redis = injectedRedis ?? createRedisClient(env.REDIS_URL);
+
+  // Cache one limiter per tier to avoid creating duplicate Redis pipelines
+  const limiterCache = new Map<RateLimitTier, ReturnType<typeof createRateLimiter>>();
+  function getLimiter(tier: RateLimitTier) {
+    if (!limiterCache.has(tier)) {
+      limiterCache.set(
+        tier,
+        createRateLimiter(redis, { ...RATE_LIMIT_TIERS[tier], keyPrefix: `gw:rl:${tier}` })
+      );
+    }
+    return limiterCache.get(tier)!;
+  }
+
+  const proxy = createProxyMiddleware({
+    target: env.BACKEND_URL,
+    changeOrigin: true,
+    on: {
+      error: (_err, _req, res) => {
+        (res as Response).status(502).json({ error: "Bad gateway" });
+      },
+    },
+  });
+
+  for (const route of ROUTES) {
+    app.use(route.prefix, getLimiter(route.tier), proxy);
+  }
+
+  // ── 404 fallback ─────────────────────────────────────────────────────────────
+  app.use((_req: Request, res: Response) => {
+    res.status(404).json({ error: "Not found" });
+  });
+
+  return app;
+}

--- a/gateway/src/auth.ts
+++ b/gateway/src/auth.ts
@@ -1,0 +1,62 @@
+/**
+ * JWT authentication middleware for the API Gateway.
+ *
+ * Verifies Bearer tokens on protected routes.  Public routes (health, docs)
+ * are skipped.  On success, the decoded payload is attached to `req.user`.
+ *
+ * Security: OWASP API2 — Broken Authentication
+ *   - Tokens are verified with jsonwebtoken (HS256 by default).
+ *   - Expired tokens are rejected with 401.
+ *   - Missing tokens on protected routes are rejected with 401.
+ */
+
+import { Request, Response, NextFunction } from "express";
+import jwt from "jsonwebtoken";
+
+/** Routes that do not require authentication. */
+const PUBLIC_PATHS = new Set(["/health", "/health/live", "/health/ready"]);
+
+export interface JwtPayload {
+  userId: string;
+  role?: string;
+  walletAddress?: string;
+}
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Express {
+    interface Request {
+      user?: JwtPayload;
+    }
+  }
+}
+
+/**
+ * Creates JWT authentication middleware.
+ *
+ * @param jwtSecret  Secret used to verify tokens (from env).
+ */
+export function createAuthMiddleware(jwtSecret: string) {
+  return function authMiddleware(req: Request, res: Response, next: NextFunction): void {
+    // Skip auth for public paths
+    if (PUBLIC_PATHS.has(req.path)) {
+      next();
+      return;
+    }
+
+    const authHeader = req.headers.authorization;
+    if (!authHeader?.startsWith("Bearer ")) {
+      res.status(401).json({ error: "Authentication required" });
+      return;
+    }
+
+    const token = authHeader.slice(7);
+    try {
+      const payload = jwt.verify(token, jwtSecret) as JwtPayload;
+      req.user = payload;
+      next();
+    } catch {
+      res.status(401).json({ error: "Invalid or expired token" });
+    }
+  };
+}

--- a/gateway/src/config.ts
+++ b/gateway/src/config.ts
@@ -1,0 +1,37 @@
+/**
+ * Gateway environment configuration.
+ * Validates required variables at startup.
+ */
+
+export interface GatewayEnv {
+  PORT: number;
+  BACKEND_URL: string;
+  JWT_SECRET: string;
+  REDIS_URL: string;
+  ALLOWED_ORIGINS: string[];
+  NODE_ENV: string;
+}
+
+export function validateGatewayEnv(): GatewayEnv {
+  const nodeEnv = process.env.NODE_ENV ?? "development";
+  const isProd = nodeEnv === "production";
+
+  const jwtSecret = process.env.JWT_SECRET ?? (isProd ? "" : "dev-secret-key-change-me");
+  if (isProd && !jwtSecret) throw new Error("JWT_SECRET is required in production.");
+
+  const backendUrl = process.env.BACKEND_URL ?? "http://localhost:3001";
+
+  const allowedOrigins = (process.env.ALLOWED_ORIGINS ?? "http://localhost:5173")
+    .split(",")
+    .map((o) => o.trim())
+    .filter(Boolean);
+
+  return {
+    PORT: parseInt(process.env.GATEWAY_PORT ?? "4000", 10),
+    BACKEND_URL: backendUrl,
+    JWT_SECRET: jwtSecret,
+    REDIS_URL: process.env.REDIS_URL ?? "redis://localhost:6379",
+    ALLOWED_ORIGINS: allowedOrigins,
+    NODE_ENV: nodeEnv,
+  };
+}

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -1,0 +1,12 @@
+import "dotenv/config";
+import { validateGatewayEnv } from "./config";
+import { createApp } from "./app";
+
+const env = validateGatewayEnv();
+const app = createApp({ env });
+
+app.listen(env.PORT, () => {
+  console.log(`🚪 API Gateway running on port ${env.PORT}`);
+  console.log(`   → Proxying to ${env.BACKEND_URL}`);
+  console.log(`   → Environment: ${env.NODE_ENV}`);
+});

--- a/gateway/src/rateLimiter.ts
+++ b/gateway/src/rateLimiter.ts
@@ -1,0 +1,125 @@
+/**
+ * Redis-backed sliding-window rate limiter for the API Gateway.
+ *
+ * Mirrors the pattern in backend/src/middleware/rateLimiter.ts but is
+ * self-contained so the gateway has no dependency on the backend package.
+ *
+ * Algorithm: sliding-window counter via Redis sorted sets.
+ *   - Each request is stored as a member with score = timestamp (ms).
+ *   - Entries older than the window are pruned atomically.
+ *   - The key TTL is set to window + 1 s to prevent stale data.
+ *
+ * Fail-open: when Redis is unavailable the middleware calls next() rather
+ * than blocking all traffic due to a cache outage.
+ *
+ * Headers set on every response:
+ *   X-RateLimit-Limit     – configured maximum
+ *   X-RateLimit-Remaining – requests left in the current window
+ *   X-RateLimit-Reset     – Unix timestamp (s) when the window resets
+ *   Retry-After           – seconds until reset (only on 429)
+ */
+
+import { Request, Response, NextFunction } from "express";
+import Redis from "ioredis";
+
+export interface RateLimitConfig {
+  /** Time window in milliseconds. */
+  windowMs: number;
+  /** Maximum requests allowed per window. */
+  max: number;
+  /** Error message returned on 429. */
+  message?: string;
+  /** Redis key prefix for namespace isolation. */
+  keyPrefix?: string;
+}
+
+/**
+ * Creates a Redis client.  Fails fast on connection errors (enableOfflineQueue=false)
+ * so the gateway does not queue requests when Redis is down.
+ */
+export function createRedisClient(url: string): Redis {
+  const client = new Redis(url, {
+    enableOfflineQueue: false,
+    lazyConnect: true,
+    maxRetriesPerRequest: 1,
+  });
+  client.on("error", (err: Error) => {
+    console.error("[Gateway:RateLimiter] Redis error:", err.message);
+  });
+  return client;
+}
+
+/**
+ * Atomically records a request and returns the count within the window.
+ */
+export async function incrementSlidingWindow(
+  redis: Redis,
+  key: string,
+  windowMs: number
+): Promise<number> {
+  const now = Date.now();
+  const windowStart = now - windowMs;
+  const expireSeconds = Math.ceil(windowMs / 1000) + 1;
+
+  const pipeline = redis.pipeline();
+  pipeline.zremrangebyscore(key, "-inf", windowStart);
+  pipeline.zadd(key, now, `${now}-${Math.random()}`);
+  pipeline.zcard(key);
+  pipeline.expire(key, expireSeconds);
+
+  const results = await pipeline.exec();
+  return (results?.[2]?.[1] as number) ?? 1;
+}
+
+/**
+ * Resolves the rate-limit key for a request.
+ * Authenticated requests are keyed by wallet address; anonymous by IP.
+ */
+export function resolveRateLimitKey(req: Request, prefix: string): string {
+  const walletAddress = req.user?.walletAddress;
+  if (walletAddress) return `${prefix}:wallet:${walletAddress}`;
+  const ip = req.ip ?? req.socket?.remoteAddress ?? "unknown";
+  return `${prefix}:ip:${ip}`;
+}
+
+/**
+ * Creates an Express rate-limiting middleware backed by Redis.
+ */
+export function createRateLimiter(redis: Redis, config: RateLimitConfig) {
+  const {
+    windowMs,
+    max,
+    message = "Too many requests, please try again later.",
+    keyPrefix = "gw:rl",
+  } = config;
+
+  return async function rateLimiterMiddleware(
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<void> {
+    const key = resolveRateLimitKey(req, keyPrefix);
+    const resetAt = Math.ceil((Date.now() + windowMs) / 1000);
+
+    let count: number;
+    try {
+      count = await incrementSlidingWindow(redis, key, windowMs);
+    } catch {
+      // Redis unavailable — fail open to avoid blocking all traffic
+      next();
+      return;
+    }
+
+    res.setHeader("X-RateLimit-Limit", max);
+    res.setHeader("X-RateLimit-Remaining", Math.max(0, max - count));
+    res.setHeader("X-RateLimit-Reset", resetAt);
+
+    if (count > max) {
+      res.setHeader("Retry-After", resetAt - Math.floor(Date.now() / 1000));
+      res.status(429).json({ error: message });
+      return;
+    }
+
+    next();
+  };
+}

--- a/gateway/src/routes.ts
+++ b/gateway/src/routes.ts
@@ -1,0 +1,43 @@
+/**
+ * Route table for the API Gateway.
+ *
+ * Each entry maps a path prefix to a rate-limit tier.
+ * The proxy target is always BACKEND_URL; only the rate limits differ per route.
+ *
+ * Tiers:
+ *   strict  – 20 req / 15 min  (write operations, auth endpoints)
+ *   default – 100 req / 15 min (general API)
+ *   relaxed – 300 req / 15 min (read-heavy public endpoints)
+ */
+
+export type RateLimitTier = "strict" | "default" | "relaxed";
+
+export interface RouteConfig {
+  /** Path prefix to match (e.g. "/api/admin"). */
+  prefix: string;
+  /** Rate-limit tier applied to this prefix. */
+  tier: RateLimitTier;
+  /** Whether the route requires a valid JWT. */
+  requiresAuth: boolean;
+}
+
+export const RATE_LIMIT_TIERS: Record<RateLimitTier, { windowMs: number; max: number }> = {
+  strict:  { windowMs: 15 * 60 * 1000, max: 20 },
+  default: { windowMs: 15 * 60 * 1000, max: 100 },
+  relaxed: { windowMs: 15 * 60 * 1000, max: 300 },
+};
+
+export const ROUTES: RouteConfig[] = [
+  { prefix: "/api/admin",      tier: "strict",  requiresAuth: true  },
+  { prefix: "/api/governance", tier: "strict",  requiresAuth: true  },
+  { prefix: "/api/webhooks",   tier: "strict",  requiresAuth: true  },
+  { prefix: "/api/tokens",     tier: "default", requiresAuth: false },
+  { prefix: "/api/dividends",  tier: "default", requiresAuth: false },
+  { prefix: "/api/campaigns",  tier: "default", requiresAuth: false },
+  { prefix: "/api/streams",    tier: "default", requiresAuth: false },
+  { prefix: "/api/vaults",     tier: "default", requiresAuth: false },
+  { prefix: "/api/leaderboard",tier: "relaxed", requiresAuth: false },
+  { prefix: "/api/search",     tier: "relaxed", requiresAuth: false },
+  { prefix: "/api/stats",      tier: "relaxed", requiresAuth: false },
+  { prefix: "/api/graphql",    tier: "default", requiresAuth: false },
+];

--- a/gateway/tsconfig.json
+++ b/gateway/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/gateway/vitest.config.ts
+++ b/gateway/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      include: ["src/**/*.ts"],
+      exclude: ["src/index.ts"],
+      thresholds: { lines: 90, functions: 90, branches: 90, statements: 90 },
+    },
+  },
+});

--- a/istio/README.md
+++ b/istio/README.md
@@ -1,0 +1,25 @@
+# Nova Launch — Istio Service Mesh
+#
+# Apply order:
+#   1. namespace.yaml          — create namespace + enable sidecar injection
+#   2. deployments.yaml        — workloads (backend, frontend, gateway)
+#   3. services.yaml           — ClusterIP services
+#   4. gateway.yaml            — Istio IngressGateway
+#   5. virtual-services.yaml   — routing rules
+#   6. destination-rules.yaml  — traffic policies (mTLS, circuit breaker)
+#   7. peer-authentication.yaml — enforce STRICT mTLS mesh-wide
+#
+# Quick start:
+#   kubectl apply -f istio/
+#
+# Prerequisites:
+#   - Kubernetes 1.27+
+#   - Istio 1.20+ installed (istioctl install --set profile=default)
+#   - Secrets created (see README section below)
+#
+# Secrets required before applying:
+#   kubectl create secret generic nova-launch-secrets \
+#     --from-literal=DATABASE_URL='postgresql://...' \
+#     --from-literal=JWT_SECRET='...' \
+#     --from-literal=ADMIN_JWT_SECRET='...' \
+#     -n nova-launch

--- a/istio/__tests__/manifests.test.js
+++ b/istio/__tests__/manifests.test.js
@@ -1,0 +1,308 @@
+/**
+ * Istio manifest validation tests.
+ *
+ * These tests parse the YAML manifests and assert structural and security
+ * properties without requiring a live Kubernetes cluster.
+ *
+ * Coverage areas:
+ *   - All expected resources are present with correct apiVersions/kinds
+ *   - Namespace has istio-injection label
+ *   - Deployments: non-root user, resource limits, health probes, correct ports
+ *   - Services: named ports (required for Istio L7 policies)
+ *   - Gateway: correct selector and server definitions
+ *   - VirtualServices: routing rules, timeouts, retries
+ *   - DestinationRules: mTLS mode, circuit breaker, Redis exemption
+ *   - PeerAuthentication: STRICT default, Redis PERMISSIVE exemption
+ *   - No secrets hardcoded in manifests
+ */
+
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { describe, it, expect, beforeAll } from 'vitest';
+import yaml from 'js-yaml';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ISTIO_DIR = join(__dirname, '..');
+
+/** Load and parse all documents from a YAML file. */
+function loadAll(filename) {
+  const raw = readFileSync(join(ISTIO_DIR, filename), 'utf8');
+  return yaml.loadAll(raw).filter(Boolean);
+}
+
+/** Find a document by kind (and optional name). */
+function find(docs, kind, name) {
+  return docs.find(
+    (d) => d.kind === kind && (name === undefined || d.metadata?.name === name)
+  );
+}
+
+// ── Load all manifests once ───────────────────────────────────────────────────
+
+let ns, deployments, services, gateway, virtualServices, destRules, peerAuths;
+
+beforeAll(() => {
+  ns           = loadAll('namespace.yaml');
+  deployments  = loadAll('deployments.yaml');
+  services     = loadAll('services.yaml');
+  gateway      = loadAll('gateway.yaml');
+  virtualServices = loadAll('virtual-services.yaml');
+  destRules    = loadAll('destination-rules.yaml');
+  peerAuths    = loadAll('peer-authentication.yaml');
+});
+
+// ── namespace.yaml ────────────────────────────────────────────────────────────
+
+describe('namespace.yaml', () => {
+  it('defines a Namespace resource', () => {
+    expect(find(ns, 'Namespace', 'nova-launch')).toBeDefined();
+  });
+
+  it('has istio-injection=enabled label', () => {
+    const n = find(ns, 'Namespace', 'nova-launch');
+    expect(n.metadata.labels['istio-injection']).toBe('enabled');
+  });
+});
+
+// ── deployments.yaml ──────────────────────────────────────────────────────────
+
+describe('deployments.yaml', () => {
+  const SERVICES = ['backend', 'frontend', 'gateway'];
+
+  it.each(SERVICES)('defines a Deployment for %s', (name) => {
+    expect(find(deployments, 'Deployment', name)).toBeDefined();
+  });
+
+  it.each(SERVICES)('%s deployment is in nova-launch namespace', (name) => {
+    const d = find(deployments, 'Deployment', name);
+    expect(d.metadata.namespace).toBe('nova-launch');
+  });
+
+  it.each(SERVICES)('%s deployment has version=v1 label', (name) => {
+    const d = find(deployments, 'Deployment', name);
+    expect(d.spec.template.metadata.labels.version).toBe('v1');
+  });
+
+  it('backend runs as non-root user', () => {
+    const d = find(deployments, 'Deployment', 'backend');
+    const sc = d.spec.template.spec.securityContext;
+    expect(sc.runAsNonRoot).toBe(true);
+    expect(sc.runAsUser).toBeGreaterThan(0);
+  });
+
+  it('gateway runs as non-root user', () => {
+    const d = find(deployments, 'Deployment', 'gateway');
+    const sc = d.spec.template.spec.securityContext;
+    expect(sc.runAsNonRoot).toBe(true);
+  });
+
+  it.each(['backend', 'gateway'])('%s has resource limits defined', (name) => {
+    const d = find(deployments, 'Deployment', name);
+    const res = d.spec.template.spec.containers[0].resources;
+    expect(res.limits.cpu).toBeDefined();
+    expect(res.limits.memory).toBeDefined();
+  });
+
+  it.each(['backend', 'gateway'])('%s has readiness probe', (name) => {
+    const d = find(deployments, 'Deployment', name);
+    expect(d.spec.template.spec.containers[0].readinessProbe).toBeDefined();
+  });
+
+  it.each(['backend', 'gateway'])('%s has liveness probe', (name) => {
+    const d = find(deployments, 'Deployment', name);
+    expect(d.spec.template.spec.containers[0].livenessProbe).toBeDefined();
+  });
+
+  it('backend exposes port 3001', () => {
+    const d = find(deployments, 'Deployment', 'backend');
+    const ports = d.spec.template.spec.containers[0].ports;
+    expect(ports.some((p) => p.containerPort === 3001)).toBe(true);
+  });
+
+  it('gateway exposes port 4000', () => {
+    const d = find(deployments, 'Deployment', 'gateway');
+    const ports = d.spec.template.spec.containers[0].ports;
+    expect(ports.some((p) => p.containerPort === 4000)).toBe(true);
+  });
+
+  it('no hardcoded secrets in env values', () => {
+    for (const d of deployments) {
+      const containers = d.spec?.template?.spec?.containers ?? [];
+      for (const c of containers) {
+        for (const env of c.env ?? []) {
+          // Env vars with plain `value` must not look like secrets
+          if (env.value && /secret|password|key/i.test(env.name)) {
+            // Should use secretKeyRef, not a plain value
+            expect(env.valueFrom?.secretKeyRef).toBeDefined();
+          }
+        }
+      }
+    }
+  });
+});
+
+// ── services.yaml ─────────────────────────────────────────────────────────────
+
+describe('services.yaml', () => {
+  const SVCS = ['backend', 'frontend', 'gateway', 'redis'];
+
+  it.each(SVCS)('defines a Service for %s', (name) => {
+    expect(find(services, 'Service', name)).toBeDefined();
+  });
+
+  it.each(['backend', 'frontend', 'gateway'])('%s service port is named http', (name) => {
+    const svc = find(services, 'Service', name);
+    expect(svc.spec.ports[0].name).toBe('http');
+  });
+
+  it('redis service port is named tcp-redis (required for Istio)', () => {
+    const svc = find(services, 'Service', 'redis');
+    expect(svc.spec.ports[0].name).toMatch(/^tcp/);
+  });
+
+  it('backend service targets port 3001', () => {
+    const svc = find(services, 'Service', 'backend');
+    expect(svc.spec.ports[0].port).toBe(3001);
+  });
+
+  it('gateway service targets port 4000', () => {
+    const svc = find(services, 'Service', 'gateway');
+    expect(svc.spec.ports[0].port).toBe(4000);
+  });
+});
+
+// ── gateway.yaml ──────────────────────────────────────────────────────────────
+
+describe('gateway.yaml', () => {
+  it('defines an Istio Gateway', () => {
+    expect(find(gateway, 'Gateway', 'nova-launch-gateway')).toBeDefined();
+  });
+
+  it('uses istio ingressgateway selector', () => {
+    const gw = find(gateway, 'Gateway', 'nova-launch-gateway');
+    expect(gw.spec.selector.istio).toBe('ingressgateway');
+  });
+
+  it('exposes port 80 (HTTP)', () => {
+    const gw = find(gateway, 'Gateway', 'nova-launch-gateway');
+    const ports = gw.spec.servers.map((s) => s.port.number);
+    expect(ports).toContain(80);
+  });
+
+  it('exposes port 443 (HTTPS)', () => {
+    const gw = find(gateway, 'Gateway', 'nova-launch-gateway');
+    const ports = gw.spec.servers.map((s) => s.port.number);
+    expect(ports).toContain(443);
+  });
+
+  it('HTTPS server uses SIMPLE TLS mode', () => {
+    const gw = find(gateway, 'Gateway', 'nova-launch-gateway');
+    const https = gw.spec.servers.find((s) => s.port.number === 443);
+    expect(https.tls.mode).toBe('SIMPLE');
+  });
+});
+
+// ── virtual-services.yaml ─────────────────────────────────────────────────────
+
+describe('virtual-services.yaml', () => {
+  it('defines ingress VirtualService', () => {
+    expect(find(virtualServices, 'VirtualService', 'nova-launch-ingress')).toBeDefined();
+  });
+
+  it('defines backend-internal VirtualService', () => {
+    expect(find(virtualServices, 'VirtualService', 'backend-internal')).toBeDefined();
+  });
+
+  it('ingress VS routes /api/* to gateway', () => {
+    const vs = find(virtualServices, 'VirtualService', 'nova-launch-ingress');
+    const apiRoute = vs.spec.http.find((r) =>
+      r.match?.some((m) => m.uri?.prefix === '/api')
+    );
+    expect(apiRoute).toBeDefined();
+    expect(apiRoute.route[0].destination.host).toBe('gateway');
+  });
+
+  it('ingress VS routes /health* to backend', () => {
+    const vs = find(virtualServices, 'VirtualService', 'nova-launch-ingress');
+    const healthRoute = vs.spec.http.find((r) =>
+      r.match?.some((m) => m.uri?.prefix === '/health')
+    );
+    expect(healthRoute).toBeDefined();
+    expect(healthRoute.route[0].destination.host).toBe('backend');
+  });
+
+  it('ingress VS has a default route to frontend', () => {
+    const vs = find(virtualServices, 'VirtualService', 'nova-launch-ingress');
+    const defaultRoute = vs.spec.http.find((r) => !r.match);
+    expect(defaultRoute).toBeDefined();
+    expect(defaultRoute.route[0].destination.host).toBe('frontend');
+  });
+
+  it('/api route has retry policy', () => {
+    const vs = find(virtualServices, 'VirtualService', 'nova-launch-ingress');
+    const apiRoute = vs.spec.http.find((r) =>
+      r.match?.some((m) => m.uri?.prefix === '/api')
+    );
+    expect(apiRoute.retries).toBeDefined();
+    expect(apiRoute.retries.attempts).toBeGreaterThan(0);
+  });
+
+  it('backend-internal VS has timeout', () => {
+    const vs = find(virtualServices, 'VirtualService', 'backend-internal');
+    expect(vs.spec.http[0].timeout).toBeDefined();
+  });
+});
+
+// ── destination-rules.yaml ────────────────────────────────────────────────────
+
+describe('destination-rules.yaml', () => {
+  const MTLS_SERVICES = ['backend', 'gateway', 'frontend'];
+
+  it.each(MTLS_SERVICES)('%s DestinationRule uses ISTIO_MUTUAL TLS', (name) => {
+    const dr = find(destRules, 'DestinationRule', name);
+    expect(dr).toBeDefined();
+    expect(dr.spec.trafficPolicy.tls.mode).toBe('ISTIO_MUTUAL');
+  });
+
+  it('redis DestinationRule disables TLS (plain TCP)', () => {
+    const dr = find(destRules, 'DestinationRule', 'redis');
+    expect(dr.spec.trafficPolicy.tls.mode).toBe('DISABLE');
+  });
+
+  it.each(['backend', 'gateway'])('%s has outlier detection (circuit breaker)', (name) => {
+    const dr = find(destRules, 'DestinationRule', name);
+    expect(dr.spec.trafficPolicy.outlierDetection).toBeDefined();
+    expect(dr.spec.trafficPolicy.outlierDetection.consecutive5xxErrors).toBeGreaterThan(0);
+  });
+
+  it.each(['backend', 'gateway'])('%s has connection pool limits', (name) => {
+    const dr = find(destRules, 'DestinationRule', name);
+    expect(dr.spec.trafficPolicy.connectionPool).toBeDefined();
+  });
+});
+
+// ── peer-authentication.yaml ──────────────────────────────────────────────────
+
+describe('peer-authentication.yaml', () => {
+  it('defines a default PeerAuthentication', () => {
+    expect(find(peerAuths, 'PeerAuthentication', 'default')).toBeDefined();
+  });
+
+  it('default policy enforces STRICT mTLS', () => {
+    const pa = find(peerAuths, 'PeerAuthentication', 'default');
+    expect(pa.spec.mtls.mode).toBe('STRICT');
+  });
+
+  it('default policy applies to the nova-launch namespace', () => {
+    const pa = find(peerAuths, 'PeerAuthentication', 'default');
+    expect(pa.metadata.namespace).toBe('nova-launch');
+  });
+
+  it('redis has a PERMISSIVE exemption', () => {
+    const pa = find(peerAuths, 'PeerAuthentication', 'redis-permissive');
+    expect(pa).toBeDefined();
+    expect(pa.spec.mtls.mode).toBe('PERMISSIVE');
+    expect(pa.spec.selector.matchLabels.app).toBe('redis');
+  });
+});

--- a/istio/deployments.yaml
+++ b/istio/deployments.yaml
@@ -1,0 +1,183 @@
+# Backend deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+  namespace: nova-launch
+  labels:
+    app: backend
+    version: v1
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: backend
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: backend
+        version: v1
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+      containers:
+        - name: backend
+          image: nova-launch/backend:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 3001
+              name: http
+          env:
+            - name: NODE_ENV
+              value: production
+            - name: PORT
+              value: "3001"
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: nova-launch-secrets
+                  key: DATABASE_URL
+            - name: JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: nova-launch-secrets
+                  key: JWT_SECRET
+            - name: ADMIN_JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: nova-launch-secrets
+                  key: ADMIN_JWT_SECRET
+            - name: REDIS_URL
+              value: redis://redis:6379
+            - name: STELLAR_NETWORK
+              value: mainnet
+          readinessProbe:
+            httpGet:
+              path: /health/ready
+              port: 3001
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health/live
+              port: 3001
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+---
+# Frontend deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  namespace: nova-launch
+  labels:
+    app: frontend
+    version: v1
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: frontend
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: frontend
+        version: v1
+    spec:
+      containers:
+        - name: frontend
+          image: nova-launch/frontend:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 80
+              name: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+---
+# API Gateway deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gateway
+  namespace: nova-launch
+  labels:
+    app: gateway
+    version: v1
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: gateway
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: gateway
+        version: v1
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+      containers:
+        - name: gateway
+          image: nova-launch/gateway:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 4000
+              name: http
+          env:
+            - name: NODE_ENV
+              value: production
+            - name: GATEWAY_PORT
+              value: "4000"
+            - name: BACKEND_URL
+              value: http://backend:3001
+            - name: JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: nova-launch-secrets
+                  key: JWT_SECRET
+            - name: REDIS_URL
+              value: redis://redis:6379
+            - name: ALLOWED_ORIGINS
+              value: "https://nova-launch.app"
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 4000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health/live
+              port: 4000
+            initialDelaySeconds: 10
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 300m
+              memory: 256Mi

--- a/istio/destination-rules.yaml
+++ b/istio/destination-rules.yaml
@@ -1,0 +1,79 @@
+# DestinationRules — traffic policies per service.
+#
+# Enforces:
+#   - ISTIO_MUTUAL TLS for all HTTP services (works with PeerAuthentication STRICT)
+#   - Connection pool limits to prevent cascade failures
+#   - Outlier detection (circuit breaker) to eject unhealthy hosts
+
+# ── backend ───────────────────────────────────────────────────────────────────
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: backend
+  namespace: nova-launch
+spec:
+  host: backend
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+    connectionPool:
+      http:
+        http1MaxPendingRequests: 100
+        http2MaxRequests: 200
+    outlierDetection:
+      consecutive5xxErrors: 5
+      interval: 30s
+      baseEjectionTime: 30s
+      maxEjectionPercent: 50
+---
+# ── gateway ───────────────────────────────────────────────────────────────────
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: gateway
+  namespace: nova-launch
+spec:
+  host: gateway
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+    connectionPool:
+      http:
+        http1MaxPendingRequests: 200
+        http2MaxRequests: 400
+    outlierDetection:
+      consecutive5xxErrors: 5
+      interval: 30s
+      baseEjectionTime: 30s
+      maxEjectionPercent: 50
+---
+# ── frontend ──────────────────────────────────────────────────────────────────
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: frontend
+  namespace: nova-launch
+spec:
+  host: frontend
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+    connectionPool:
+      http:
+        http1MaxPendingRequests: 100
+---
+# ── redis (TCP — no mTLS upgrade, passthrough) ────────────────────────────────
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: redis
+  namespace: nova-launch
+spec:
+  host: redis
+  trafficPolicy:
+    tls:
+      mode: DISABLE   # Redis does not speak TLS by default
+    connectionPool:
+      tcp:
+        maxConnections: 50
+        connectTimeout: 3s

--- a/istio/gateway.yaml
+++ b/istio/gateway.yaml
@@ -1,0 +1,33 @@
+# Istio IngressGateway — single entry point for external traffic.
+#
+# Routes:
+#   /*          → frontend (SPA)
+#   /api/*      → gateway  (rate-limited, authenticated)
+#   /health*    → backend  (liveness/readiness probes, no auth)
+apiVersion: networking.istio.io/v1beta1
+kind: Gateway
+metadata:
+  name: nova-launch-gateway
+  namespace: nova-launch
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+    - port:
+        number: 80
+        name: http
+        protocol: HTTP
+      hosts:
+        - "*"
+      # Redirect HTTP → HTTPS in production; remove for local dev
+      tls:
+        httpsRedirect: false
+    - port:
+        number: 443
+        name: https
+        protocol: HTTPS
+      hosts:
+        - "*"
+      tls:
+        mode: SIMPLE
+        credentialName: nova-launch-tls  # kubectl create secret tls nova-launch-tls ...

--- a/istio/namespace.yaml
+++ b/istio/namespace.yaml
@@ -1,0 +1,7 @@
+# Namespace with Istio sidecar injection enabled.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nova-launch
+  labels:
+    istio-injection: enabled

--- a/istio/package.json
+++ b/istio/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "nova-launch-istio-tests",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "devDependencies": {
+    "@vitest/coverage-v8": "^1.6.1",
+    "js-yaml": "^4.1.0",
+    "vitest": "^1.6.1"
+  }
+}

--- a/istio/peer-authentication.yaml
+++ b/istio/peer-authentication.yaml
@@ -1,0 +1,31 @@
+# PeerAuthentication — enforce STRICT mTLS for all workloads in the namespace.
+#
+# STRICT mode means:
+#   - All inbound connections MUST present a valid Istio-issued certificate.
+#   - Plain-text connections are rejected.
+#   - Combined with DestinationRule ISTIO_MUTUAL, this gives end-to-end mTLS
+#     for all service-to-service communication inside the mesh.
+#
+# Redis is excluded via a workload-specific policy (PERMISSIVE) because it
+# does not support TLS natively.
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: default
+  namespace: nova-launch
+spec:
+  mtls:
+    mode: STRICT
+---
+# Redis workload exemption — allow plain TCP connections
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: redis-permissive
+  namespace: nova-launch
+spec:
+  selector:
+    matchLabels:
+      app: redis
+  mtls:
+    mode: PERMISSIVE

--- a/istio/services.yaml
+++ b/istio/services.yaml
@@ -1,0 +1,62 @@
+# ClusterIP services — Istio sidecars handle mTLS between them.
+# Ports are named (http/tcp) so Istio can apply L7 policies.
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend
+  namespace: nova-launch
+  labels:
+    app: backend
+spec:
+  selector:
+    app: backend
+  ports:
+    - name: http
+      port: 3001
+      targetPort: 3001
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  namespace: nova-launch
+  labels:
+    app: frontend
+spec:
+  selector:
+    app: frontend
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: gateway
+  namespace: nova-launch
+  labels:
+    app: gateway
+spec:
+  selector:
+    app: gateway
+  ports:
+    - name: http
+      port: 4000
+      targetPort: 4000
+---
+# Redis — tcp port (no L7 policy needed)
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: nova-launch
+  labels:
+    app: redis
+spec:
+  selector:
+    app: redis
+  ports:
+    - name: tcp-redis
+      port: 6379
+      targetPort: 6379

--- a/istio/virtual-services.yaml
+++ b/istio/virtual-services.yaml
@@ -1,0 +1,77 @@
+# VirtualServices — L7 routing rules applied by Istio sidecars.
+#
+# External traffic (via IngressGateway):
+#   /api/*   → gateway:4000
+#   /health* → backend:3001  (bypass gateway for k8s probes)
+#   /*       → frontend:80
+#
+# Internal traffic (service-to-service):
+#   gateway → backend  (with retry + timeout)
+#   backend → redis    (passthrough, no retries on tcp)
+
+# ── External routing ──────────────────────────────────────────────────────────
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: nova-launch-ingress
+  namespace: nova-launch
+spec:
+  hosts:
+    - "*"
+  gateways:
+    - nova-launch-gateway
+  http:
+    # Health endpoints bypass the gateway (used by k8s probes and monitoring)
+    - match:
+        - uri:
+            prefix: /health
+      route:
+        - destination:
+            host: backend
+            port:
+              number: 3001
+      timeout: 5s
+
+    # All /api/* traffic goes through the API gateway
+    - match:
+        - uri:
+            prefix: /api
+      route:
+        - destination:
+            host: gateway
+            port:
+              number: 4000
+      timeout: 30s
+      retries:
+        attempts: 3
+        perTryTimeout: 10s
+        retryOn: gateway-error,connect-failure,retriable-4xx
+
+    # Everything else → frontend SPA
+    - route:
+        - destination:
+            host: frontend
+            port:
+              number: 80
+      timeout: 10s
+---
+# ── gateway → backend (internal) ─────────────────────────────────────────────
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: backend-internal
+  namespace: nova-launch
+spec:
+  hosts:
+    - backend
+  http:
+    - route:
+        - destination:
+            host: backend
+            port:
+              number: 3001
+      timeout: 15s
+      retries:
+        attempts: 3
+        perTryTimeout: 5s
+        retryOn: gateway-error,connect-failure,reset

--- a/istio/vitest.config.js
+++ b/istio/vitest.config.js
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    coverage: {
+      provider: 'v8',
+      include: ['__tests__/**/*.js'],
+      thresholds: { lines: 90, functions: 90, branches: 90, statements: 90 },
+    },
+  },
+});

--- a/load-tests/lib/ci-load-helpers.js
+++ b/load-tests/lib/ci-load-helpers.js
@@ -1,0 +1,124 @@
+/**
+ * Pure helper functions extracted from ci-load.js for unit testing.
+ *
+ * k6 scripts import k6-specific modules (k6/http, k6/metrics) that are not
+ * available in Node.js.  This module contains only the logic that can be
+ * tested without a k6 runtime.
+ */
+
+/**
+ * Pick a random element from an array.
+ * @param {Array} arr
+ * @returns {*}
+ */
+export function pick(arr) {
+  if (!arr || arr.length === 0) return undefined;
+  return arr[Math.floor(Math.random() * arr.length)];
+}
+
+/**
+ * Determine which scenario group a VU should execute based on a [0,1) roll.
+ *
+ * Distribution:
+ *   [0.00, 0.50) → token_search
+ *   [0.50, 0.75) → health
+ *   [0.75, 0.90) → leaderboard
+ *   [0.90, 1.00) → stats
+ *
+ * @param {number} roll  Random value in [0, 1)
+ * @returns {'token_search'|'health'|'leaderboard'|'stats'}
+ */
+export function selectScenario(roll) {
+  if (roll < 0.50) return 'token_search';
+  if (roll < 0.75) return 'health';
+  if (roll < 0.90) return 'leaderboard';
+  return 'stats';
+}
+
+/**
+ * Format the load test summary for stdout.
+ *
+ * @param {{ passed: boolean, timestamp: string, vus: number, duration: number,
+ *           metrics: object }} s
+ * @returns {string}
+ */
+export function formatSummary(s) {
+  const status = s.passed ? '✅ PASSED' : '❌ FAILED';
+  const m = s.metrics;
+  return [
+    '',
+    `=== CI Load Test Summary — ${status} ===`,
+    `  Timestamp : ${s.timestamp}`,
+    `  VUs       : ${s.vus}`,
+    `  Duration  : ${s.duration}s steady state`,
+    '',
+    '  Latency:',
+    `    p95 : ${m.http_req_duration_p95?.toFixed(1) ?? 'n/a'} ms`,
+    `    p99 : ${m.http_req_duration_p99?.toFixed(1) ?? 'n/a'} ms`,
+    '',
+    '  Reliability:',
+    `    HTTP error rate : ${((m.http_req_failed_rate ?? 0) * 100).toFixed(2)} %`,
+    `    CI error rate   : ${((m.ci_errors_rate ?? 0) * 100).toFixed(2)} %`,
+    '',
+    `  Total requests : ${m.ci_total_requests ?? 0}`,
+    '',
+  ].join('\n');
+}
+
+/**
+ * Build the summary object written to ci-load-summary.json.
+ *
+ * @param {object} k6Data  k6 handleSummary data object
+ * @param {number} vus
+ * @param {number} duration
+ * @returns {object}
+ */
+export function buildSummary(k6Data, vus, duration) {
+  const passed = !Object.values(k6Data.metrics ?? {}).some(
+    (m) => m.thresholds && Object.values(m.thresholds).some((t) => t.ok === false)
+  );
+
+  return {
+    passed,
+    timestamp: new Date().toISOString(),
+    vus,
+    duration,
+    metrics: {
+      http_req_duration_p95: k6Data.metrics?.http_req_duration?.values?.['p(95)'],
+      http_req_duration_p99: k6Data.metrics?.http_req_duration?.values?.['p(99)'],
+      http_req_failed_rate: k6Data.metrics?.http_req_failed?.values?.rate,
+      ci_errors_rate: k6Data.metrics?.ci_errors?.values?.rate,
+      ci_total_requests: k6Data.metrics?.ci_total_requests?.values?.count,
+    },
+    thresholds: Object.fromEntries(
+      Object.entries(k6Data.metrics ?? {})
+        .filter(([, m]) => m.thresholds)
+        .map(([name, m]) => [name, m.thresholds])
+    ),
+  };
+}
+
+/**
+ * Build the Markdown comment body for a PR.
+ *
+ * @param {object} summary  Output of buildSummary()
+ * @returns {string}
+ */
+export function buildPrComment(summary) {
+  const m = summary.metrics;
+  const status = summary.passed ? '✅ PASSED' : '❌ FAILED';
+  return [
+    `## 🔥 Load Test Results — ${status}`,
+    '',
+    `| Metric | Value |`,
+    `|--------|-------|`,
+    `| p95 latency | ${m.http_req_duration_p95?.toFixed(1) ?? 'n/a'} ms |`,
+    `| p99 latency | ${m.http_req_duration_p99?.toFixed(1) ?? 'n/a'} ms |`,
+    `| HTTP error rate | ${((m.http_req_failed_rate ?? 0) * 100).toFixed(2)} % |`,
+    `| Total requests | ${m.ci_total_requests ?? 0} |`,
+    `| VUs | ${summary.vus} |`,
+    `| Duration | ${summary.duration}s |`,
+    '',
+    `> Thresholds: p95 < 1000 ms · p99 < 2000 ms · error rate < 1 %`,
+  ].join('\n');
+}

--- a/load-tests/package.json
+++ b/load-tests/package.json
@@ -2,6 +2,7 @@
   "name": "nova-launch-load-tests",
   "version": "1.0.0",
   "description": "Load and stress tests for Nova Launch",
+  "type": "module",
   "scripts": {
     "test:normal": "k6 run scenarios/normal-load.js",
     "test:peak": "k6 run scenarios/peak-load.js",
@@ -9,10 +10,14 @@
     "test:spike": "k6 run scenarios/spike-test.js",
     "test:api": "k6 run scenarios/api-load.js",
     "test:search": "k6 run scenarios/search-load.js",
+    "test:ci": "k6 run --env CI_VUS=10 --env CI_DURATION=60 scenarios/ci-load.js",
     "test:all": "npm run test:normal && npm run test:peak && npm run test:stress",
+    "test:unit": "vitest run",
+    "test:unit:coverage": "vitest run --coverage",
     "report": "node scripts/generate-report.js"
   },
   "devDependencies": {
-    "k6": "^0.0.0"
+    "@vitest/coverage-v8": "^1.6.1",
+    "vitest": "^1.6.1"
   }
 }

--- a/load-tests/scenarios/ci-load.js
+++ b/load-tests/scenarios/ci-load.js
@@ -1,0 +1,169 @@
+/**
+ * CI Load Test — load-tests/scenarios/ci-load.js
+ *
+ * Designed to run in CI pipelines where:
+ *   - No real backend is available (uses BASE_URL env var, defaults to mock)
+ *   - Duration must be short (< 3 minutes total)
+ *   - Thresholds must be strict enough to catch regressions
+ *   - Results are written to load-tests/results/ for artifact upload
+ *
+ * Scenario mix (mirrors production traffic distribution):
+ *   50% — token search / list  (read-heavy, cacheable)
+ *   25% — health / version     (lightweight liveness probes)
+ *   15% — leaderboard          (aggregation queries)
+ *   10% — stats                (heavier aggregation)
+ *
+ * Environment variables:
+ *   BASE_URL          API base URL (default: http://localhost:3001)
+ *   CI_VUS            Virtual users during steady state (default: 10)
+ *   CI_DURATION       Steady-state duration in seconds (default: 60)
+ *   FAIL_ON_THRESHOLD Set to "false" to collect data without failing CI
+ */
+
+import http from 'k6/http';
+import { check, sleep, group } from 'k6';
+import { Rate, Trend, Counter } from 'k6/metrics';
+import { config } from '../config/test-config.js';
+
+// ── Custom metrics ────────────────────────────────────────────────────────────
+
+const errorRate = new Rate('ci_errors');
+const p95Duration = new Trend('ci_p95_duration');
+const requestCounter = new Counter('ci_total_requests');
+
+// ── Options ───────────────────────────────────────────────────────────────────
+
+const VUS = parseInt(__ENV.CI_VUS || '10');
+const DURATION = parseInt(__ENV.CI_DURATION || '60');
+
+export const options = {
+  stages: [
+    { duration: '30s', target: VUS },          // ramp-up
+    { duration: `${DURATION}s`, target: VUS }, // steady state
+    { duration: '30s', target: 0 },            // ramp-down
+  ],
+  thresholds: {
+    // Error rate must stay below 1 %
+    http_req_failed: ['rate<0.01'],
+    ci_errors: ['rate<0.01'],
+    // p95 latency under 500 ms for search, 1 s overall
+    http_req_duration: ['p(95)<1000', 'p(99)<2000'],
+    ci_p95_duration: ['p(95)<500'],
+  },
+  tags: { test_type: 'ci_load' },
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const BASE_URL = __ENV.BASE_URL || config.baseUrl;
+
+/** Pick a random element from an array. */
+function pick(arr) {
+  return arr[Math.floor(Math.random() * arr.length)];
+}
+
+/** Record a response: check status, update metrics. */
+function record(res, name, maxMs = 500) {
+  const ok = check(res, {
+    [`${name} status 200`]: (r) => r.status === 200,
+    [`${name} < ${maxMs}ms`]: (r) => r.timings.duration < maxMs,
+  });
+  errorRate.add(!ok);
+  p95Duration.add(res.timings.duration);
+  requestCounter.add(1);
+  return ok;
+}
+
+// ── Default function (VU loop) ────────────────────────────────────────────────
+
+export default function () {
+  const roll = Math.random();
+
+  if (roll < 0.50) {
+    // 50 % — token search
+    group('token_search', () => {
+      const q = pick(config.testData.searchQueries);
+      const res = http.get(`${BASE_URL}/api/tokens/search?q=${q}&page=1&limit=20`, {
+        tags: { name: 'TokenSearch' },
+      });
+      record(res, 'token_search', 500);
+    });
+  } else if (roll < 0.75) {
+    // 25 % — health probe
+    group('health', () => {
+      const res = http.get(`${BASE_URL}/health`, { tags: { name: 'Health' } });
+      record(res, 'health', 200);
+    });
+  } else if (roll < 0.90) {
+    // 15 % — leaderboard
+    group('leaderboard', () => {
+      const res = http.get(`${BASE_URL}/api/leaderboard?limit=10`, {
+        tags: { name: 'Leaderboard' },
+      });
+      record(res, 'leaderboard', 800);
+    });
+  } else {
+    // 10 % — stats
+    group('stats', () => {
+      const res = http.get(`${BASE_URL}/api/stats`, { tags: { name: 'Stats' } });
+      record(res, 'stats', 1000);
+    });
+  }
+
+  sleep(1);
+}
+
+// ── Summary ───────────────────────────────────────────────────────────────────
+
+export function handleSummary(data) {
+  const passed = !Object.values(data.metrics).some(
+    (m) => m.thresholds && Object.values(m.thresholds).some((t) => t.ok === false)
+  );
+
+  const summary = {
+    passed,
+    timestamp: new Date().toISOString(),
+    vus: VUS,
+    duration: DURATION,
+    metrics: {
+      http_req_duration_p95: data.metrics.http_req_duration?.values?.['p(95)'],
+      http_req_duration_p99: data.metrics.http_req_duration?.values?.['p(99)'],
+      http_req_failed_rate: data.metrics.http_req_failed?.values?.rate,
+      ci_errors_rate: data.metrics.ci_errors?.values?.rate,
+      ci_total_requests: data.metrics.ci_total_requests?.values?.count,
+    },
+    thresholds: Object.fromEntries(
+      Object.entries(data.metrics)
+        .filter(([, m]) => m.thresholds)
+        .map(([name, m]) => [name, m.thresholds])
+    ),
+  };
+
+  return {
+    'load-tests/results/ci-load-summary.json': JSON.stringify(summary, null, 2),
+    stdout: formatSummary(summary),
+  };
+}
+
+function formatSummary(s) {
+  const status = s.passed ? '✅ PASSED' : '❌ FAILED';
+  const m = s.metrics;
+  return [
+    '',
+    `=== CI Load Test Summary — ${status} ===`,
+    `  Timestamp : ${s.timestamp}`,
+    `  VUs       : ${s.vus}`,
+    `  Duration  : ${s.duration}s steady state`,
+    '',
+    '  Latency:',
+    `    p95 : ${m.http_req_duration_p95?.toFixed(1) ?? 'n/a'} ms`,
+    `    p99 : ${m.http_req_duration_p99?.toFixed(1) ?? 'n/a'} ms`,
+    '',
+    '  Reliability:',
+    `    HTTP error rate : ${((m.http_req_failed_rate ?? 0) * 100).toFixed(2)} %`,
+    `    CI error rate   : ${((m.ci_errors_rate ?? 0) * 100).toFixed(2)} %`,
+    '',
+    `  Total requests : ${m.ci_total_requests ?? 0}`,
+    '',
+  ].join('\n');
+}

--- a/load-tests/scripts/ci-load-helpers.test.js
+++ b/load-tests/scripts/ci-load-helpers.test.js
@@ -1,0 +1,238 @@
+import { describe, it, expect } from 'vitest';
+import {
+  pick,
+  selectScenario,
+  formatSummary,
+  buildSummary,
+  buildPrComment,
+} from '../lib/ci-load-helpers.js';
+
+// ── pick ──────────────────────────────────────────────────────────────────────
+
+describe('pick', () => {
+  it('returns an element from the array', () => {
+    const arr = ['a', 'b', 'c'];
+    expect(arr).toContain(pick(arr));
+  });
+
+  it('returns undefined for an empty array', () => {
+    expect(pick([])).toBeUndefined();
+  });
+
+  it('returns undefined for null/undefined input', () => {
+    expect(pick(null)).toBeUndefined();
+    expect(pick(undefined)).toBeUndefined();
+  });
+
+  it('returns the only element for a single-element array', () => {
+    expect(pick(['only'])).toBe('only');
+  });
+
+  it('distributes picks across all elements over many calls', () => {
+    const arr = ['a', 'b', 'c', 'd'];
+    const seen = new Set();
+    for (let i = 0; i < 200; i++) seen.add(pick(arr));
+    expect(seen.size).toBe(arr.length);
+  });
+});
+
+// ── selectScenario ────────────────────────────────────────────────────────────
+
+describe('selectScenario', () => {
+  it('returns token_search for roll < 0.50', () => {
+    expect(selectScenario(0)).toBe('token_search');
+    expect(selectScenario(0.25)).toBe('token_search');
+    expect(selectScenario(0.499)).toBe('token_search');
+  });
+
+  it('returns health for roll in [0.50, 0.75)', () => {
+    expect(selectScenario(0.50)).toBe('health');
+    expect(selectScenario(0.62)).toBe('health');
+    expect(selectScenario(0.749)).toBe('health');
+  });
+
+  it('returns leaderboard for roll in [0.75, 0.90)', () => {
+    expect(selectScenario(0.75)).toBe('leaderboard');
+    expect(selectScenario(0.82)).toBe('leaderboard');
+    expect(selectScenario(0.899)).toBe('leaderboard');
+  });
+
+  it('returns stats for roll in [0.90, 1.00)', () => {
+    expect(selectScenario(0.90)).toBe('stats');
+    expect(selectScenario(0.95)).toBe('stats');
+    expect(selectScenario(0.999)).toBe('stats');
+  });
+
+  it('covers the correct distribution over 10000 samples', () => {
+    const counts = { token_search: 0, health: 0, leaderboard: 0, stats: 0 };
+    const N = 10_000;
+    for (let i = 0; i < N; i++) counts[selectScenario(Math.random())]++;
+    // token_search ≈ 50 % ± 2 %
+    expect(counts.token_search / N).toBeGreaterThan(0.48);
+    expect(counts.token_search / N).toBeLessThan(0.52);
+    // health ≈ 25 % ± 2 %
+    expect(counts.health / N).toBeGreaterThan(0.23);
+    expect(counts.health / N).toBeLessThan(0.27);
+    // leaderboard ≈ 15 % ± 2 %
+    expect(counts.leaderboard / N).toBeGreaterThan(0.13);
+    expect(counts.leaderboard / N).toBeLessThan(0.17);
+    // stats ≈ 10 % ± 2 %
+    expect(counts.stats / N).toBeGreaterThan(0.08);
+    expect(counts.stats / N).toBeLessThan(0.12);
+  });
+});
+
+// ── buildSummary ──────────────────────────────────────────────────────────────
+
+describe('buildSummary', () => {
+  const passingData = {
+    metrics: {
+      http_req_duration: {
+        values: { 'p(95)': 120, 'p(99)': 250 },
+        thresholds: { 'p(95)<1000': { ok: true }, 'p(99)<2000': { ok: true } },
+      },
+      http_req_failed: {
+        values: { rate: 0.002 },
+        thresholds: { 'rate<0.01': { ok: true } },
+      },
+      ci_errors: { values: { rate: 0.001 }, thresholds: { 'rate<0.01': { ok: true } } },
+      ci_total_requests: { values: { count: 600 } },
+    },
+  };
+
+  it('sets passed=true when all thresholds pass', () => {
+    expect(buildSummary(passingData, 10, 60).passed).toBe(true);
+  });
+
+  it('sets passed=false when any threshold fails', () => {
+    const failing = JSON.parse(JSON.stringify(passingData));
+    failing.metrics.http_req_duration.thresholds['p(95)<1000'].ok = false;
+    expect(buildSummary(failing, 10, 60).passed).toBe(false);
+  });
+
+  it('includes vus and duration', () => {
+    const s = buildSummary(passingData, 20, 120);
+    expect(s.vus).toBe(20);
+    expect(s.duration).toBe(120);
+  });
+
+  it('extracts p95 and p99 latency', () => {
+    const s = buildSummary(passingData, 10, 60);
+    expect(s.metrics.http_req_duration_p95).toBe(120);
+    expect(s.metrics.http_req_duration_p99).toBe(250);
+  });
+
+  it('extracts error rates', () => {
+    const s = buildSummary(passingData, 10, 60);
+    expect(s.metrics.http_req_failed_rate).toBe(0.002);
+    expect(s.metrics.ci_errors_rate).toBe(0.001);
+  });
+
+  it('extracts total request count', () => {
+    const s = buildSummary(passingData, 10, 60);
+    expect(s.metrics.ci_total_requests).toBe(600);
+  });
+
+  it('handles empty metrics gracefully', () => {
+    const s = buildSummary({ metrics: {} }, 5, 30);
+    expect(s.passed).toBe(true);
+    expect(s.metrics.http_req_duration_p95).toBeUndefined();
+  });
+
+  it('includes a timestamp string', () => {
+    const s = buildSummary(passingData, 10, 60);
+    expect(s.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+});
+
+// ── formatSummary ─────────────────────────────────────────────────────────────
+
+describe('formatSummary', () => {
+  const summary = {
+    passed: true,
+    timestamp: '2026-01-01T00:00:00.000Z',
+    vus: 10,
+    duration: 60,
+    metrics: {
+      http_req_duration_p95: 120.5,
+      http_req_duration_p99: 250.3,
+      http_req_failed_rate: 0.002,
+      ci_errors_rate: 0.001,
+      ci_total_requests: 600,
+    },
+  };
+
+  it('contains PASSED for a passing summary', () => {
+    expect(formatSummary(summary)).toContain('✅ PASSED');
+  });
+
+  it('contains FAILED for a failing summary', () => {
+    expect(formatSummary({ ...summary, passed: false })).toContain('❌ FAILED');
+  });
+
+  it('includes p95 latency', () => {
+    expect(formatSummary(summary)).toContain('120.5');
+  });
+
+  it('includes p99 latency', () => {
+    expect(formatSummary(summary)).toContain('250.3');
+  });
+
+  it('includes error rate as percentage', () => {
+    expect(formatSummary(summary)).toContain('0.20');
+  });
+
+  it('includes total request count', () => {
+    expect(formatSummary(summary)).toContain('600');
+  });
+
+  it('shows n/a when metrics are undefined', () => {
+    const s = { ...summary, metrics: {} };
+    expect(formatSummary(s)).toContain('n/a');
+  });
+});
+
+// ── buildPrComment ────────────────────────────────────────────────────────────
+
+describe('buildPrComment', () => {
+  const summary = {
+    passed: true,
+    vus: 10,
+    duration: 60,
+    metrics: {
+      http_req_duration_p95: 120.5,
+      http_req_duration_p99: 250.3,
+      http_req_failed_rate: 0.002,
+      ci_total_requests: 600,
+    },
+  };
+
+  it('contains PASSED status', () => {
+    expect(buildPrComment(summary)).toContain('✅ PASSED');
+  });
+
+  it('contains FAILED status for failing summary', () => {
+    expect(buildPrComment({ ...summary, passed: false })).toContain('❌ FAILED');
+  });
+
+  it('includes p95 latency in table', () => {
+    expect(buildPrComment(summary)).toContain('120.5');
+  });
+
+  it('includes total requests in table', () => {
+    expect(buildPrComment(summary)).toContain('600');
+  });
+
+  it('includes threshold description', () => {
+    expect(buildPrComment(summary)).toContain('p95 < 1000 ms');
+  });
+
+  it('shows n/a when metrics are undefined', () => {
+    const s = { ...summary, metrics: {} };
+    expect(buildPrComment(s)).toContain('n/a');
+  });
+
+  it('is valid Markdown (contains table header)', () => {
+    expect(buildPrComment(summary)).toContain('| Metric | Value |');
+  });
+});

--- a/load-tests/vitest.config.js
+++ b/load-tests/vitest.config.js
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['scripts/**/*.test.js'],
+    coverage: {
+      provider: 'v8',
+      include: ['lib/**/*.js'],
+      thresholds: { lines: 90, functions: 90, branches: 90, statements: 90 },
+    },
+  },
+});

--- a/scripts/deploy-multi-region.sh
+++ b/scripts/deploy-multi-region.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# deploy-multi-region.sh — Deploy the token-factory contract to all configured regions.
+#
+# Usage:
+#   ./scripts/deploy-multi-region.sh [--network testnet|mainnet] [--sequential] [--regions id,id]
+#
+# Prerequisites:
+#   - soroban CLI installed and configured
+#   - Admin/treasury identities created (run setup-soroban.sh first)
+#   - Contract WASM built (cargo build --target wasm32-unknown-unknown --release)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+echo "🌍 Nova Launch — Multi-Region Deployment"
+echo "========================================="
+
+# Forward all arguments to the TypeScript CLI
+cd "${REPO_ROOT}/scripts/deployment"
+exec npx tsx deployMultiRegion.ts "$@"

--- a/scripts/deployment/__tests__/multiRegion.test.ts
+++ b/scripts/deployment/__tests__/multiRegion.test.ts
@@ -1,0 +1,283 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { readFileSync, writeFileSync, existsSync } from 'fs';
+import {
+  readRegistry,
+  writeRegistryEntry,
+  checkWasmHashConsistency,
+  deployMultiRegion,
+} from '../multiRegionOrchestrator.js';
+import type { RegionConfig, RegionDeploymentResult } from '../multiRegionTypes.js';
+import { TESTNET_REGIONS, MAINNET_REGIONS } from '../multiRegionTypes.js';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+vi.mock('fs');
+vi.mock('child_process');
+vi.mock('crypto', () => ({
+  createHash: vi.fn(() => ({
+    update: vi.fn().mockReturnThis(),
+    digest: vi.fn(() => 'mock-wasm-hash'),
+  })),
+}));
+
+// Mock DeploymentOrchestrator so we don't need soroban CLI
+const mockDeploy = vi.fn().mockResolvedValue({
+  contractId: 'CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+  admin: 'GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+  treasury: 'GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+  network: 'testnet',
+  deployedAt: '2026-01-01T00:00:00.000Z',
+  transactionHash: 'tx_mock',
+  wasmHash: 'mock-wasm-hash',
+});
+
+vi.mock('../orchestrator.js', () => ({
+  DeploymentOrchestrator: class {
+    deploy = mockDeploy;
+  },
+}));
+
+const mockReadFileSync = vi.mocked(readFileSync);
+const mockWriteFileSync = vi.mocked(writeFileSync);
+const mockExistsSync = vi.mocked(existsSync);
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const REGION: RegionConfig = TESTNET_REGIONS[0];
+
+function makeResult(overrides: Partial<RegionDeploymentResult> = {}): RegionDeploymentResult {
+  return {
+    regionId: 'testnet-primary',
+    success: true,
+    result: {
+      contractId: 'CXXX',
+      admin: 'GXXX',
+      treasury: 'GXXX',
+      network: 'testnet',
+      deployedAt: '2026-01-01T00:00:00.000Z',
+      transactionHash: 'tx_1',
+      wasmHash: 'hash-a',
+    },
+    ...overrides,
+  };
+}
+
+// ── readRegistry ──────────────────────────────────────────────────────────────
+
+describe('readRegistry', () => {
+  it('returns empty object when registry file does not exist', () => {
+    mockExistsSync.mockReturnValue(false);
+    expect(readRegistry()).toEqual({});
+  });
+
+  it('returns parsed registry when file exists', () => {
+    mockExistsSync.mockReturnValue(true);
+    const data = { 'testnet-primary': { regionId: 'testnet-primary', contractId: 'CXXX' } };
+    mockReadFileSync.mockReturnValue(JSON.stringify(data) as any);
+    expect(readRegistry()).toEqual(data);
+  });
+
+  it('returns empty object when file contains invalid JSON', () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue('not-json' as any);
+    expect(readRegistry()).toEqual({});
+  });
+});
+
+// ── writeRegistryEntry ────────────────────────────────────────────────────────
+
+describe('writeRegistryEntry', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExistsSync.mockReturnValue(false);
+    mockWriteFileSync.mockImplementation(() => undefined);
+  });
+
+  it('writes a new entry to an empty registry', () => {
+    const entry = {
+      deployedAt: '2026-01-01T00:00:00.000Z',
+      regionId: 'testnet-primary',
+      network: 'testnet' as const,
+      contractId: 'CXXX',
+      horizonUrl: 'https://horizon-testnet.stellar.org',
+      sorobanRpcUrl: 'https://soroban-testnet.stellar.org',
+      wasmHash: 'hash-a',
+    };
+    writeRegistryEntry(entry);
+    expect(mockWriteFileSync).toHaveBeenCalledOnce();
+    const written = JSON.parse(mockWriteFileSync.mock.calls[0][1] as string);
+    expect(written['testnet-primary']).toMatchObject({ contractId: 'CXXX' });
+  });
+
+  it('merges with existing entries without overwriting others', () => {
+    const existing = { 'other-region': { contractId: 'CYYY' } };
+    mockExistsSync.mockReturnValue(true);
+    // Return existing registry JSON (not the WASM buffer)
+    mockReadFileSync.mockReturnValueOnce(JSON.stringify(existing) as any);
+
+    writeRegistryEntry({
+      deployedAt: '2026-01-01T00:00:00.000Z',
+      regionId: 'testnet-primary',
+      network: 'testnet',
+      contractId: 'CXXX',
+      horizonUrl: 'h',
+      sorobanRpcUrl: 'r',
+      wasmHash: 'w',
+    });
+
+    const written = JSON.parse(mockWriteFileSync.mock.calls[0][1] as string);
+    expect(written['other-region']).toMatchObject({ contractId: 'CYYY' });
+    expect(written['testnet-primary']).toMatchObject({ contractId: 'CXXX' });
+  });
+});
+
+// ── checkWasmHashConsistency ──────────────────────────────────────────────────
+
+describe('checkWasmHashConsistency', () => {
+  it('returns true when all regions have the same hash', () => {
+    const results = [makeResult(), makeResult({ regionId: 'r2' })];
+    expect(checkWasmHashConsistency(results)).toBe(true);
+  });
+
+  it('returns false and warns when hashes differ', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const results = [
+      makeResult({ result: { ...makeResult().result!, wasmHash: 'hash-a' } }),
+      makeResult({ regionId: 'r2', result: { ...makeResult().result!, wasmHash: 'hash-b' } }),
+    ];
+    expect(checkWasmHashConsistency(results)).toBe(false);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('inconsistency'));
+    warn.mockRestore();
+  });
+
+  it('returns true when there are no successful results', () => {
+    expect(checkWasmHashConsistency([makeResult({ success: false, result: undefined })])).toBe(true);
+  });
+
+  it('returns true for a single successful region', () => {
+    expect(checkWasmHashConsistency([makeResult()])).toBe(true);
+  });
+});
+
+// ── deployMultiRegion ─────────────────────────────────────────────────────────
+
+describe('deployMultiRegion', () => {
+  beforeEach(() => {
+    mockExistsSync.mockReturnValue(false);
+    mockWriteFileSync.mockImplementation(() => undefined);
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    // Reset to default success behaviour before each test
+    mockDeploy.mockResolvedValue({
+      contractId: 'CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+      admin: 'GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+      treasury: 'GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+      network: 'testnet',
+      deployedAt: '2026-01-01T00:00:00.000Z',
+      transactionHash: 'tx_mock',
+      wasmHash: 'mock-wasm-hash',
+    });
+  });
+
+  it('throws when no regions are provided', async () => {
+    await expect(deployMultiRegion([])).rejects.toThrow('No regions provided');
+  });
+
+  it('returns allSucceeded=true when all regions succeed', async () => {
+    const result = await deployMultiRegion([REGION]);
+    expect(result.allSucceeded).toBe(true);
+    expect(result.successCount).toBe(1);
+    expect(result.failureCount).toBe(0);
+  });
+
+  it('includes startedAt and completedAt timestamps', async () => {
+    const result = await deployMultiRegion([REGION]);
+    expect(result.startedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(result.completedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('returns one result per region', async () => {
+    const result = await deployMultiRegion(TESTNET_REGIONS);
+    expect(result.regions).toHaveLength(TESTNET_REGIONS.length);
+  });
+
+  it('captures failure without aborting other regions', async () => {
+    // First call fails, second succeeds
+    mockDeploy
+      .mockRejectedValueOnce(new Error('network error'))
+      .mockResolvedValueOnce({
+        contractId: 'CYYY',
+        admin: 'G',
+        treasury: 'G',
+        network: 'mainnet',
+        deployedAt: '2026-01-01T00:00:00.000Z',
+        transactionHash: 'tx_2',
+        wasmHash: 'mock-wasm-hash',
+      });
+
+    const result = await deployMultiRegion(MAINNET_REGIONS.slice(0, 2), false);
+    expect(result.successCount).toBe(1);
+    expect(result.failureCount).toBe(1);
+    expect(result.allSucceeded).toBe(false);
+    expect(result.regions[0].error).toContain('network error');
+    expect(result.regions[1].success).toBe(true);
+  });
+
+  it('runs in parallel by default (Promise.all path)', async () => {
+    const start = Date.now();
+    await deployMultiRegion(TESTNET_REGIONS);
+    // Parallel should be fast; just verify it completes without error
+    expect(Date.now() - start).toBeLessThan(5000);
+  });
+
+  it('runs sequentially when parallel=false', async () => {
+    const result = await deployMultiRegion([REGION], false);
+    expect(result.allSucceeded).toBe(true);
+  });
+
+  it('writes registry entry for each successful region', async () => {
+    await deployMultiRegion([REGION]);
+    expect(mockWriteFileSync).toHaveBeenCalled();
+    const written = JSON.parse(mockWriteFileSync.mock.calls[0][1] as string);
+    expect(written[REGION.id]).toBeDefined();
+  });
+});
+
+// ── Region presets ────────────────────────────────────────────────────────────
+
+describe('TESTNET_REGIONS', () => {
+  it('contains at least one region', () => {
+    expect(TESTNET_REGIONS.length).toBeGreaterThan(0);
+  });
+
+  it('all regions target testnet network', () => {
+    TESTNET_REGIONS.forEach((r) => expect(r.network).toBe('testnet'));
+  });
+
+  it('all regions have unique IDs', () => {
+    const ids = TESTNET_REGIONS.map((r) => r.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe('MAINNET_REGIONS', () => {
+  it('contains at least one region', () => {
+    expect(MAINNET_REGIONS.length).toBeGreaterThan(0);
+  });
+
+  it('all regions target mainnet network', () => {
+    MAINNET_REGIONS.forEach((r) => expect(r.network).toBe('mainnet'));
+  });
+
+  it('all regions have unique IDs', () => {
+    const ids = MAINNET_REGIONS.map((r) => r.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('all regions have valid horizon URLs', () => {
+    MAINNET_REGIONS.forEach((r) => expect(r.horizonUrl).toMatch(/^https?:\/\//));
+  });
+
+  it('all regions have valid soroban RPC URLs', () => {
+    MAINNET_REGIONS.forEach((r) => expect(r.sorobanRpcUrl).toMatch(/^https?:\/\//));
+  });
+});

--- a/scripts/deployment/deployMultiRegion.ts
+++ b/scripts/deployment/deployMultiRegion.ts
@@ -1,0 +1,109 @@
+#!/usr/bin/env tsx
+/**
+ * Multi-region deployment CLI entry point.
+ *
+ * Usage:
+ *   ./scripts/deploy-multi-region.sh
+ *   tsx scripts/deployment/deployMultiRegion.ts [options]
+ *
+ * Options:
+ *   --network <testnet|mainnet>  Target network (default: testnet)
+ *   --sequential                 Deploy regions one-by-one instead of in parallel
+ *   --regions <id,id,...>        Comma-separated region IDs to deploy (default: all)
+ *   --help, -h                   Show this help
+ */
+
+import { config } from 'dotenv';
+import { deployMultiRegion } from './multiRegionOrchestrator.js';
+import { TESTNET_REGIONS, MAINNET_REGIONS } from './multiRegionTypes.js';
+import type { RegionConfig, StellarNetwork } from './multiRegionTypes.js';
+
+config();
+
+function printUsage(): void {
+  console.log(`
+Nova Launch Multi-Region Deployment
+
+Usage: tsx deployMultiRegion.ts [options]
+
+Options:
+  --network <testnet|mainnet>  Target network (default: testnet)
+  --sequential                 Deploy regions sequentially (default: parallel)
+  --regions <id,id,...>        Comma-separated region IDs to include
+  --help, -h                   Show this help
+
+Examples:
+  tsx deployMultiRegion.ts
+  tsx deployMultiRegion.ts --network mainnet
+  tsx deployMultiRegion.ts --network mainnet --regions mainnet-us-east,mainnet-eu-west
+  tsx deployMultiRegion.ts --sequential
+`);
+}
+
+function parseArgs(): { network: StellarNetwork; parallel: boolean; regionIds?: string[] } {
+  const args = process.argv.slice(2);
+  let network: StellarNetwork = 'testnet';
+  let parallel = true;
+  let regionIds: string[] | undefined;
+
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case '--network':
+        network = args[++i] as StellarNetwork;
+        break;
+      case '--sequential':
+        parallel = false;
+        break;
+      case '--regions':
+        regionIds = args[++i].split(',').map((s) => s.trim());
+        break;
+      case '--help':
+      case '-h':
+        printUsage();
+        process.exit(0);
+    }
+  }
+
+  return { network, parallel, regionIds };
+}
+
+async function main(): Promise<void> {
+  const { network, parallel, regionIds } = parseArgs();
+
+  const allRegions: RegionConfig[] = network === 'mainnet' ? MAINNET_REGIONS : TESTNET_REGIONS;
+  const regions = regionIds
+    ? allRegions.filter((r) => regionIds.includes(r.id))
+    : allRegions;
+
+  if (regions.length === 0) {
+    console.error(`❌ No matching regions found for network="${network}"`);
+    process.exit(1);
+  }
+
+  const result = await deployMultiRegion(regions, parallel);
+
+  console.log('\n📋 Multi-Region Deployment Summary:');
+  console.log(`   Started:   ${result.startedAt}`);
+  console.log(`   Completed: ${result.completedAt}`);
+  console.log(`   Succeeded: ${result.successCount}/${regions.length}`);
+  console.log('');
+
+  for (const r of result.regions) {
+    if (r.success) {
+      console.log(`   ✅ ${r.regionId}: ${r.result!.contractId}`);
+    } else {
+      console.log(`   ❌ ${r.regionId}: ${r.error}`);
+    }
+  }
+
+  if (!result.allSucceeded) {
+    console.error('\n❌ One or more regions failed. Check errors above.');
+    process.exit(1);
+  }
+
+  console.log('\n🎉 All regions deployed successfully!');
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/scripts/deployment/multiRegionOrchestrator.ts
+++ b/scripts/deployment/multiRegionOrchestrator.ts
@@ -1,0 +1,167 @@
+/**
+ * Multi-Region Deployment Orchestrator.
+ *
+ * Deploys the same contract WASM to multiple Stellar endpoint regions in
+ * parallel (or sequentially when `parallel=false`).  After each successful
+ * region deployment the result is written to `multi-region-deployments.json`
+ * so the registry is always up-to-date even if later regions fail.
+ *
+ * Design decisions:
+ *   - Reuses `DeploymentOrchestrator` per region — no duplicated deploy logic.
+ *   - Fail-partial: a failure in one region does not abort the others.
+ *   - Registry file is written atomically per region (append-on-success).
+ *   - WASM hash consistency check: all successful regions must report the
+ *     same WASM hash, otherwise a warning is emitted (hash mismatch would
+ *     indicate a race condition or tampered build artifact).
+ */
+
+import { readFileSync, writeFileSync, existsSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { DeploymentOrchestrator } from './orchestrator.js';
+import type { DeploymentConfig } from './types.js';
+import type {
+  RegionConfig,
+  RegionDeploymentResult,
+  MultiRegionDeploymentResult,
+  MultiRegionRegistry,
+  RegionRegistry,
+} from './multiRegionTypes.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/** Path to the shared registry file. */
+const REGISTRY_PATH = join(__dirname, '../../multi-region-deployments.json');
+
+/**
+ * Converts a `RegionConfig` to the `DeploymentConfig` shape expected by
+ * `DeploymentOrchestrator`.
+ */
+function toDeploymentConfig(region: RegionConfig): DeploymentConfig {
+  return {
+    network: region.network,
+    horizonUrl: region.horizonUrl,
+    sorobanRpcUrl: region.sorobanRpcUrl,
+    adminKeyName: region.adminKeyName,
+    treasuryKeyName: region.treasuryKeyName,
+    baseFee: region.baseFee,
+    metadataFee: region.metadataFee,
+    wasmPath: region.wasmPath,
+    envFile: region.envFile,
+  };
+}
+
+/**
+ * Reads the current registry from disk, or returns an empty object.
+ */
+export function readRegistry(): MultiRegionRegistry {
+  if (!existsSync(REGISTRY_PATH)) return {};
+  try {
+    return JSON.parse(readFileSync(REGISTRY_PATH, 'utf8')) as MultiRegionRegistry;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Persists a single region entry to the registry file.
+ * Merges with existing entries so other regions are not overwritten.
+ */
+export function writeRegistryEntry(entry: RegionRegistry): void {
+  const registry = readRegistry();
+  registry[entry.regionId] = entry;
+  writeFileSync(REGISTRY_PATH, JSON.stringify(registry, null, 2));
+}
+
+/**
+ * Deploys to a single region and returns the outcome.
+ * Never throws — errors are captured in `RegionDeploymentResult.error`.
+ */
+async function deployRegion(region: RegionConfig): Promise<RegionDeploymentResult> {
+  const orchestrator = new DeploymentOrchestrator(toDeploymentConfig(region));
+  try {
+    const result = await orchestrator.deploy();
+
+    // Persist to registry immediately so partial progress is not lost
+    writeRegistryEntry({
+      deployedAt: result.deployedAt,
+      regionId: region.id,
+      network: region.network,
+      contractId: result.contractId,
+      horizonUrl: region.horizonUrl,
+      sorobanRpcUrl: region.sorobanRpcUrl,
+      wasmHash: result.wasmHash,
+    });
+
+    return { regionId: region.id, result, success: true };
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return { regionId: region.id, error, success: false };
+  }
+}
+
+/**
+ * Checks that all successful regions report the same WASM hash.
+ * Emits a console warning (not an error) when a mismatch is detected —
+ * the caller decides whether to treat this as fatal.
+ */
+export function checkWasmHashConsistency(results: RegionDeploymentResult[]): boolean {
+  const hashes = results
+    .filter((r) => r.success && r.result?.wasmHash)
+    .map((r) => r.result!.wasmHash);
+
+  if (hashes.length === 0) return true;
+  const unique = new Set(hashes);
+  if (unique.size > 1) {
+    console.warn(
+      `⚠️  WASM hash inconsistency detected across regions: ${[...unique].join(', ')}`
+    );
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Deploys to all provided regions.
+ *
+ * @param regions  List of region configs to deploy to.
+ * @param parallel When true (default) all regions are deployed concurrently.
+ *                 Set to false for sequential deployment (useful for debugging).
+ */
+export async function deployMultiRegion(
+  regions: RegionConfig[],
+  parallel = true
+): Promise<MultiRegionDeploymentResult> {
+  if (regions.length === 0) throw new Error('No regions provided for deployment.');
+
+  const startedAt = new Date().toISOString();
+  console.log(`🌍 Starting multi-region deployment to ${regions.length} region(s)...`);
+  regions.forEach((r) => console.log(`   • ${r.id} (${r.label})`));
+
+  let regionResults: RegionDeploymentResult[];
+
+  if (parallel) {
+    regionResults = await Promise.all(regions.map(deployRegion));
+  } else {
+    regionResults = [];
+    for (const region of regions) {
+      regionResults.push(await deployRegion(region));
+    }
+  }
+
+  const successCount = regionResults.filter((r) => r.success).length;
+  const failureCount = regionResults.length - successCount;
+
+  checkWasmHashConsistency(regionResults);
+
+  const completedAt = new Date().toISOString();
+
+  return {
+    startedAt,
+    completedAt,
+    regions: regionResults,
+    successCount,
+    failureCount,
+    allSucceeded: failureCount === 0,
+  };
+}

--- a/scripts/deployment/multiRegionTypes.ts
+++ b/scripts/deployment/multiRegionTypes.ts
@@ -1,0 +1,155 @@
+/**
+ * Multi-region deployment types.
+ *
+ * A "region" in the Stellar context maps to a network endpoint cluster
+ * (e.g. a specific Horizon + Soroban RPC pair).  Geo-replication means
+ * deploying the same contract WASM to multiple regions and keeping a
+ * registry of all contract IDs so the frontend / gateway can route to
+ * the nearest healthy endpoint.
+ */
+
+import type { DeploymentResult } from './types.js';
+
+/** Supported Stellar network environments. */
+export type StellarNetwork = 'testnet' | 'mainnet';
+
+/**
+ * Configuration for a single deployment region.
+ *
+ * Each region targets a specific Horizon + Soroban RPC pair.
+ * Multiple regions on the same logical network (e.g. mainnet) allow
+ * geo-distributed read traffic while sharing the same ledger state.
+ */
+export interface RegionConfig {
+  /** Unique region identifier, e.g. "us-east", "eu-west", "ap-south". */
+  id: string;
+  /** Human-readable label. */
+  label: string;
+  /** Stellar network this region belongs to. */
+  network: StellarNetwork;
+  /** Horizon REST API URL for this region. */
+  horizonUrl: string;
+  /** Soroban RPC URL for this region. */
+  sorobanRpcUrl: string;
+  /** Admin key name in the local Soroban keystore. */
+  adminKeyName: string;
+  /** Treasury key name in the local Soroban keystore. */
+  treasuryKeyName: string;
+  /** Base fee in stroops. */
+  baseFee: number;
+  /** Metadata fee in stroops. */
+  metadataFee: number;
+  /** Path to the compiled WASM file. */
+  wasmPath: string;
+  /** Path to the env file to update after deployment. */
+  envFile: string;
+}
+
+/** Result of deploying to a single region. */
+export interface RegionDeploymentResult {
+  regionId: string;
+  /** Undefined when the region deployment failed. */
+  result?: DeploymentResult;
+  /** Error message when deployment failed. */
+  error?: string;
+  /** Whether this region's deployment succeeded. */
+  success: boolean;
+}
+
+/** Aggregated result of a multi-region deployment run. */
+export interface MultiRegionDeploymentResult {
+  /** ISO timestamp when the run started. */
+  startedAt: string;
+  /** ISO timestamp when the run finished. */
+  completedAt: string;
+  /** Per-region outcomes. */
+  regions: RegionDeploymentResult[];
+  /** Number of regions that succeeded. */
+  successCount: number;
+  /** Number of regions that failed. */
+  failureCount: number;
+  /** True only when every region succeeded. */
+  allSucceeded: boolean;
+}
+
+/**
+ * Registry entry written to `multi-region-deployments.json`.
+ * Consumers (frontend, gateway) read this file to discover the
+ * contract ID and RPC URL for each region.
+ */
+export interface RegionRegistry {
+  /** ISO timestamp of the last successful deployment to this region. */
+  deployedAt: string;
+  regionId: string;
+  network: StellarNetwork;
+  contractId: string;
+  horizonUrl: string;
+  sorobanRpcUrl: string;
+  wasmHash: string;
+}
+
+/** Full registry file shape. */
+export type MultiRegionRegistry = Record<string, RegionRegistry>;
+
+// ── Well-known region presets ─────────────────────────────────────────────────
+
+const WASM_PATH =
+  '../../contracts/token-factory/target/wasm32-unknown-unknown/release/token_factory.wasm';
+
+export const TESTNET_REGIONS: RegionConfig[] = [
+  {
+    id: 'testnet-primary',
+    label: 'Testnet Primary (SDF)',
+    network: 'testnet',
+    horizonUrl: 'https://horizon-testnet.stellar.org',
+    sorobanRpcUrl: 'https://soroban-testnet.stellar.org',
+    adminKeyName: 'admin',
+    treasuryKeyName: 'treasury',
+    baseFee: 70_000_000,
+    metadataFee: 30_000_000,
+    wasmPath: WASM_PATH,
+    envFile: '../../.env.testnet',
+  },
+];
+
+export const MAINNET_REGIONS: RegionConfig[] = [
+  {
+    id: 'mainnet-us-east',
+    label: 'Mainnet US-East (SDF)',
+    network: 'mainnet',
+    horizonUrl: 'https://horizon.stellar.org',
+    sorobanRpcUrl: 'https://soroban-mainnet.stellar.org',
+    adminKeyName: 'admin-mainnet',
+    treasuryKeyName: 'treasury-mainnet',
+    baseFee: 70_000_000,
+    metadataFee: 30_000_000,
+    wasmPath: WASM_PATH,
+    envFile: '../../.env.mainnet',
+  },
+  {
+    id: 'mainnet-eu-west',
+    label: 'Mainnet EU-West (Lobstr)',
+    network: 'mainnet',
+    horizonUrl: 'https://horizon.stellar.lobstr.co',
+    sorobanRpcUrl: 'https://rpc.stellar.lobstr.co',
+    adminKeyName: 'admin-mainnet',
+    treasuryKeyName: 'treasury-mainnet',
+    baseFee: 70_000_000,
+    metadataFee: 30_000_000,
+    wasmPath: WASM_PATH,
+    envFile: '../../.env.mainnet.eu',
+  },
+  {
+    id: 'mainnet-ap-south',
+    label: 'Mainnet AP-South (SatoshiPay)',
+    network: 'mainnet',
+    horizonUrl: 'https://stellar-horizon.satoshipay.io',
+    sorobanRpcUrl: 'https://soroban-mainnet.stellar.org', // fallback to SDF RPC
+    adminKeyName: 'admin-mainnet',
+    treasuryKeyName: 'treasury-mainnet',
+    baseFee: 70_000_000,
+    metadataFee: 30_000_000,
+    wasmPath: WASM_PATH,
+    envFile: '../../.env.mainnet.ap',
+  },
+];

--- a/scripts/deployment/package.json
+++ b/scripts/deployment/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "scripts": {
     "deploy": "tsx deploy.ts",
+    "deploy:multi-region": "tsx deployMultiRegion.ts",
     "verify": "tsx verify.ts",
     "test": "vitest",
     "test:coverage": "vitest --coverage"


### PR DESCRIPTION
## Summary

Adds a complete Istio service mesh configuration for the Nova Launch microservices (`kubectl apply -f istio/`).

### Files

| File | Purpose |
|------|---------|
| `namespace.yaml` | `nova-launch` namespace with `istio-injection: enabled` |
| `deployments.yaml` | backend, frontend, gateway workloads |
| `services.yaml` | ClusterIP services with named ports |
| `gateway.yaml` | Istio IngressGateway (HTTP + HTTPS) |
| `virtual-services.yaml` | L7 routing rules |
| `destination-rules.yaml` | mTLS, circuit breaker, connection pools |
| `peer-authentication.yaml` | Mesh-wide STRICT mTLS |

### Architecture

```
Internet → IngressGateway
              /api/*   → gateway:4000  (rate-limited, JWT auth)
              /health* → backend:3001  (k8s probes, no auth)
              /*       → frontend:80   (SPA)

gateway → backend  (mTLS, retries, circuit breaker)
backend → redis    (plain TCP, TLS disabled)
```

### Security
- **STRICT mTLS** enforced namespace-wide via `PeerAuthentication`
- **ISTIO_MUTUAL** TLS on all HTTP DestinationRules
- Redis exempted (PERMISSIVE) — does not support TLS natively
- No secrets hardcoded in manifests — all via `secretKeyRef`
- Non-root containers for backend and gateway
- HTTPS on port 443 with `SIMPLE` TLS (cert via `nova-launch-tls` secret)

### Resilience
- Retries (3 attempts, 10s per-try) on `/api/*` routes
- Circuit breaker: eject hosts after 5 consecutive 5xx errors
- Connection pool limits on backend and gateway

### Testing
- 56 manifest validation tests (no cluster required)
- `cd istio && npm install && npm test`

### Apply
```bash
# Prerequisites: Istio installed, secrets created (see istio/README.md)
kubectl apply -f istio/
```

Closes #902