### PR TITLE
feat(backend): add idempotency keys to token creation

### DIFF
--- a/backend/src/__tests__/idempotency.test.ts
+++ b/backend/src/__tests__/idempotency.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import express, { Request, Response } from "express";
+import request from "supertest";
+import {
+  IdempotencyStore,
+  createIdempotencyMiddleware,
+  DEFAULT_IDEMPOTENCY_WINDOW_MS,
+  IDEMPOTENCY_HEADER,
+} from "../middleware/idempotency";
+
+function buildApp(store: IdempotencyStore) {
+  const app = express();
+  app.use(express.json());
+  app.use(createIdempotencyMiddleware(store));
+
+  let callCount = 0;
+  app.post("/tokens", (_req: Request, res: Response) => {
+    callCount++;
+    res.status(201).json({ id: `tok-${callCount}`, callCount });
+  });
+
+  return { app, getCallCount: () => callCount };
+}
+
+describe("IdempotencyStore", () => {
+  it("returns undefined for an unseen key", () => {
+    const store = new IdempotencyStore();
+    expect(store.get("missing")).toBeUndefined();
+  });
+
+  it("returns the stored result within the window", () => {
+    const store = new IdempotencyStore(60_000);
+    store.set("k1", 201, { id: "abc" });
+    const result = store.get("k1");
+    expect(result?.body).toEqual({ id: "abc" });
+    expect(result?.statusCode).toBe(201);
+  });
+
+  it("returns undefined after the window expires", () => {
+    vi.useFakeTimers();
+    const store = new IdempotencyStore(1_000);
+    store.set("k2", 201, { id: "xyz" });
+    vi.advanceTimersByTime(1_001);
+    expect(store.get("k2")).toBeUndefined();
+    vi.useRealTimers();
+  });
+
+  it("purgeExpired removes stale entries", () => {
+    vi.useFakeTimers();
+    const store = new IdempotencyStore(500);
+    store.set("a", 201, {});
+    store.set("b", 201, {});
+    vi.advanceTimersByTime(600);
+    store.purgeExpired();
+    expect(store.size).toBe(0);
+    vi.useRealTimers();
+  });
+});
+
+describe("createIdempotencyMiddleware", () => {
+  let store: IdempotencyStore;
+
+  beforeEach(() => {
+    store = new IdempotencyStore();
+  });
+
+  it("passes through requests without an idempotency key", async () => {
+    const { app, getCallCount } = buildApp(store);
+    await request(app).post("/tokens").send({}).expect(201);
+    await request(app).post("/tokens").send({}).expect(201);
+    expect(getCallCount()).toBe(2);
+  });
+
+  it("returns the original response on a retried key", async () => {
+    const { app, getCallCount } = buildApp(store);
+
+    const r1 = await request(app)
+      .post("/tokens")
+      .set(IDEMPOTENCY_HEADER, "key-001")
+      .send({})
+      .expect(201);
+
+    const r2 = await request(app)
+      .post("/tokens")
+      .set(IDEMPOTENCY_HEADER, "key-001")
+      .send({})
+      .expect(201);
+
+    // Handler only called once
+    expect(getCallCount()).toBe(1);
+    // Both responses have the same body
+    expect(r2.body).toEqual(r1.body);
+  });
+
+  it("treats different keys as independent requests", async () => {
+    const { app, getCallCount } = buildApp(store);
+
+    await request(app).post("/tokens").set(IDEMPOTENCY_HEADER, "key-A").send({}).expect(201);
+    await request(app).post("/tokens").set(IDEMPOTENCY_HEADER, "key-B").send({}).expect(201);
+
+    expect(getCallCount()).toBe(2);
+  });
+
+  it("rejects a key that is too long", async () => {
+    const { app } = buildApp(store);
+    const longKey = "x".repeat(256);
+    const r = await request(app)
+      .post("/tokens")
+      .set(IDEMPOTENCY_HEADER, longKey)
+      .send({});
+    expect(r.status).toBe(400);
+  });
+
+  it("does not cache error responses", async () => {
+    const store2 = new IdempotencyStore();
+    const app2 = express();
+    app2.use(express.json());
+    app2.use(createIdempotencyMiddleware(store2));
+
+    let calls = 0;
+    app2.post("/fail-then-succeed", (_req, res) => {
+      calls++;
+      if (calls === 1) return res.status(500).json({ error: "boom" });
+      return res.status(201).json({ id: "ok" });
+    });
+
+    await request(app2).post("/fail-then-succeed").set(IDEMPOTENCY_HEADER, "k-err").send({});
+    const r2 = await request(app2).post("/fail-then-succeed").set(IDEMPOTENCY_HEADER, "k-err").send({});
+
+    // Second call should have reached the handler (error not cached)
+    expect(calls).toBe(2);
+    expect(r2.status).toBe(201);
+  });
+
+  it("expires stored key after the configured window", async () => {
+    vi.useFakeTimers();
+    const shortStore = new IdempotencyStore(500);
+    const { app, getCallCount } = buildApp(shortStore);
+
+    await request(app).post("/tokens").set(IDEMPOTENCY_HEADER, "expire-key").send({}).expect(201);
+
+    // Advance past the window
+    vi.advanceTimersByTime(600);
+
+    await request(app).post("/tokens").set(IDEMPOTENCY_HEADER, "expire-key").send({}).expect(201);
+
+    expect(getCallCount()).toBe(2);
+    vi.useRealTimers();
+  });
+});

--- a/backend/src/middleware/idempotency.ts
+++ b/backend/src/middleware/idempotency.ts
@@ -1,0 +1,126 @@
+import { Request, Response, NextFunction } from "express";
+import { BadRequestError } from "../lib/errors";
+
+export const IDEMPOTENCY_HEADER = "idempotency-key";
+
+/** Default window in which the same key returns the cached result. */
+export const DEFAULT_IDEMPOTENCY_WINDOW_MS = 24 * 60 * 60 * 1000; // 24 h
+
+/** Maximum length accepted for an idempotency key. */
+const MAX_KEY_LENGTH = 255;
+
+interface StoredResult {
+  statusCode: number;
+  body: unknown;
+  createdAt: number;
+}
+
+/**
+ * In-process idempotency store (suitable for single-process deployments).
+ * Swap out for a Redis-backed store in multi-replica environments.
+ */
+export class IdempotencyStore {
+  private readonly store = new Map<string, StoredResult>();
+
+  constructor(private readonly windowMs: number = DEFAULT_IDEMPOTENCY_WINDOW_MS) {}
+
+  get(key: string): StoredResult | undefined {
+    const entry = this.store.get(key);
+    if (!entry) return undefined;
+    if (Date.now() - entry.createdAt > this.windowMs) {
+      this.store.delete(key);
+      return undefined;
+    }
+    return entry;
+  }
+
+  set(key: string, statusCode: number, body: unknown): void {
+    this.store.set(key, { statusCode, body, createdAt: Date.now() });
+  }
+
+  delete(key: string): void {
+    this.store.delete(key);
+  }
+
+  /** Remove all expired entries (call periodically to prevent unbounded growth). */
+  purgeExpired(): void {
+    const now = Date.now();
+    for (const [k, v] of this.store) {
+      if (now - v.createdAt > this.windowMs) {
+        this.store.delete(k);
+      }
+    }
+  }
+
+  get size(): number {
+    return this.store.size;
+  }
+}
+
+/** Singleton store used by the default middleware. */
+export const idempotencyStore = new IdempotencyStore();
+
+// Purge expired keys every hour.
+setInterval(() => idempotencyStore.purgeExpired(), 60 * 60 * 1000).unref();
+
+/**
+ * Express middleware that deduplicates POST requests using an Idempotency-Key header.
+ *
+ * Contract:
+ *  - Clients include `Idempotency-Key: <uuid>` on creation requests.
+ *  - If the key was seen within `windowMs`, the original response is returned immediately.
+ *  - If the key is absent, the request is passed through unmodified.
+ *  - Keys longer than MAX_KEY_LENGTH or containing non-printable characters are rejected 400.
+ *
+ * @param store   IdempotencyStore instance (defaults to the module-level singleton)
+ * @param windowMs Expiry window (defaults to DEFAULT_IDEMPOTENCY_WINDOW_MS)
+ */
+export function createIdempotencyMiddleware(
+  store: IdempotencyStore = idempotencyStore,
+) {
+  return function idempotencyMiddleware(
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): void {
+    const rawKey = req.headers[IDEMPOTENCY_HEADER];
+
+    // No key → pass through
+    if (!rawKey) {
+      return next();
+    }
+
+    const key = Array.isArray(rawKey) ? rawKey[0] : rawKey;
+
+    // Validate key
+    if (key.length > MAX_KEY_LENGTH || !/^[\x20-\x7E]+$/.test(key)) {
+      const err = new BadRequestError(
+        `Idempotency-Key must be 1-${MAX_KEY_LENGTH} printable ASCII characters`,
+      );
+      res.status(err.httpStatus).json(err.toHttpResponse());
+      return;
+    }
+
+    // Cache hit → replay stored response
+    const stored = store.get(key);
+    if (stored) {
+      res.status(stored.statusCode).json(stored.body);
+      return;
+    }
+
+    // Intercept res.json to capture the response for future replays
+    const originalJson = res.json.bind(res) as (body: unknown) => Response;
+    res.json = (body: unknown): Response => {
+      // Only cache successful (2xx) responses
+      if (res.statusCode >= 200 && res.statusCode < 300) {
+        store.set(key, res.statusCode, body);
+      }
+      return originalJson(body);
+    };
+
+    next();
+  };
+}
+
+/** Pre-built middleware instance using the default store and window. */
+export const idempotencyMiddleware = createIdempotencyMiddleware();

--- a/backend/src/routes/campaigns.ts
+++ b/backend/src/routes/campaigns.ts
@@ -5,6 +5,7 @@ import {
   validateCampaignId,
   validateCampaignExecutionQuery,
 } from "../middleware/validation";
+import { idempotencyMiddleware } from "../middleware/idempotency";
 
 const router = Router();
 
@@ -99,9 +100,10 @@ router.get("/:campaignId", validateCampaignId, async (req, res) => {
 /**
  * POST /api/campaigns
  * Create a new campaign. Validated by validateCampaignCreate middleware.
+ * Supports Idempotency-Key header to deduplicate retried requests.
  * @contract CampaignRecord
  */
-router.post("/", validateCampaignCreate, async (req, res) => {
+router.post("/", idempotencyMiddleware, validateCampaignCreate, async (req, res) => {
   try {
     const { tokenId, creator, type, targetAmount, startTime, endTime, metadata, txHash } = req.body;
 


### PR DESCRIPTION
## Summary

- Introduces `middleware/idempotency.ts` with `IdempotencyStore` and `createIdempotencyMiddleware()`.
- Applies `idempotencyMiddleware` to `POST /api/campaigns` so retried requests with the same `Idempotency-Key` header return the original response without creating a duplicate record.
- Error responses (4xx / 5xx) are never cached — transient failures remain retryable.
- Expired keys are purged automatically every hour to prevent unbounded memory growth.

## Header contract

| Header | `Idempotency-Key: <value>` |
|---|---|
| Required? | No — requests without the header pass through unchanged |
| Format | 1–255 printable ASCII characters |
| Invalid key | HTTP 400 |
| Cache window | 24 h (configurable via `IdempotencyStore` constructor) |

## Behaviour

1. First request with key `K` → handler runs, `2xx` response stored under `K`.
2. Subsequent requests with key `K` within the window → stored response replayed, handler **not** called.
3. After window expiry → key purged, next request treated as new.
4. `5xx` / `4xx` responses are **not** stored so clients can retry after a failure.

## Test plan
- [x] Requests without a key pass through normally
- [x] Retried key returns original body, handler called only once
- [x] Different keys treated independently
- [x] Key > 255 chars rejected 400
- [x] Error responses not cached (second attempt reaches handler)
- [x] Key expires after window; subsequent request hits handler again

Closes #1106

🤖 Generated with [Claude Code](https://claude.com/claude-code)