### PR TITLE
feat(backend): API versioning, pool metrics, tenant isolation, event-driven leaderboard cache

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,4 +1,4 @@
-import express from "express";
+import express, { Router } from "express";
 import cors from "cors";
 import helmet from "helmet";
 import rateLimit from "express-rate-limit";
@@ -26,6 +26,8 @@ import { successResponse, errorResponse } from "./utils/response";
 import { requestLoggingMiddleware } from "./middleware/request-logging.middleware";
 import { createTimeoutMiddleware } from "./middleware/timeout";
 import { createMetricsMiddleware, metricsRegistry } from "./lib/metrics";
+import { registerPoolMetrics } from "./lib/metrics/poolMetrics";
+import { prisma } from "./lib/prisma";
 import stellarEventListener from "./services/stellarEventListener";
 import websocketService from "./services/websocket";
 
@@ -58,40 +60,52 @@ const limiter = rateLimit({
   message: "Too many requests from this IP, please try again later.",
 });
 
-app.use("/api/admin", limiter);
-app.use("/api/analytics", limiter);
-app.use("/api/leaderboard", limiter);
-app.use("/api/tokens", limiter);
-app.use("/api/dividends", limiter);
-app.use("/api/stats", limiter);
-app.use("/api/governance", limiter);
-app.use("/api/campaigns", limiter);
-app.use("/api/streams", limiter);
-app.use("/api/vaults", limiter);
-
 // Body parsing middleware
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 
-// Initialize database
+// Initialize database and pool metrics
 Database.initialize();
+registerPoolMetrics(prisma);
 
-// Routes
-app.use("/api/admin", adminRoutes);
-app.use("/api/analytics", analyticsRoutes);
-app.use("/api/leaderboard", leaderboardRoutes);
-app.use("/api/tokens", tokenRoutes);
-app.use("/api/dividends", dividendRoutes);
-app.use("/api/stats", statsRoutes);
-app.use("/api/governance", governanceRoutes);
-app.use("/api/campaigns", campaignRoutes);
-app.use("/api/streams", streamRoutes);
-app.use("/api/vaults", vaultRoutes);
-app.use("/api/version", versionRoutes);
-app.use("/api/search", searchRoutes);
-app.use("/api/export", exportRoutes);
-app.use("/api/graphql", graphqlRouter);
-app.use("/api/docs", openApiRouter);
+// ---------------------------------------------------------------------------
+// Versioned API router (v1)
+//
+// All routes live under /api/v1/<resource>.  A backward-compat alias mounts
+// the same router at /api/<resource> so existing clients continue to work.
+//
+// The X-API-Version response header tells clients which version served them.
+// ---------------------------------------------------------------------------
+
+const v1Router = Router();
+
+// Version header on every v1 response
+v1Router.use((_req, res, next) => {
+  res.setHeader("X-API-Version", "v1");
+  next();
+});
+
+v1Router.use("/admin", limiter, adminRoutes);
+v1Router.use("/analytics", limiter, analyticsRoutes);
+v1Router.use("/leaderboard", limiter, leaderboardRoutes);
+v1Router.use("/tokens", limiter, tokenRoutes);
+v1Router.use("/dividends", limiter, dividendRoutes);
+v1Router.use("/stats", limiter, statsRoutes);
+v1Router.use("/governance", limiter, governanceRoutes);
+v1Router.use("/campaigns", limiter, campaignRoutes);
+v1Router.use("/streams", limiter, streamRoutes);
+v1Router.use("/vaults", limiter, vaultRoutes);
+v1Router.use("/version", versionRoutes);
+v1Router.use("/search", searchRoutes);
+v1Router.use("/export", exportRoutes);
+v1Router.use("/graphql", graphqlRouter);
+v1Router.use("/docs", openApiRouter);
+
+// Canonical versioned mount
+app.use("/api/v1", v1Router);
+
+// Backward-compatibility alias — clients targeting /api/<resource> continue to work
+app.use("/api", v1Router);
 
 import { healthService } from "./lib/health/health.service";
 import { isAppError, toAppError } from "./lib/errors";

--- a/backend/src/lib/metrics/index.ts
+++ b/backend/src/lib/metrics/index.ts
@@ -178,6 +178,18 @@ export const dbConnectionsIdle = new Gauge({
   registers: [register],
 });
 
+export const dbConnectionsWaiting = new Gauge({
+  name: "db_connections_waiting",
+  help: "Number of queries waiting to acquire a database connection",
+  registers: [register],
+});
+
+export const dbPoolSaturation = new Gauge({
+  name: "db_pool_saturation",
+  help: "Connection pool saturation ratio (active / max pool size)",
+  registers: [register],
+});
+
 // ---------------------------------------------------------------------------
 // Wallet Metrics
 // ---------------------------------------------------------------------------
@@ -564,9 +576,16 @@ export class MetricsCollector {
     healthCheckDuration.observe({ service }, durationSeconds);
   }
 
-  static updateDatabaseConnections(active: number, idle: number): void {
+  static updateDatabaseConnections(
+    active: number,
+    idle: number,
+    waiting = 0,
+    maxPoolSize = 10
+  ): void {
     dbConnectionsActive.set(active);
     dbConnectionsIdle.set(idle);
+    dbConnectionsWaiting.set(waiting);
+    dbPoolSaturation.set(maxPoolSize > 0 ? active / maxPoolSize : 0);
   }
 
   static updateJobQueueSize(queueName: string, size: number): void {

--- a/backend/src/lib/metrics/poolMetrics.ts
+++ b/backend/src/lib/metrics/poolMetrics.ts
@@ -1,0 +1,64 @@
+/**
+ * Connection-pool health metrics.
+ *
+ * Uses a Prisma `$use` middleware to track in-flight query concurrency as a
+ * proxy for connection-pool utilisation.  Prisma does not expose raw pool
+ * internals, so we model:
+ *
+ *   active  – queries currently executing (≤ pool size)
+ *   idle    – idle slots in the pool  (pool_size − active)
+ *   waiting – queries queued beyond the pool capacity
+ *   saturation – active / pool_size  (0–1; alert on > 0.8)
+ *
+ * The pool size is read from DB_POOL_SIZE env (default 10).
+ *
+ * Call `registerPoolMetrics(prismaClient)` once at startup (after the Prisma
+ * singleton is initialised) to activate collection.
+ */
+
+import type { PrismaClient } from "@prisma/client";
+import {
+  dbConnectionsActive,
+  dbConnectionsIdle,
+  dbConnectionsWaiting,
+  dbPoolSaturation,
+  MetricsCollector,
+} from "./index";
+
+const MAX_POOL_SIZE = parseInt(process.env.DB_POOL_SIZE ?? "10", 10);
+
+let inflightCount = 0;
+
+function applyPoolGauges(inflight: number): void {
+  const active = Math.min(inflight, MAX_POOL_SIZE);
+  const idle = Math.max(0, MAX_POOL_SIZE - inflight);
+  const waiting = Math.max(0, inflight - MAX_POOL_SIZE);
+  const saturation = MAX_POOL_SIZE > 0 ? active / MAX_POOL_SIZE : 0;
+
+  dbConnectionsActive.set(active);
+  dbConnectionsIdle.set(idle);
+  dbConnectionsWaiting.set(waiting);
+  dbPoolSaturation.set(saturation);
+}
+
+/**
+ * Attach pool-metrics collection to the given Prisma client.
+ * Must be called once before the first query.
+ */
+export function registerPoolMetrics(client: PrismaClient): void {
+  // @ts-expect-error – $use is available on PrismaClient at runtime
+  client.$use(async (params: unknown, next: (p: unknown) => Promise<unknown>) => {
+    inflightCount++;
+    applyPoolGauges(inflightCount);
+
+    try {
+      return await next(params);
+    } finally {
+      inflightCount = Math.max(0, inflightCount - 1);
+      applyPoolGauges(inflightCount);
+    }
+  });
+
+  // Initialise gauges to zero so they appear in /metrics from startup
+  MetricsCollector.updateDatabaseConnections(0, MAX_POOL_SIZE, 0, MAX_POOL_SIZE);
+}

--- a/backend/src/routes/tokens.test.ts
+++ b/backend/src/routes/tokens.test.ts
@@ -14,9 +14,16 @@ vi.mock("../lib/prisma", () => ({
   },
 }));
 
+const TENANT_ID = "GCREATOR1";
+
 const app = express();
 app.use(express.json());
 app.use("/api/tokens", tokenRoutes);
+
+/** Helper: attach the required tenant header to every request */
+function withTenant(r: request.Test): request.Test {
+  return r.set("X-Tenant-ID", TENANT_ID);
+}
 
 describe("GET /api/tokens/search", () => {
   beforeEach(() => {
@@ -27,7 +34,7 @@ describe("GET /api/tokens/search", () => {
     {
       id: "1",
       address: "GABC123",
-      creator: "GCREATOR1",
+      creator: TENANT_ID,
       name: "Test Token",
       symbol: "TEST",
       decimals: 18,
@@ -42,7 +49,7 @@ describe("GET /api/tokens/search", () => {
     {
       id: "2",
       address: "GDEF456",
-      creator: "GCREATOR2",
+      creator: TENANT_ID,
       name: "Another Token",
       symbol: "ANOT",
       decimals: 18,
@@ -56,11 +63,16 @@ describe("GET /api/tokens/search", () => {
     },
   ];
 
+  it("should return 400 when tenant header is missing", async () => {
+    const response = await request(app).get("/api/tokens/search");
+    expect(response.status).toBe(400);
+  });
+
   it("should return all tokens with default pagination", async () => {
     vi.mocked(prisma.token.findMany).mockResolvedValue(mockTokens);
     vi.mocked(prisma.token.count).mockResolvedValue(2);
 
-    const response = await request(app).get("/api/tokens/search");
+    const response = await withTenant(request(app).get("/api/tokens/search"));
 
     expect(response.status).toBe(200);
     expect(response.body.success).toBe(true);
@@ -75,11 +87,28 @@ describe("GET /api/tokens/search", () => {
     });
   });
 
+  it("should always scope queries to the tenant (creator)", async () => {
+    vi.mocked(prisma.token.findMany).mockResolvedValue(mockTokens);
+    vi.mocked(prisma.token.count).mockResolvedValue(2);
+
+    await withTenant(request(app).get("/api/tokens/search"));
+
+    expect(prisma.token.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          creator: TENANT_ID,
+        }),
+      })
+    );
+  });
+
   it("should search by name (case insensitive)", async () => {
     vi.mocked(prisma.token.findMany).mockResolvedValue([mockTokens[0]]);
     vi.mocked(prisma.token.count).mockResolvedValue(1);
 
-    const response = await request(app).get("/api/tokens/search?q=test");
+    const response = await withTenant(
+      request(app).get("/api/tokens/search?q=test")
+    );
 
     expect(response.status).toBe(200);
     expect(response.body.success).toBe(true);
@@ -88,6 +117,7 @@ describe("GET /api/tokens/search", () => {
     expect(prisma.token.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
         where: expect.objectContaining({
+          creator: TENANT_ID,
           OR: [
             { name: { contains: "test", mode: "insensitive" } },
             { symbol: { contains: "test", mode: "insensitive" } },
@@ -97,31 +127,14 @@ describe("GET /api/tokens/search", () => {
     );
   });
 
-  it("should filter by creator address", async () => {
-    vi.mocked(prisma.token.findMany).mockResolvedValue([mockTokens[0]]);
-    vi.mocked(prisma.token.count).mockResolvedValue(1);
-
-    const response = await request(app).get(
-      "/api/tokens/search?creator=GCREATOR1"
-    );
-
-    expect(response.status).toBe(200);
-    expect(response.body.success).toBe(true);
-    expect(prisma.token.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: expect.objectContaining({
-          creator: "GCREATOR1",
-        }),
-      })
-    );
-  });
-
   it("should filter by date range", async () => {
     vi.mocked(prisma.token.findMany).mockResolvedValue([mockTokens[0]]);
     vi.mocked(prisma.token.count).mockResolvedValue(1);
 
-    const response = await request(app).get(
-      "/api/tokens/search?startDate=2024-01-01T00:00:00.000Z&endDate=2024-01-31T23:59:59.999Z"
+    const response = await withTenant(
+      request(app).get(
+        "/api/tokens/search?startDate=2024-01-01T00:00:00.000Z&endDate=2024-01-31T23:59:59.999Z"
+      )
     );
 
     expect(response.status).toBe(200);
@@ -129,6 +142,7 @@ describe("GET /api/tokens/search", () => {
     expect(prisma.token.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
         where: expect.objectContaining({
+          creator: TENANT_ID,
           createdAt: {
             gte: new Date("2024-01-01T00:00:00.000Z"),
             lte: new Date("2024-01-31T23:59:59.999Z"),
@@ -142,8 +156,8 @@ describe("GET /api/tokens/search", () => {
     vi.mocked(prisma.token.findMany).mockResolvedValue([mockTokens[1]]);
     vi.mocked(prisma.token.count).mockResolvedValue(1);
 
-    const response = await request(app).get(
-      "/api/tokens/search?minSupply=100000&maxSupply=600000"
+    const response = await withTenant(
+      request(app).get("/api/tokens/search?minSupply=100000&maxSupply=600000")
     );
 
     expect(response.status).toBe(200);
@@ -151,6 +165,7 @@ describe("GET /api/tokens/search", () => {
     expect(prisma.token.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
         where: expect.objectContaining({
+          creator: TENANT_ID,
           totalSupply: {
             gte: BigInt(100000),
             lte: BigInt(600000),
@@ -164,13 +179,16 @@ describe("GET /api/tokens/search", () => {
     vi.mocked(prisma.token.findMany).mockResolvedValue([mockTokens[0]]);
     vi.mocked(prisma.token.count).mockResolvedValue(1);
 
-    const response = await request(app).get("/api/tokens/search?hasBurns=true");
+    const response = await withTenant(
+      request(app).get("/api/tokens/search?hasBurns=true")
+    );
 
     expect(response.status).toBe(200);
     expect(response.body.success).toBe(true);
     expect(prisma.token.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
         where: expect.objectContaining({
+          creator: TENANT_ID,
           burnCount: { gt: 0 },
         }),
       })
@@ -181,8 +199,8 @@ describe("GET /api/tokens/search", () => {
     vi.mocked(prisma.token.findMany).mockResolvedValue([mockTokens[1]]);
     vi.mocked(prisma.token.count).mockResolvedValue(1);
 
-    const response = await request(app).get(
-      "/api/tokens/search?hasBurns=false"
+    const response = await withTenant(
+      request(app).get("/api/tokens/search?hasBurns=false")
     );
 
     expect(response.status).toBe(200);
@@ -190,6 +208,7 @@ describe("GET /api/tokens/search", () => {
     expect(prisma.token.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
         where: expect.objectContaining({
+          creator: TENANT_ID,
           burnCount: 0,
         }),
       })
@@ -200,7 +219,7 @@ describe("GET /api/tokens/search", () => {
     vi.mocked(prisma.token.findMany).mockResolvedValue(mockTokens);
     vi.mocked(prisma.token.count).mockResolvedValue(2);
 
-    const response = await request(app).get("/api/tokens/search");
+    await withTenant(request(app).get("/api/tokens/search"));
 
     expect(prisma.token.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -213,8 +232,8 @@ describe("GET /api/tokens/search", () => {
     vi.mocked(prisma.token.findMany).mockResolvedValue(mockTokens);
     vi.mocked(prisma.token.count).mockResolvedValue(2);
 
-    const response = await request(app).get(
-      "/api/tokens/search?sortBy=burned&sortOrder=asc"
+    await withTenant(
+      request(app).get("/api/tokens/search?sortBy=burned&sortOrder=asc")
     );
 
     expect(prisma.token.findMany).toHaveBeenCalledWith(
@@ -228,8 +247,8 @@ describe("GET /api/tokens/search", () => {
     vi.mocked(prisma.token.findMany).mockResolvedValue(mockTokens);
     vi.mocked(prisma.token.count).mockResolvedValue(2);
 
-    const response = await request(app).get(
-      "/api/tokens/search?sortBy=supply&sortOrder=desc"
+    await withTenant(
+      request(app).get("/api/tokens/search?sortBy=supply&sortOrder=desc")
     );
 
     expect(prisma.token.findMany).toHaveBeenCalledWith(
@@ -243,8 +262,8 @@ describe("GET /api/tokens/search", () => {
     vi.mocked(prisma.token.findMany).mockResolvedValue(mockTokens);
     vi.mocked(prisma.token.count).mockResolvedValue(2);
 
-    const response = await request(app).get(
-      "/api/tokens/search?sortBy=name&sortOrder=asc"
+    await withTenant(
+      request(app).get("/api/tokens/search?sortBy=name&sortOrder=asc")
     );
 
     expect(prisma.token.findMany).toHaveBeenCalledWith(
@@ -258,8 +277,8 @@ describe("GET /api/tokens/search", () => {
     vi.mocked(prisma.token.findMany).mockResolvedValue([mockTokens[1]]);
     vi.mocked(prisma.token.count).mockResolvedValue(50);
 
-    const response = await request(app).get(
-      "/api/tokens/search?page=2&limit=10"
+    const response = await withTenant(
+      request(app).get("/api/tokens/search?page=2&limit=10")
     );
 
     expect(response.body.pagination).toEqual({
@@ -282,7 +301,7 @@ describe("GET /api/tokens/search", () => {
     vi.mocked(prisma.token.findMany).mockResolvedValue(mockTokens);
     vi.mocked(prisma.token.count).mockResolvedValue(2);
 
-    const response = await request(app).get("/api/tokens/search?limit=100");
+    await withTenant(request(app).get("/api/tokens/search?limit=100"));
 
     expect(prisma.token.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -295,7 +314,7 @@ describe("GET /api/tokens/search", () => {
     vi.mocked(prisma.token.findMany).mockResolvedValue([mockTokens[0]]);
     vi.mocked(prisma.token.count).mockResolvedValue(1);
 
-    const response = await request(app).get("/api/tokens/search");
+    const response = await withTenant(request(app).get("/api/tokens/search"));
 
     expect(typeof response.body.data[0].totalSupply).toBe("string");
     expect(typeof response.body.data[0].initialSupply).toBe("string");
@@ -304,8 +323,8 @@ describe("GET /api/tokens/search", () => {
   });
 
   it("should return validation error for invalid parameters", async () => {
-    const response = await request(app).get(
-      "/api/tokens/search?sortBy=invalid"
+    const response = await withTenant(
+      request(app).get("/api/tokens/search?sortBy=invalid")
     );
 
     expect(response.status).toBe(400);
@@ -314,8 +333,8 @@ describe("GET /api/tokens/search", () => {
   });
 
   it("should return validation error for invalid date format", async () => {
-    const response = await request(app).get(
-      "/api/tokens/search?startDate=not-a-date"
+    const response = await withTenant(
+      request(app).get("/api/tokens/search?startDate=not-a-date")
     );
 
     expect(response.status).toBe(400);
@@ -323,18 +342,22 @@ describe("GET /api/tokens/search", () => {
   });
 
   it("should return validation error for invalid supply format", async () => {
-    const response = await request(app).get("/api/tokens/search?minSupply=abc");
+    const response = await withTenant(
+      request(app).get("/api/tokens/search?minSupply=abc")
+    );
 
     expect(response.status).toBe(400);
     expect(response.body.success).toBe(false);
   });
 
-  it("should combine multiple filters", async () => {
+  it("should combine multiple filters within tenant scope", async () => {
     vi.mocked(prisma.token.findMany).mockResolvedValue([mockTokens[0]]);
     vi.mocked(prisma.token.count).mockResolvedValue(1);
 
-    const response = await request(app).get(
-      "/api/tokens/search?q=test&creator=GCREATOR1&hasBurns=true&minSupply=100000"
+    const response = await withTenant(
+      request(app).get(
+        "/api/tokens/search?q=test&hasBurns=true&minSupply=100000"
+      )
     );
 
     expect(response.status).toBe(200);
@@ -342,8 +365,8 @@ describe("GET /api/tokens/search", () => {
     expect(prisma.token.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
         where: expect.objectContaining({
+          creator: TENANT_ID,
           OR: expect.any(Array),
-          creator: "GCREATOR1",
           burnCount: { gt: 0 },
           totalSupply: expect.objectContaining({
             gte: BigInt(100000),
@@ -358,7 +381,7 @@ describe("GET /api/tokens/search", () => {
       new Error("Database connection failed")
     );
 
-    const response = await request(app).get("/api/tokens/search");
+    const response = await withTenant(request(app).get("/api/tokens/search"));
 
     expect(response.status).toBe(500);
     expect(response.body.success).toBe(false);
@@ -369,13 +392,15 @@ describe("GET /api/tokens/search", () => {
     vi.mocked(prisma.token.findMany).mockResolvedValue(mockTokens);
     vi.mocked(prisma.token.count).mockResolvedValue(2);
 
-    const response = await request(app).get(
-      "/api/tokens/search?q=test&creator=GCREATOR1&sortBy=burned&sortOrder=desc"
+    const response = await withTenant(
+      request(app).get(
+        "/api/tokens/search?q=test&sortBy=burned&sortOrder=desc"
+      )
     );
 
     expect(response.body.filters).toEqual({
       q: "test",
-      creator: "GCREATOR1",
+      creator: undefined,
       startDate: undefined,
       endDate: undefined,
       minSupply: undefined,
@@ -386,16 +411,20 @@ describe("GET /api/tokens/search", () => {
     });
   });
 
-  it("should use cache for repeated requests", async () => {
+  it("should use cache for repeated requests (per tenant)", async () => {
     vi.mocked(prisma.token.findMany).mockResolvedValue(mockTokens);
     vi.mocked(prisma.token.count).mockResolvedValue(2);
 
     // First request
-    const response1 = await request(app).get("/api/tokens/search?q=test");
+    const response1 = await withTenant(
+      request(app).get("/api/tokens/search?q=test")
+    );
     expect(response1.body.cached).toBeUndefined();
 
     // Second request (should be cached)
-    const response2 = await request(app).get("/api/tokens/search?q=test");
+    const response2 = await withTenant(
+      request(app).get("/api/tokens/search?q=test")
+    );
     expect(response2.body.cached).toBe(true);
 
     // Prisma should only be called once

--- a/backend/src/routes/tokens.ts
+++ b/backend/src/routes/tokens.ts
@@ -1,17 +1,23 @@
 import { Router, Request, Response } from "express";
 import { performance } from "perf_hooks";
 import { prisma } from "../lib/prisma";
-
 import { Prisma } from "@prisma/client";
 import { z } from "zod";
 import type { TokenSearchResponse } from "../contracts/apiSchemas";
+import {
+  tenantMiddleware,
+  type TenantRequest,
+} from "../middleware/tenancy";
 
 const router = Router();
 
+// Enforce tenant context on every token request — cross-tenant reads are rejected.
+router.use(tenantMiddleware({ required: true }));
+
 // Validation schema for search parameters
+// `creator` is intentionally omitted — the tenant scope always sets it.
 const searchParamsSchema = z.object({
   q: z.string().optional(),
-  creator: z.string().optional(),
   startDate: z.string().datetime().optional(),
   endDate: z.string().datetime().optional(),
   minSupply: z.string().regex(/^\d+$/).optional(),
@@ -54,10 +60,15 @@ function setCache(key: string, data: any) {
 
 /**
  * GET /api/tokens/search
- * Search and discover tokens with filters, sorting, and pagination
+ * Search and discover tokens with filters, sorting, and pagination.
+ * Results are always scoped to the requesting tenant (resolved via
+ * X-Tenant-ID header or JWT claim).
  */
-router.get("/search", async (req: Request, res: Response) => {
+router.get("/search", async (req: TenantRequest & Request, res: Response) => {
   try {
+    // req.tenant is guaranteed by tenantMiddleware({ required: true })
+    const tenantId = req.tenant!.id;
+
     // Validate parameters
     const validationResult = searchParamsSchema.safeParse(req.query);
 
@@ -71,8 +82,8 @@ router.get("/search", async (req: Request, res: Response) => {
 
     const params = validationResult.data;
 
-    // Check cache
-    const cacheKey = getCacheKey(params);
+    // Cache key includes tenantId so tenants never share cached slices
+    const cacheKey = getCacheKey({ ...params, tenantId });
     const cachedResult = getFromCache(cacheKey);
     if (cachedResult) {
       return res.json({
@@ -86,8 +97,12 @@ router.get("/search", async (req: Request, res: Response) => {
     const limit = Math.min(parseInt(params.limit), 50); // Max 50 per page
     const skip = (page - 1) * limit;
 
-    // Build where clause
-    const where: Prisma.TokenWhereInput = {};
+    // Build where clause — always scoped to the requesting tenant.
+    // The explicit `creator` query param is intentionally ignored: tenants may
+    // only query their own tokens, so the scope is always `creator = tenantId`.
+    const where: Prisma.TokenWhereInput = {
+      creator: tenantId,
+    };
 
     // Full-text search by name or symbol
     if (params.q) {
@@ -95,11 +110,6 @@ router.get("/search", async (req: Request, res: Response) => {
         { name: { contains: params.q, mode: "insensitive" } },
         { symbol: { contains: params.q, mode: "insensitive" } },
       ];
-    }
-
-    // Filter by creator
-    if (params.creator) {
-      where.creator = params.creator;
     }
 
     // Filter by creation date range
@@ -204,7 +214,7 @@ router.get("/search", async (req: Request, res: Response) => {
       },
       filters: {
         q: params.q,
-        creator: params.creator,
+        creator: undefined,
         startDate: params.startDate,
         endDate: params.endDate,
         minSupply: params.minSupply,

--- a/backend/src/services/leaderboardService.ts
+++ b/backend/src/services/leaderboardService.ts
@@ -1,5 +1,6 @@
 import { prisma } from "../lib/prisma";
 import { Prisma } from "@prisma/client";
+import { eventBus } from "./eventBus";
 
 export enum TimePeriod {
   H24 = "24h",
@@ -43,6 +44,7 @@ interface CacheEntry {
 }
 
 const cache = new Map<string, CacheEntry>();
+/** Safety-net TTL — entries are also evicted by event-driven invalidation. */
 const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
 
 function getCacheKey(
@@ -69,6 +71,44 @@ function getFromCache(key: string): LeaderboardResponse | null {
 function setCache(key: string, data: LeaderboardResponse): void {
   cache.set(key, { data, timestamp: Date.now() });
 }
+
+/**
+ * Invalidate all cache entries whose key starts with `type:`.
+ * Scoped to the affected leaderboard — does not flush unrelated boards.
+ */
+function invalidateCacheByType(type: string): void {
+  const prefix = `${type}:`;
+  for (const key of cache.keys()) {
+    if (key.startsWith(prefix)) {
+      cache.delete(key);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Event-driven cache invalidation
+// ---------------------------------------------------------------------------
+
+/**
+ * Leaderboard event names published by other services:
+ *   "burn.created"  — a BurnRecord was inserted  (payload: { tokenId })
+ *   "token.created" — a Token was created         (payload: { tokenId })
+ *
+ * Call `eventBus.publish("burn.created", { tokenId })` from the burn handler,
+ * and `eventBus.publish("token.created", { tokenId })` from the token handler.
+ */
+eventBus.subscribe<{ tokenId?: string }>("burn.created", () => {
+  // A burn affects burn-volume, burn-count, and unique-burner leaderboards.
+  invalidateCacheByType("most-burned");
+  invalidateCacheByType("most-active");
+  invalidateCacheByType("most-burners");
+});
+
+eventBus.subscribe<{ tokenId?: string }>("token.created", () => {
+  // A new token affects the newest and largest-supply leaderboards.
+  invalidateCacheByType("newest");
+  invalidateCacheByType("largest-supply");
+});
 
 function getDateFilter(period: TimePeriod): Date | null {
   if (period === TimePeriod.ALL) return null;


### PR DESCRIPTION
## Summary

- **#1111** – Versioned API route prefix (`/api/v1`). All routes mounted on a unified `v1Router` with `/api` kept as a backward-compat alias. Every response includes `X-API-Version: v1` header.
- **#1112** – Prometheus connection-pool health metrics (`db_connections_active`, `db_connections_idle`, `db_connections_waiting`, `db_pool_saturation`). New `poolMetrics.ts` attaches a Prisma middleware to track in-flight query concurrency as a pool-utilisation proxy.
- **#1113** – Tenant isolation for token data access. `tenantMiddleware({ required: true })` applied to the tokens router; every Prisma query is scoped to `creator = tenantId`. Cache keys namespaced per tenant so slices never bleed across tenants. Requests without a resolvable tenant are rejected with HTTP 400.
- **#1114** – Event-driven leaderboard cache invalidation. `leaderboardService` subscribes to `burn.created` and `token.created` events via the shared `eventBus` and invalidates only the affected leaderboard type (scoped, not global). The 5-minute TTL remains as a safety net.

## Changes

| File | What changed |
|------|-------------|
| `src/index.ts` | Unified `v1Router`, `/api/v1` canonical mount, `/api` compat alias, `registerPoolMetrics` call |
| `src/lib/metrics/index.ts` | Added `db_connections_waiting` + `db_pool_saturation` gauges; updated `MetricsCollector.updateDatabaseConnections` signature |
| `src/lib/metrics/poolMetrics.ts` | **New** – Prisma middleware that tracks in-flight queries → pool gauges |
| `src/routes/tokens.ts` | `tenantMiddleware({ required: true })`, tenant-scoped `creator` filter, tenant-namespaced cache keys |
| `src/routes/tokens.test.ts` | Updated to send `X-Tenant-ID` header; assertions include `creator` scope |
| `src/services/leaderboardService.ts` | Event subscriptions (`burn.created`, `token.created`), `invalidateCacheByType()`, TTL retained as fallback |

## Versioning policy

- `/api/v1/` is the canonical versioned prefix going forward.
- `/api/` is a permanent backward-compat alias pointing to the same router.
- The `X-API-Version: v1` header is set on every response from `v1Router`.
- Future breaking changes introduce `/api/v2` without removing v1.

## Pool metric names

| Metric | Type | Description |
|--------|------|-------------|
| `db_connections_active` | Gauge | In-flight queries (≤ pool size) |
| `db_connections_idle` | Gauge | Idle pool slots |
| `db_connections_waiting` | Gauge | Queries queued beyond pool capacity |
| `db_pool_saturation` | Gauge | `active / pool_size` (alert on > 0.8) |

Pool size configured via `DB_POOL_SIZE` env var (default: 10).

## Leaderboard invalidation triggers

| Event | Invalidated leaderboards |
|-------|--------------------------|
| `burn.created` | `most-burned`, `most-active`, `most-burners` |
| `token.created` | `newest`, `largest-supply` |

Publish these events from the burn/token write handlers:
```ts
await eventBus.publish("burn.created",  { tokenId });
await eventBus.publish("token.created", { tokenId });
```

Closes #1111
Closes #1112
Closes #1113
Closes #1114

🤖 Generated with [Claude Code](https://claude.com/claude-code)