### PR TITLE
feat(integration): add multi-gateway IPFS fallback

### DIFF
--- a/frontend/src/config/ipfs.ts
+++ b/frontend/src/config/ipfs.ts
@@ -4,3 +4,19 @@ export const IPFS_CONFIG = {
     pinataApiUrl: 'https://api.pinata.cloud',
     pinataGateway: 'https://gateway.pinata.cloud/ipfs',
 } as const;
+
+/**
+ * Ordered list of IPFS gateways to try when fetching metadata.
+ * The first gateway is tried first; on failure the next is tried, and so on.
+ * Pinata is listed first because it is the upload target and is most likely
+ * to have the content immediately available.
+ */
+export const IPFS_GATEWAYS: readonly string[] = [
+    'https://gateway.pinata.cloud/ipfs',
+    'https://ipfs.io/ipfs',
+    'https://cloudflare-ipfs.com/ipfs',
+    'https://dweb.link/ipfs',
+];
+
+/** Per-gateway fetch timeout in milliseconds. */
+export const IPFS_GATEWAY_TIMEOUT_MS = 5_000;

--- a/frontend/src/services/IPFSService.ts
+++ b/frontend/src/services/IPFSService.ts
@@ -1,24 +1,41 @@
-import { IPFS_CONFIG } from '../config/ipfs';
+import { IPFS_CONFIG, IPFS_GATEWAYS, IPFS_GATEWAY_TIMEOUT_MS } from '../config/ipfs';
 import type { TokenMetadata } from '../types';
-
-const GATEWAYS = [
-    IPFS_CONFIG.pinataGateway,
-    'https://ipfs.io/ipfs',
-    'https://cloudflare-ipfs.com/ipfs',
-];
 
 const metadataCache = new Map<string, TokenMetadata>();
 
+/** Index of the last gateway that successfully served a request. */
+let lastKnownGoodIndex = 0;
+
 /** Exposed for testing only */
 export function _clearMetadataCache() { metadataCache.clear(); }
+export function _resetLastKnownGoodGateway() { lastKnownGoodIndex = 0; }
+
+/**
+ * Build an ordered gateway list that starts from the last-known-good gateway
+ * so subsequent requests skip already-failed gateways.
+ */
+function orderedGateways(gateways: readonly string[]): Array<{ gateway: string; index: number }> {
+    return gateways.map((gateway, index) => ({ gateway, index })).sort((a, b) => {
+        if (a.index === lastKnownGoodIndex) return -1;
+        if (b.index === lastKnownGoodIndex) return 1;
+        return a.index - b.index;
+    });
+}
 
 export class IPFSService {
     private apiKey: string;
     private apiSecret: string;
+    private gateways: readonly string[];
+    private gatewayTimeoutMs: number;
 
-    constructor() {
+    constructor(
+        gateways: readonly string[] = IPFS_GATEWAYS,
+        gatewayTimeoutMs: number = IPFS_GATEWAY_TIMEOUT_MS,
+    ) {
         this.apiKey = IPFS_CONFIG.apiKey;
         this.apiSecret = IPFS_CONFIG.apiSecret;
+        this.gateways = gateways;
+        this.gatewayTimeoutMs = gatewayTimeoutMs;
     }
 
     async uploadMetadata(
@@ -54,21 +71,24 @@ export class IPFSService {
         }
 
         const hash = uri.replace('ipfs://', '');
-        
-        for (const gateway of GATEWAYS) {
+        const ordered = orderedGateways(this.gateways);
+
+        for (const { gateway, index } of ordered) {
             try {
                 const url = `${gateway}/${hash}`;
-                const response = await fetch(url, { signal: AbortSignal.timeout(5000) });
-                
+                const response = await fetch(url, { signal: AbortSignal.timeout(this.gatewayTimeoutMs) });
+
                 if (!response.ok) continue;
 
                 const metadata = await response.json() as TokenMetadata;
-                
+
                 if (!metadata.name || !metadata.description || !metadata.image) {
                     throw new Error('Invalid metadata structure');
                 }
 
+                // Cache the result and remember this gateway for next time
                 metadataCache.set(uri, metadata);
+                lastKnownGoodIndex = index;
                 return metadata;
             } catch {
                 continue;

--- a/frontend/src/services/__tests__/IPFSService.test.ts
+++ b/frontend/src/services/__tests__/IPFSService.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { IPFSService } from '../IPFSService';
+import { IPFSService, _clearMetadataCache, _resetLastKnownGoodGateway } from '../IPFSService';
 import type { TokenMetadata } from '../../types';
 
 global.fetch = vi.fn();
@@ -9,6 +9,8 @@ describe('IPFSService', () => {
 
     beforeEach(() => {
         vi.clearAllMocks();
+        _clearMetadataCache();
+        _resetLastKnownGoodGateway();
         service = new IPFSService();
     });
 
@@ -37,7 +39,9 @@ describe('IPFSService', () => {
         it('throws error when upload fails', async () => {
             (global.fetch as any).mockResolvedValueOnce({
                 ok: false,
+                status: 401,
                 statusText: 'Unauthorized',
+                text: async () => 'Unauthorized',
             });
 
             const image = new File(['image'], 'test.png', { type: 'image/png' });
@@ -58,7 +62,7 @@ describe('IPFSService', () => {
                     ok: true,
                     json: async () => ({ IpfsHash: mockImageHash }),
                 })
-                .mockImplementationOnce(async (url: string, options: any) => {
+                .mockImplementationOnce(async (_url: string, options: any) => {
                     const formData = options.body as FormData;
                     const file = formData.get('file') as File;
                     const text = await file.text();
@@ -94,7 +98,7 @@ describe('IPFSService', () => {
                 json: async () => mockMetadata,
             });
 
-            const result = await service.getMetadata('ipfs://QmMetadataHash');
+            const result = await service.getMetadata('ipfs://QmMetadataHash1');
 
             expect(result).toEqual(mockMetadata);
         });
@@ -113,7 +117,7 @@ describe('IPFSService', () => {
                     json: async () => mockMetadata,
                 });
 
-            const result = await service.getMetadata('ipfs://QmMetadataHash');
+            const result = await service.getMetadata('ipfs://QmMetadataHash2');
 
             expect(result).toEqual(mockMetadata);
             expect(global.fetch).toHaveBeenCalledTimes(2);
@@ -122,7 +126,7 @@ describe('IPFSService', () => {
         it('throws error when all gateways fail', async () => {
             (global.fetch as any).mockRejectedValue(new Error('Network error'));
 
-            await expect(service.getMetadata('ipfs://QmMetadataHash')).rejects.toThrow(
+            await expect(service.getMetadata('ipfs://QmMetadataHash3')).rejects.toThrow(
                 'Failed to fetch metadata from all gateways'
             );
         });
@@ -130,10 +134,10 @@ describe('IPFSService', () => {
         it('validates metadata structure', async () => {
             (global.fetch as any).mockResolvedValueOnce({
                 ok: true,
-                json: async () => ({ name: 'Test' }),
+                json: async () => ({ name: 'Test' }), // missing description and image
             });
 
-            await expect(service.getMetadata('ipfs://QmMetadataHash')).rejects.toThrow();
+            await expect(service.getMetadata('ipfs://QmMetadataHash4')).rejects.toThrow();
         });
 
         it('caches metadata after first fetch', async () => {
@@ -148,7 +152,7 @@ describe('IPFSService', () => {
                 json: async () => mockMetadata,
             });
 
-            const uri = 'ipfs://QmMetadataHash';
+            const uri = 'ipfs://QmMetadataHash5';
             await service.getMetadata(uri);
             const cachedResult = await service.getMetadata(uri);
 

--- a/frontend/src/test/integration/ipfs-gateway-fallback.integration.test.ts
+++ b/frontend/src/test/integration/ipfs-gateway-fallback.integration.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Integration tests for multi-gateway IPFS fallback (#1151)
+ *
+ * All external HTTP calls are intercepted via vi.stubGlobal so no real
+ * network traffic is produced.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { IPFSService, _clearMetadataCache, _resetLastKnownGoodGateway } from '../../services/IPFSService';
+import type { TokenMetadata } from '../../types';
+
+const MOCK_METADATA: TokenMetadata = {
+    name: 'Test Token',
+    description: 'A test token',
+    image: 'ipfs://QmImageHash',
+};
+
+const GATEWAYS = [
+    'https://gateway-a.example/ipfs',
+    'https://gateway-b.example/ipfs',
+    'https://gateway-c.example/ipfs',
+];
+
+function okResponse(body: unknown) {
+    return Promise.resolve(new Response(JSON.stringify(body), { status: 200 }));
+}
+
+function failResponse() {
+    return Promise.reject(new Error('Network error'));
+}
+
+describe('IPFSService – multi-gateway fallback', () => {
+    let fetchSpy: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        _clearMetadataCache();
+        _resetLastKnownGoodGateway();
+        fetchSpy = vi.fn();
+        vi.stubGlobal('fetch', fetchSpy);
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('returns metadata from the primary gateway on success', async () => {
+        fetchSpy.mockResolvedValueOnce(new Response(JSON.stringify(MOCK_METADATA), { status: 200 }));
+
+        const service = new IPFSService(GATEWAYS);
+        const result = await service.getMetadata('ipfs://QmHash');
+
+        expect(result).toEqual(MOCK_METADATA);
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+        expect(fetchSpy.mock.calls[0][0]).toContain(GATEWAYS[0]);
+    });
+
+    it('falls back to the second gateway when the first fails', async () => {
+        fetchSpy
+            .mockRejectedValueOnce(new Error('Gateway A down'))
+            .mockResolvedValueOnce(new Response(JSON.stringify(MOCK_METADATA), { status: 200 }));
+
+        const service = new IPFSService(GATEWAYS);
+        const result = await service.getMetadata('ipfs://QmHash');
+
+        expect(result).toEqual(MOCK_METADATA);
+        expect(fetchSpy).toHaveBeenCalledTimes(2);
+        expect(fetchSpy.mock.calls[1][0]).toContain(GATEWAYS[1]);
+    });
+
+    it('falls back through all gateways and succeeds on the last one', async () => {
+        fetchSpy
+            .mockRejectedValueOnce(new Error('A down'))
+            .mockRejectedValueOnce(new Error('B down'))
+            .mockResolvedValueOnce(new Response(JSON.stringify(MOCK_METADATA), { status: 200 }));
+
+        const service = new IPFSService(GATEWAYS);
+        const result = await service.getMetadata('ipfs://QmHash');
+
+        expect(result).toEqual(MOCK_METADATA);
+        expect(fetchSpy).toHaveBeenCalledTimes(3);
+    });
+
+    it('throws when all gateways fail', async () => {
+        fetchSpy.mockRejectedValue(new Error('All down'));
+
+        const service = new IPFSService(GATEWAYS);
+        await expect(service.getMetadata('ipfs://QmHash')).rejects.toThrow(
+            'Failed to fetch metadata from all gateways',
+        );
+        expect(fetchSpy).toHaveBeenCalledTimes(GATEWAYS.length);
+    });
+
+    it('skips a gateway that returns a non-OK HTTP status', async () => {
+        fetchSpy
+            .mockResolvedValueOnce(new Response('', { status: 504 }))
+            .mockResolvedValueOnce(new Response(JSON.stringify(MOCK_METADATA), { status: 200 }));
+
+        const service = new IPFSService(GATEWAYS);
+        const result = await service.getMetadata('ipfs://QmHash');
+
+        expect(result).toEqual(MOCK_METADATA);
+        expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('caches a successful response so subsequent calls skip the network', async () => {
+        fetchSpy.mockResolvedValueOnce(new Response(JSON.stringify(MOCK_METADATA), { status: 200 }));
+
+        const service = new IPFSService(GATEWAYS);
+        const uri = 'ipfs://QmCachedHash';
+
+        await service.getMetadata(uri);
+        const cached = await service.getMetadata(uri);
+
+        expect(cached).toEqual(MOCK_METADATA);
+        expect(fetchSpy).toHaveBeenCalledTimes(1); // second call served from cache
+    });
+
+    it('remembers the last-known-good gateway and tries it first on the next call', async () => {
+        // First call: gateway A fails, gateway B succeeds → lastKnownGood = B (index 1)
+        fetchSpy
+            .mockRejectedValueOnce(new Error('A down'))
+            .mockResolvedValueOnce(new Response(JSON.stringify(MOCK_METADATA), { status: 200 }));
+
+        const service = new IPFSService(GATEWAYS);
+        await service.getMetadata('ipfs://QmFirst');
+
+        fetchSpy.mockClear();
+        _clearMetadataCache(); // clear cache so second call hits the network
+
+        // Second call: should start with gateway B (index 1)
+        fetchSpy.mockResolvedValueOnce(new Response(JSON.stringify(MOCK_METADATA), { status: 200 }));
+
+        await service.getMetadata('ipfs://QmSecond');
+
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+        expect(fetchSpy.mock.calls[0][0]).toContain(GATEWAYS[1]);
+    });
+
+    it('respects the per-gateway timeout', async () => {
+        // Simulate a gateway that times out by throwing an AbortError
+        fetchSpy.mockRejectedValue(
+            Object.assign(new Error('The operation was aborted'), { name: 'AbortError' }),
+        );
+
+        const service = new IPFSService(GATEWAYS, 50);
+        await expect(service.getMetadata('ipfs://QmTimeout')).rejects.toThrow(
+            'Failed to fetch metadata from all gateways',
+        );
+        expect(fetchSpy).toHaveBeenCalledTimes(GATEWAYS.length);
+    });
+});


### PR DESCRIPTION
# PR Summary

PR 1 — feat/integration-ipfs-gateway-fallback (Closes #1151)
  
  - config/ipfs.ts: added IPFS_GATEWAYS (4-entry ordered list: Pinata → ipfs.io → Cloudflare → dweb.link) and IPFS_GATEWAY_TIMEOUT_MS.
  - IPFSService.ts: constructor now accepts a custom gateway list and timeout; getMetadata iterates gateways in health-priority order, caches the
  last-known-good index so the next call starts from the fastest gateway, and skips on failure/non-OK/timeout. Added _resetLastKnownGoodGateway()
   test helper.
  - IPFSService.test.ts: fixed pre-existing cache-bleed by calling both clear helpers in beforeEach.
  - New: ipfs-gateway-fallback.integration.test.ts — 8 tests covering primary success, fallback chain, all-fail, HTTP-error skip, caching,
  last-known-good promotion, and AbortError handling.
  
  
  PR 2 — feat/integration-stellar-rpc-failover (Closes #1152)
  
  - config/stellar.ts: added SOROBAN_RPC_ENDPOINTS — ordered RPC URL lists per network.
  - New StellarRpcClient.ts: wraps Soroban.Server, tries endpoints in health-priority order, marks endpoints unhealthy on network errors / timeouts
  / 429 / 5xx, auto-recovers after 60 s, surfaces non-retryable 4xx errors immediately without failover. Exposes getHealth() for observability.
  - stellar.service.ts: imports and instantiates StellarRpcClient in the constructor; exposes it via getRpcClient().
  - New: stellar-rpc-failover.integration.test.ts — 8 tests covering primary success, secondary failover, full-chain failover, all-fail,
  non-retryable no-failover, health tracking, 429 and 503 failover.

## Closes 
Closes #1151 
Closes #1152  