### PR TITLE
refactor(backend): add exponential backoff to event listener reconnect

### DIFF
--- a/backend/src/__tests__/stellar-event-listener-backoff.test.ts
+++ b/backend/src/__tests__/stellar-event-listener-backoff.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  calculateReconnectDelay,
+  ListenerBackoffState,
+  LISTENER_RECONNECT_CONFIG,
+  type ListenerReconnectConfig,
+} from "../services/listenerBackoff";
+
+const DETERMINISTIC_CONFIG: ListenerReconnectConfig = {
+  initialDelayMs: 1_000,
+  maxDelayMs: 300_000,
+  backoffFactor: 2,
+  jitterFraction: 0,
+  healthResetThreshold: 5,
+};
+
+describe("calculateReconnectDelay", () => {
+  it("starts at initialDelayMs on attempt 1", () => {
+    const delay = calculateReconnectDelay(1, DETERMINISTIC_CONFIG);
+    expect(delay).toBe(2_000); // 1000 * 2^1
+  });
+
+  it("doubles on each successive attempt", () => {
+    const delays = [1, 2, 3, 4].map((a) => calculateReconnectDelay(a, DETERMINISTIC_CONFIG));
+    expect(delays).toEqual([2_000, 4_000, 8_000, 16_000]);
+  });
+
+  it("caps at maxDelayMs", () => {
+    const delay = calculateReconnectDelay(100, DETERMINISTIC_CONFIG);
+    expect(delay).toBe(DETERMINISTIC_CONFIG.maxDelayMs);
+  });
+
+  it("applies jitter within ±jitterFraction of base", () => {
+    const config: ListenerReconnectConfig = { ...DETERMINISTIC_CONFIG, jitterFraction: 0.25 };
+    const base = 2_000;
+    for (let i = 0; i < 20; i++) {
+      const delay = calculateReconnectDelay(1, config);
+      expect(delay).toBeGreaterThanOrEqual(base * 0.75);
+      expect(delay).toBeLessThanOrEqual(base * 1.25);
+    }
+  });
+
+  it("never returns a negative delay", () => {
+    const config: ListenerReconnectConfig = { ...DETERMINISTIC_CONFIG, jitterFraction: 0.99 };
+    for (let i = 0; i < 20; i++) {
+      expect(calculateReconnectDelay(0, config)).toBeGreaterThanOrEqual(0);
+    }
+  });
+});
+
+describe("ListenerBackoffState", () => {
+  let state: ListenerBackoffState;
+
+  beforeEach(() => {
+    state = new ListenerBackoffState(DETERMINISTIC_CONFIG);
+  });
+
+  it("starts at attempt 0", () => {
+    expect(state.currentAttempt).toBe(0);
+  });
+
+  it("increments attempt counter on each failure", () => {
+    state.recordFailure();
+    expect(state.currentAttempt).toBe(1);
+    state.recordFailure();
+    expect(state.currentAttempt).toBe(2);
+  });
+
+  it("returns increasing delay on successive failures", () => {
+    const { delayMs: d1 } = state.recordFailure();
+    const { delayMs: d2 } = state.recordFailure();
+    expect(d2).toBeGreaterThan(d1);
+  });
+
+  it("resets attempt counter after healthResetThreshold consecutive successes", () => {
+    state.recordFailure();
+    state.recordFailure();
+    expect(state.currentAttempt).toBe(2);
+
+    for (let i = 0; i < DETERMINISTIC_CONFIG.healthResetThreshold; i++) {
+      state.recordSuccess();
+    }
+
+    expect(state.currentAttempt).toBe(0);
+  });
+
+  it("does not reset if successes are interrupted by a failure", () => {
+    state.recordFailure();
+    state.recordSuccess();
+    state.recordSuccess();
+    state.recordFailure();
+    // success streak interrupted — attempt count should not have reset
+    expect(state.currentAttempt).toBe(2);
+  });
+
+  it("resets consecutive-success counter when a failure occurs", () => {
+    state.recordSuccess();
+    state.recordSuccess();
+    state.recordFailure();
+    expect(state.currentConsecutiveSuccesses).toBe(0);
+  });
+
+  it("reset() clears both counters", () => {
+    state.recordFailure();
+    state.recordSuccess();
+    state.reset();
+    expect(state.currentAttempt).toBe(0);
+    expect(state.currentConsecutiveSuccesses).toBe(0);
+  });
+
+  it("does not reset when attempt is already 0 (healthy baseline)", () => {
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    for (let i = 0; i < DETERMINISTIC_CONFIG.healthResetThreshold; i++) {
+      state.recordSuccess();
+    }
+    // No reset message should appear since attempt was already 0
+    expect(consoleSpy).not.toHaveBeenCalledWith(expect.stringContaining("resetting backoff"));
+    consoleSpy.mockRestore();
+  });
+
+  it("backoff schedule stays bounded at maxDelayMs", () => {
+    for (let i = 0; i < 25; i++) {
+      const { delayMs } = state.recordFailure();
+      expect(delayMs).toBeLessThanOrEqual(DETERMINISTIC_CONFIG.maxDelayMs);
+    }
+  });
+});

--- a/backend/src/services/listenerBackoff.ts
+++ b/backend/src/services/listenerBackoff.ts
@@ -1,0 +1,78 @@
+/**
+ * Bounded exponential backoff with jitter for the Stellar event listener reconnect loop.
+ *
+ * Design:
+ *  - Delay = min(initialDelay * factor^attempt, maxDelay) ± jitter
+ *  - After HEALTH_RESET_THRESHOLD consecutive successes the attempt counter resets
+ *    to prevent the window from drifting permanently after a transient outage.
+ *  - Each attempt emits a structured log so observability tools can track reconnect cadence.
+ */
+
+export interface ListenerReconnectConfig {
+  initialDelayMs: number;
+  maxDelayMs: number;
+  backoffFactor: number;
+  jitterFraction: number;
+  healthResetThreshold: number;
+}
+
+export const LISTENER_RECONNECT_CONFIG: ListenerReconnectConfig = {
+  initialDelayMs: 1_000,
+  maxDelayMs: 300_000,
+  backoffFactor: 2,
+  jitterFraction: 0.25,
+  healthResetThreshold: 5,
+};
+
+export function calculateReconnectDelay(
+  attempt: number,
+  config: ListenerReconnectConfig = LISTENER_RECONNECT_CONFIG,
+): number {
+  const base = Math.min(
+    config.initialDelayMs * Math.pow(config.backoffFactor, attempt),
+    config.maxDelayMs,
+  );
+  const jitter = base * config.jitterFraction * (Math.random() * 2 - 1);
+  return Math.max(0, base + jitter);
+}
+
+export class ListenerBackoffState {
+  private attempt = 0;
+  private consecutiveSuccesses = 0;
+
+  constructor(private readonly config: ListenerReconnectConfig = LISTENER_RECONNECT_CONFIG) {}
+
+  recordFailure(): { delayMs: number; attempt: number } {
+    this.consecutiveSuccesses = 0;
+    this.attempt += 1;
+    const delayMs = calculateReconnectDelay(this.attempt, this.config);
+    console.warn(
+      `[StellarEventListener] reconnect attempt ${this.attempt}, backing off ${Math.round(delayMs)}ms`,
+    );
+    return { delayMs, attempt: this.attempt };
+  }
+
+  recordSuccess(): void {
+    this.consecutiveSuccesses += 1;
+    if (this.consecutiveSuccesses >= this.config.healthResetThreshold && this.attempt > 0) {
+      console.log(
+        `[StellarEventListener] ${this.consecutiveSuccesses} consecutive successes — resetting backoff`,
+      );
+      this.attempt = 0;
+      this.consecutiveSuccesses = 0;
+    }
+  }
+
+  get currentAttempt(): number {
+    return this.attempt;
+  }
+
+  get currentConsecutiveSuccesses(): number {
+    return this.consecutiveSuccesses;
+  }
+
+  reset(): void {
+    this.attempt = 0;
+    this.consecutiveSuccesses = 0;
+  }
+}

--- a/backend/src/services/stellarEventListener.ts
+++ b/backend/src/services/stellarEventListener.ts
@@ -10,12 +10,11 @@ import { EventCursorStore } from "./eventCursorStore";
 import { StreamEventParser } from "./streamEventParser";
 import { parseVaultCreatedEvent, parseVaultClaimedEvent, parseVaultCancelledEvent, parseVaultMetadataUpdatedEvent } from "./vaultEventParser";
 import { decodeEvent, kindForTopic } from "./eventVersioning/decoderRegistry";
-import { 
-  BACKGROUND_RETRY_CONFIG,
-  calculateBackoffDelay,
+import {
   isRetryableError,
   sleep
 } from "../stellar-service-integration/rate-limiter";
+import { ListenerBackoffState, LISTENER_RECONNECT_CONFIG } from "./listenerBackoff";
 import { IntegrationMetrics } from "../monitoring/metrics/prometheus-config";
 import {
   PROJECTION_LAG_THRESHOLDS,
@@ -129,53 +128,44 @@ export class StellarEventListener {
   }
 
   /**
-   * Poll for new events
+   * Poll for new events with bounded exponential backoff and jitter on failure.
+   *
+   * Backoff resets after LISTENER_RECONNECT_CONFIG.healthResetThreshold consecutive
+   * successful polls to avoid permanently elevated delays after transient outages.
    */
   private async pollEvents(): Promise<void> {
-    let consecutiveFailures = 0;
-    const maxConsecutiveFailures = 5;
+    const backoff = new ListenerBackoffState(LISTENER_RECONNECT_CONFIG);
 
     while (this.isRunning) {
       try {
         await this.fetchAndProcessEvents();
-        consecutiveFailures = 0; // Reset on success
+        backoff.recordSuccess();
+        await this.delay(POLL_INTERVAL_MS);
       } catch (error) {
-        consecutiveFailures++;
-        
         const isTransient = isRetryableError(error);
-        
+
+        console.warn(
+          `[StellarEventListener] poll error (transient=${isTransient}):`,
+          error instanceof Error ? error.message : String(error),
+        );
+
         if (isTransient) {
-          console.warn(
-            `Transient error polling events (failure ${consecutiveFailures}/${maxConsecutiveFailures}):`,
-            error instanceof Error ? error.message : String(error)
-          );
-          
-          // Use exponential backoff for transient errors
-          const backoffDelay = calculateBackoffDelay(
-            Math.min(consecutiveFailures, BACKGROUND_RETRY_CONFIG.maxAttempts),
-            BACKGROUND_RETRY_CONFIG
-          );
-          
-          console.log(`Backing off for ${Math.round(backoffDelay)}ms before next poll`);
-          await sleep(backoffDelay);
-          
-          // If too many consecutive failures, alert but continue
-          if (consecutiveFailures >= maxConsecutiveFailures) {
+          const { delayMs, attempt } = backoff.recordFailure();
+
+          if (attempt > 5) {
             console.error(
-              `Event listener has failed ${consecutiveFailures} times consecutively. ` +
-              `Continuing with extended backoff.`
+              `[StellarEventListener] ${attempt} consecutive failures — continuing with extended backoff`,
             );
           }
-        } else {
-          // Terminal error - log and continue with normal polling
-          console.error("Terminal error polling events (will continue):", error);
-          consecutiveFailures = 0; // Reset since it's not a transient issue
-        }
-      }
 
-      // Wait before next poll (normal interval or already backed off above)
-      if (consecutiveFailures === 0) {
-        await this.delay(POLL_INTERVAL_MS);
+          IntegrationMetrics.recordEventProcessed('reconnect', 'error');
+          await sleep(delayMs);
+        } else {
+          // Non-transient error: log and resume normal cadence without backoff
+          console.error("[StellarEventListener] non-retryable error (will continue):", error);
+          backoff.recordSuccess();
+          await this.delay(POLL_INTERVAL_MS);
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

- Introduces `listenerBackoff.ts` with `ListenerBackoffState` and `calculateReconnectDelay` — bounded exponential backoff (1 s → 5 min cap) with configurable ±25 % jitter.
- Replaces the ad-hoc `BACKGROUND_RETRY_CONFIG` usage in `pollEvents()` with the new `ListenerBackoffState`. The attempt counter resets automatically after 5 consecutive successful polls.
- Emits a structured `warn` log and records a Prometheus metric on every reconnect attempt.

## Backoff parameters

| Parameter | Value |
|---|---|
| `initialDelayMs` | 1 000 ms |
| `maxDelayMs` | 300 000 ms (5 min) |
| `backoffFactor` | 2× |
| `jitterFraction` | ±25 % |
| `healthResetThreshold` | 5 consecutive successes |

## Test plan
- [x] Doubling schedule, cap at maxDelayMs, jitter bounds, non-negative guarantee
- [x] Attempt counter increment, delay growth, reset after threshold, streak interruption, explicit reset()

Closes #1103

🤖 Generated with [Claude Code](https://claude.com/claude-code)