### PR TITLE
feat(backend): add request timeout configuration with graceful degradation

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -22,6 +22,7 @@ import openApiRouter from "./lib/openapi/router";
 import { Database } from "./config/database";
 import { successResponse, errorResponse } from "./utils/response";
 import { requestLoggingMiddleware } from "./middleware/request-logging.middleware";
+import { createTimeoutMiddleware } from "./middleware/timeout";
 import { createMetricsMiddleware, metricsRegistry } from "./lib/metrics";
 import stellarEventListener from "./services/stellarEventListener";
 import websocketService from "./services/websocket";
@@ -37,6 +38,9 @@ const PORT = env.PORT;
 
 // Request logging middleware (first to capture all requests)
 app.use(requestLoggingMiddleware);
+
+// Request timeout — responds 503 if a handler takes too long
+app.use(createTimeoutMiddleware());
 
 // Prometheus metrics middleware — records HTTP request duration and counts
 app.use(createMetricsMiddleware());

--- a/backend/src/middleware/timeout.test.ts
+++ b/backend/src/middleware/timeout.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import request from "supertest";
+import express, { Request, Response } from "express";
+import {
+  createTimeoutMiddleware,
+  DEFAULT_TIMEOUT_MS,
+  getTimeoutMs,
+} from "./timeout";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────
+
+function makeApp(timeoutMs: number, handlerDelayMs?: number) {
+  const app = express();
+  app.use(createTimeoutMiddleware(timeoutMs));
+
+  app.get("/fast", (_req: Request, res: Response) => {
+    res.json({ ok: true });
+  });
+
+  app.get("/slow", (_req: Request, res: Response) => {
+    setTimeout(() => {
+      if (!res.headersSent) res.json({ ok: true });
+    }, handlerDelayMs ?? timeoutMs * 2);
+  });
+
+  app.get("/already-sent", (_req: Request, res: Response) => {
+    res.json({ ok: true });
+    // Simulate a second write after headers sent — middleware must not crash
+  });
+
+  return app;
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────
+
+describe("getTimeoutMs()", () => {
+  const originalEnv = process.env.REQUEST_TIMEOUT_MS;
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.REQUEST_TIMEOUT_MS;
+    } else {
+      process.env.REQUEST_TIMEOUT_MS = originalEnv;
+    }
+  });
+
+  it("returns DEFAULT_TIMEOUT_MS when env var is not set", () => {
+    delete process.env.REQUEST_TIMEOUT_MS;
+    expect(getTimeoutMs()).toBe(DEFAULT_TIMEOUT_MS);
+  });
+
+  it("returns parsed value from REQUEST_TIMEOUT_MS env var", () => {
+    process.env.REQUEST_TIMEOUT_MS = "5000";
+    expect(getTimeoutMs()).toBe(5000);
+  });
+
+  it("falls back to default when env var is not a number", () => {
+    process.env.REQUEST_TIMEOUT_MS = "not-a-number";
+    expect(getTimeoutMs()).toBe(DEFAULT_TIMEOUT_MS);
+  });
+
+  it("falls back to default when env var is zero", () => {
+    process.env.REQUEST_TIMEOUT_MS = "0";
+    expect(getTimeoutMs()).toBe(DEFAULT_TIMEOUT_MS);
+  });
+
+  it("falls back to default when env var is negative", () => {
+    process.env.REQUEST_TIMEOUT_MS = "-100";
+    expect(getTimeoutMs()).toBe(DEFAULT_TIMEOUT_MS);
+  });
+});
+
+describe("createTimeoutMiddleware()", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("passes through fast requests without timing out", async () => {
+    const app = makeApp(1000);
+    const res = await request(app).get("/fast");
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it("responds 503 when handler exceeds timeout", async () => {
+    const app = makeApp(50, 200);
+
+    const responsePromise = request(app).get("/slow");
+    // Advance fake timers past the timeout
+    vi.advanceTimersByTime(100);
+    const res = await responsePromise;
+
+    expect(res.status).toBe(503);
+    expect(res.body.success).toBe(false);
+    expect(res.body.error.code).toBe("REQUEST_TIMEOUT");
+    expect(res.body.error.message).toContain("50ms");
+    expect(res.body.timestamp).toBeDefined();
+  });
+
+  it("does not send a second response when headers already sent", async () => {
+    const app = makeApp(1000);
+    // /already-sent sends headers immediately; no timeout should fire
+    const res = await request(app).get("/already-sent");
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it("uses the provided timeoutMs value", async () => {
+    const app = makeApp(100, 300);
+
+    const responsePromise = request(app).get("/slow");
+    vi.advanceTimersByTime(150);
+    const res = await responsePromise;
+
+    expect(res.status).toBe(503);
+    expect(res.body.error.message).toContain("100ms");
+  });
+
+  it("accepts a custom timeout via factory argument", () => {
+    const mw = createTimeoutMiddleware(9999);
+    expect(typeof mw).toBe("function");
+    expect(mw.length).toBe(3); // (req, res, next)
+  });
+
+  it("DEFAULT_TIMEOUT_MS is 30000", () => {
+    expect(DEFAULT_TIMEOUT_MS).toBe(30_000);
+  });
+});

--- a/backend/src/middleware/timeout.ts
+++ b/backend/src/middleware/timeout.ts
@@ -1,0 +1,77 @@
+import { Request, Response, NextFunction } from "express";
+
+/**
+ * Default timeout in milliseconds.
+ * Can be overridden via the REQUEST_TIMEOUT_MS environment variable.
+ */
+export const DEFAULT_TIMEOUT_MS = 30_000;
+
+/**
+ * Reads the configured timeout from the environment, falling back to the default.
+ */
+export function getTimeoutMs(): number {
+  const raw = process.env.REQUEST_TIMEOUT_MS;
+  if (raw) {
+    const parsed = parseInt(raw, 10);
+    if (!isNaN(parsed) && parsed > 0) return parsed;
+  }
+  return DEFAULT_TIMEOUT_MS;
+}
+
+/**
+ * Express middleware that enforces a per-request timeout with graceful degradation.
+ *
+ * Behaviour:
+ * - Sets a timer for `timeoutMs` milliseconds after the request arrives.
+ * - If the response has not been sent before the timer fires, responds with
+ *   HTTP 503 and a JSON error body so clients receive a structured error
+ *   rather than a hanging connection.
+ * - Clears the timer on `res.finish` / `res.close` so there is no leak for
+ *   requests that complete normally.
+ * - Skips already-sent responses to avoid "headers already sent" errors.
+ *
+ * @param timeoutMs - Milliseconds before a request is considered timed out.
+ *                    Defaults to `getTimeoutMs()`.
+ */
+export function createTimeoutMiddleware(timeoutMs: number = getTimeoutMs()) {
+  return function timeoutMiddleware(
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): void {
+    let timedOut = false;
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+
+      // Graceful degradation: if headers haven't been sent yet, return a
+      // structured 503 so the client knows the request timed out.
+      if (!res.headersSent) {
+        res.status(503).json({
+          success: false,
+          error: {
+            code: "REQUEST_TIMEOUT",
+            message: `Request timed out after ${timeoutMs}ms`,
+          },
+          timestamp: new Date().toISOString(),
+        });
+      }
+    }, timeoutMs);
+
+    // Attach the flag so downstream handlers can check it if needed.
+    (req as Request & { timedOut?: boolean }).timedOut = false;
+
+    // Clean up the timer once the response is finished or the connection closes.
+    const cleanup = () => {
+      clearTimeout(timer);
+      if (timedOut) {
+        (req as Request & { timedOut?: boolean }).timedOut = true;
+      }
+    };
+
+    res.on("finish", cleanup);
+    res.on("close", cleanup);
+
+    next();
+  };
+}


### PR DESCRIPTION
## Summary

Closes #851

Adds a configurable per-request timeout middleware with graceful degradation.

## Changes

- `backend/src/middleware/timeout.ts`
  - `createTimeoutMiddleware(timeoutMs?)` — Express middleware factory
  - Fires a 503 JSON response if a handler hasn't responded within the timeout
  - Reads `REQUEST_TIMEOUT_MS` env var; defaults to 30 000 ms
  - Clears the timer on `res.finish` / `res.close` — no timer leaks
  - Skips already-sent responses to avoid double-write errors
- `backend/src/index.ts` — registers the middleware globally after request logging
- `backend/src/middleware/timeout.test.ts` — tests covering fast path, timeout path, env config, edge cases

## Configuration

| Env var | Default | Description |
|---|---|---|
| `REQUEST_TIMEOUT_MS` | `30000` | Per-request timeout in milliseconds |

## Testing

```
npm test backend/src/middleware/timeout.test.ts
```