### PR TITLE
feat(backend): add configurable database query timeout

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -25,6 +25,7 @@ import { Database } from "./config/database";
 import { successResponse, errorResponse } from "./utils/response";
 import { requestLoggingMiddleware } from "./middleware/request-logging.middleware";
 import { createTimeoutMiddleware } from "./middleware/timeout";
+import { createQueryTimeoutMiddleware } from "./middleware/queryTimeout";
 import { createMetricsMiddleware, metricsRegistry } from "./lib/metrics";
 import stellarEventListener from "./services/stellarEventListener";
 import websocketService from "./services/websocket";
@@ -43,6 +44,9 @@ app.use(requestLoggingMiddleware);
 
 // Request timeout — responds 503 if a handler takes too long
 app.use(createTimeoutMiddleware());
+
+// Attach default DB query timeout to res.locals for downstream handlers
+app.use(createQueryTimeoutMiddleware());
 
 // Prometheus metrics middleware — records HTTP request duration and counts
 app.use(createMetricsMiddleware());

--- a/backend/src/middleware/__tests__/queryTimeout.test.ts
+++ b/backend/src/middleware/__tests__/queryTimeout.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createServer } from "http";
+import express, { Request, Response } from "express";
+import request from "supertest";
+import {
+  createQueryTimeoutMiddleware,
+  withQueryTimeout,
+  withQueryTimeoutRace,
+  getQueryTimeoutMs,
+  QueryTimeoutError,
+  DEFAULT_QUERY_TIMEOUT_MS,
+} from "../queryTimeout";
+
+describe("QueryTimeoutError", () => {
+  it("carries the timeout and operation name", () => {
+    const err = new QueryTimeoutError(5000, "fetchCampaign");
+    expect(err.message).toContain("5000ms");
+    expect(err.message).toContain("fetchCampaign");
+    expect(err.name).toBe("QueryTimeoutError");
+  });
+
+  it("works without an operation label", () => {
+    const err = new QueryTimeoutError(3000);
+    expect(err.message).toContain("3000ms");
+  });
+});
+
+describe("createQueryTimeoutMiddleware / getQueryTimeoutMs", () => {
+  it("attaches DEFAULT_QUERY_TIMEOUT_MS when no arg is passed", () => {
+    const app = express();
+    app.use(createQueryTimeoutMiddleware());
+    app.get("/", (_req: Request, res: Response) => {
+      res.json({ timeout: getQueryTimeoutMs(res) });
+    });
+
+    return request(app)
+      .get("/")
+      .expect(200)
+      .then((r) => expect(r.body.timeout).toBe(DEFAULT_QUERY_TIMEOUT_MS));
+  });
+
+  it("attaches a custom timeout when provided", () => {
+    const app = express();
+    app.use(createQueryTimeoutMiddleware(10_000));
+    app.get("/", (_req: Request, res: Response) => {
+      res.json({ timeout: getQueryTimeoutMs(res) });
+    });
+
+    return request(app)
+      .get("/")
+      .expect(200)
+      .then((r) => expect(r.body.timeout).toBe(10_000));
+  });
+});
+
+describe("withQueryTimeout (per-route override)", () => {
+  it("overrides the global timeout for a specific route", () => {
+    const app = express();
+    app.use(createQueryTimeoutMiddleware(30_000));
+    app.get("/heavy", withQueryTimeout(120_000), (_req: Request, res: Response) => {
+      res.json({ timeout: getQueryTimeoutMs(res) });
+    });
+    app.get("/normal", (_req: Request, res: Response) => {
+      res.json({ timeout: getQueryTimeoutMs(res) });
+    });
+
+    return Promise.all([
+      request(app).get("/heavy").expect(200).then((r) => expect(r.body.timeout).toBe(120_000)),
+      request(app).get("/normal").expect(200).then((r) => expect(r.body.timeout).toBe(30_000)),
+    ]);
+  });
+});
+
+describe("withQueryTimeoutRace", () => {
+  it("resolves with the operation result when it completes in time", async () => {
+    const result = await withQueryTimeoutRace(() => Promise.resolve(42), 1000, "test");
+    expect(result).toBe(42);
+  });
+
+  it("throws QueryTimeoutError when the operation exceeds the timeout", async () => {
+    const slow = () => new Promise<never>((resolve) => setTimeout(resolve, 500));
+    await expect(withQueryTimeoutRace(slow, 50, "slowOp")).rejects.toBeInstanceOf(QueryTimeoutError);
+  });
+
+  it("clears the timer on success so there are no leaks", async () => {
+    vi.useFakeTimers();
+    const op = async () => "done";
+    const p = withQueryTimeoutRace(op, 5000, "fast");
+    vi.runAllTimers();
+    await expect(p).resolves.toBe("done");
+    vi.useRealTimers();
+  });
+});

--- a/backend/src/middleware/queryTimeout.ts
+++ b/backend/src/middleware/queryTimeout.ts
@@ -1,0 +1,83 @@
+import { Request, Response, NextFunction } from "express";
+import { AppError, ErrorCode } from "../lib/errors";
+
+export const DEFAULT_QUERY_TIMEOUT_MS = 30_000;
+
+// Symbol used to stash the per-request timeout on res.locals
+const QUERY_TIMEOUT_KEY = "queryTimeoutMs";
+
+export class QueryTimeoutError extends AppError {
+  constructor(timeoutMs: number, operation?: string) {
+    super({
+      code: ErrorCode.DATABASE_ERROR,
+      message: operation
+        ? `Database query timed out after ${timeoutMs}ms (${operation})`
+        : `Database query timed out after ${timeoutMs}ms`,
+      details: { timeoutMs, operation },
+    });
+    this.name = "QueryTimeoutError";
+  }
+}
+
+/**
+ * Attach a query timeout (ms) to res.locals so downstream handlers can read it.
+ * Use createQueryTimeoutMiddleware() for the global default and
+ * withQueryTimeout() for per-route overrides.
+ */
+export function createQueryTimeoutMiddleware(timeoutMs: number = DEFAULT_QUERY_TIMEOUT_MS) {
+  return function queryTimeoutMiddleware(
+    _req: Request,
+    res: Response,
+    next: NextFunction,
+  ): void {
+    res.locals[QUERY_TIMEOUT_KEY] = timeoutMs;
+    next();
+  };
+}
+
+/**
+ * Per-route override — shorter alias intended for use inline in route definitions:
+ *
+ *   router.get("/heavy", withQueryTimeout(120_000), handler)
+ */
+export function withQueryTimeout(timeoutMs: number) {
+  return createQueryTimeoutMiddleware(timeoutMs);
+}
+
+/**
+ * Read the effective query timeout for the current request.
+ * Falls back to DEFAULT_QUERY_TIMEOUT_MS when the middleware was not mounted.
+ */
+export function getQueryTimeoutMs(res: Response): number {
+  const stored = res.locals[QUERY_TIMEOUT_KEY];
+  return typeof stored === "number" && stored > 0 ? stored : DEFAULT_QUERY_TIMEOUT_MS;
+}
+
+/**
+ * Race an async DB operation against a timeout.
+ * Throws QueryTimeoutError if the operation does not settle in time.
+ *
+ * @param operation  async function that runs the DB query
+ * @param timeoutMs  milliseconds before the timeout fires
+ * @param label      optional label included in the error message
+ */
+export async function withQueryTimeoutRace<T>(
+  operation: () => Promise<T>,
+  timeoutMs: number,
+  label?: string,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      reject(new QueryTimeoutError(timeoutMs, label));
+    }, timeoutMs);
+  });
+
+  try {
+    const result = await Promise.race([operation(), timeoutPromise]);
+    return result;
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/backend/src/routes/campaigns.ts
+++ b/backend/src/routes/campaigns.ts
@@ -5,6 +5,7 @@ import {
   validateCampaignId,
   validateCampaignExecutionQuery,
 } from "../middleware/validation";
+import { withQueryTimeout, withQueryTimeoutRace, getQueryTimeoutMs } from "../middleware/queryTimeout";
 
 const router = Router();
 
@@ -62,23 +63,32 @@ router.get("/creator/:creator", async (req, res) => {
 });
 
 /** @contract CampaignExecutionsResponse */
-router.get("/:campaignId/executions", validateCampaignExecutionQuery, async (req, res) => {
-  try {
-    const campaignId = parseInt(req.params.campaignId);
-    const limit = parseInt(req.query.limit as string) || 50;
-    const offset = parseInt(req.query.offset as string) || 0;
+router.get(
+  "/:campaignId/executions",
+  validateCampaignExecutionQuery,
+  withQueryTimeout(60_000),
+  async (req, res) => {
+    try {
+      const campaignId = parseInt(req.params.campaignId);
+      const limit = parseInt(req.query.limit as string) || 50;
+      const offset = parseInt(req.query.offset as string) || 0;
+      const timeoutMs = getQueryTimeoutMs(res);
 
-    const result = await campaignProjectionService.getExecutionHistory(
-      campaignId,
-      limit,
-      offset
-    );
+      const result = await withQueryTimeoutRace(
+        () => campaignProjectionService.getExecutionHistory(campaignId, limit, offset),
+        timeoutMs,
+        "getExecutionHistory",
+      );
 
-    res.json(result);
-  } catch (error) {
-    res.status(500).json({ error: "Failed to fetch execution history" });
-  }
-});
+      res.json(result);
+    } catch (error: any) {
+      if (error?.name === "QueryTimeoutError") {
+        return res.status(504).json({ error: error.message });
+      }
+      res.status(500).json({ error: "Failed to fetch execution history" });
+    }
+  },
+);
 
 /** @contract CampaignRecord */
 router.get("/:campaignId", validateCampaignId, async (req, res) => {


### PR DESCRIPTION
## Summary

- Adds `middleware/queryTimeout.ts` with `QueryTimeoutError` (typed `AppError`), `createQueryTimeoutMiddleware()` for the global default, `withQueryTimeout(ms)` for per-route override, and `withQueryTimeoutRace()` to race any async DB call against a deadline.
- Wires the global default (30 s) into `index.ts` so all routes inherit it via `res.locals`.
- Applies a 60 s override to `GET /:campaignId/executions` (the heaviest campaign query) using `withQueryTimeout(60_000)`.
- Timeout fires a `QueryTimeoutError` → HTTP 504.

## Defaults & overrides

| Setting | Value |
|---|---|
| Global default (`DEFAULT_QUERY_TIMEOUT_MS`) | 30 000 ms |
| `/campaigns/:id/executions` override | 60 000 ms |
| Override API | `withQueryTimeout(ms)` inline middleware |
| DB call wrapper | `withQueryTimeoutRace(fn, ms, label?)` |

## Test plan
- [x] `QueryTimeoutError` carries message and operation label
- [x] Global default and custom timeout attached to `res.locals`
- [x] Per-route override supersedes global
- [x] `withQueryTimeoutRace` resolves on time, throws on timeout, clears timer on success

Closes #1104

🤖 Generated with [Claude Code](https://claude.com/claude-code)