### PR TITLE
feat(integration): fee-bump, webhook HMAC, IPFS pin monitor, network config validation

### DIFF
--- a/backend/src/__tests__/feeBump.integration.test.ts
+++ b/backend/src/__tests__/feeBump.integration.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Integration tests for fee-bump transactions (#1159).
+ * No live network or Stellar SDK required — Horizon is fully mocked.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  submitFeeBump,
+  DEFAULT_FEE_BUMP_CONFIG,
+  FeeBumpConfig,
+  HorizonServer,
+} from "../stellar-service-integration/feeBump.service";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const ORIGINAL_HASH = "abc123originalhash";
+const ORIGINAL_FEE = "100";
+
+const testConfig: FeeBumpConfig = {
+  ...DEFAULT_FEE_BUMP_CONFIG,
+  pendingThresholdMs: 50,
+  pollIntervalMs: 5,
+  maxPollAttempts: 3,
+};
+
+function makeHorizon(overrides: Partial<HorizonServer> = {}): HorizonServer {
+  return {
+    transactions: () => ({
+      transaction: () => ({
+        call: vi.fn().mockRejectedValue({ response: { status: 404 } }),
+      }),
+    }),
+    submitTransaction: vi.fn().mockResolvedValue({ hash: "feebumphash" }),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("submitFeeBump (#1159)", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns confirmed_original when the tx confirms before the threshold", async () => {
+    const mockCall = vi.fn().mockResolvedValue({ successful: true, hash: ORIGINAL_HASH });
+    const horizon: HorizonServer = {
+      transactions: () => ({ transaction: () => ({ call: mockCall }) }),
+      submitTransaction: vi.fn(),
+    };
+
+    const result = await submitFeeBump(
+      ORIGINAL_HASH,
+      ORIGINAL_FEE,
+      () => ({}),
+      horizon,
+      testConfig
+    );
+
+    expect(result.outcome).toBe("confirmed_original");
+    if (result.outcome === "confirmed_original") {
+      expect(result.hash).toBe(ORIGINAL_HASH);
+    }
+    expect(horizon.submitTransaction).not.toHaveBeenCalled();
+  });
+
+  it("submits a fee-bump when the tx remains pending past the threshold", async () => {
+    const notFound = { response: { status: 404 } };
+    const mockCall = vi.fn().mockRejectedValue(notFound);
+    const mockSubmit = vi.fn().mockResolvedValue({ hash: "feebumphash" });
+
+    const horizon: HorizonServer = {
+      transactions: () => ({ transaction: () => ({ call: mockCall }) }),
+      submitTransaction: mockSubmit,
+    };
+
+    const result = await submitFeeBump(
+      ORIGINAL_HASH,
+      ORIGINAL_FEE,
+      (fee) => ({ fee }),
+      horizon,
+      testConfig
+    );
+
+    expect(result.outcome).toBe("fee_bumped");
+    if (result.outcome === "fee_bumped") {
+      expect(result.originalHash).toBe(ORIGINAL_HASH);
+      expect(result.feeBumpHash).toBe("feebumphash");
+    }
+    expect(mockSubmit).toHaveBeenCalledOnce();
+  });
+
+  it("does not double-submit if the original confirms between poll and bump", async () => {
+    const notFound = { response: { status: 404 } };
+    let callCount = 0;
+
+    // First N calls → 404 (stuck), then confirmed
+    const mockCall = vi.fn().mockImplementation(() => {
+      callCount++;
+      if (callCount <= testConfig.maxPollAttempts) {
+        return Promise.reject(notFound);
+      }
+      return Promise.resolve({ successful: true, hash: ORIGINAL_HASH });
+    });
+
+    const mockSubmit = vi.fn();
+    const horizon: HorizonServer = {
+      transactions: () => ({ transaction: () => ({ call: mockCall }) }),
+      submitTransaction: mockSubmit,
+    };
+
+    const result = await submitFeeBump(
+      ORIGINAL_HASH,
+      ORIGINAL_FEE,
+      (fee) => ({ fee }),
+      horizon,
+      testConfig
+    );
+
+    expect(result.outcome).toBe("confirmed_original");
+    expect(mockSubmit).not.toHaveBeenCalled();
+  });
+
+  it("applies the fee multiplier correctly", async () => {
+    const notFound = { response: { status: 404 } };
+    const mockCall = vi.fn().mockRejectedValue(notFound);
+    let capturedFee: string | null = null;
+
+    const horizon: HorizonServer = {
+      transactions: () => ({ transaction: () => ({ call: mockCall }) }),
+      submitTransaction: vi.fn().mockResolvedValue({ hash: "bumphash" }),
+    };
+
+    const customConfig: FeeBumpConfig = { ...testConfig, feeMultiplier: 5 };
+    await submitFeeBump(
+      ORIGINAL_HASH,
+      ORIGINAL_FEE,
+      (fee) => { capturedFee = fee; return { fee }; },
+      horizon,
+      customConfig
+    );
+
+    expect(capturedFee).toBe(String(parseInt(ORIGINAL_FEE, 10) * 5));
+  });
+});

--- a/backend/src/__tests__/inbound-webhook-hmac.integration.test.ts
+++ b/backend/src/__tests__/inbound-webhook-hmac.integration.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Integration tests for inbound webhook HMAC verification (#1157).
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { Request, Response, NextFunction } from "express";
+import {
+  verifyInboundWebhookSignature,
+  WEBHOOK_SIGNATURE_HEADER,
+} from "../middleware/webhookSignature";
+import {
+  generateWebhookSignature,
+  generateWebhookSecret,
+} from "../utils/crypto";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeReq(body: string, signatureHeader?: string): Partial<Request> {
+  return {
+    headers: signatureHeader
+      ? { [WEBHOOK_SIGNATURE_HEADER]: signatureHeader }
+      : {},
+    body,
+    rawBody: body,
+  } as any;
+}
+
+interface MockRes {
+  res: Partial<Response>;
+  statusCode: number | null;
+  jsonBody: any;
+}
+
+function makeRes(): MockRes {
+  const state = { statusCode: null as number | null, jsonBody: null as any };
+
+  const res: Partial<Response> = {
+    status(code: number) {
+      state.statusCode = code;
+      return this as Response;
+    },
+    json(data: any) {
+      state.jsonBody = data;
+      return this as Response;
+    },
+  };
+
+  return {
+    res,
+    get statusCode() { return state.statusCode; },
+    get jsonBody() { return state.jsonBody; },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("verifyInboundWebhookSignature (#1157)", () => {
+  const secret = generateWebhookSecret();
+  const payload = JSON.stringify({ event: "token.created", data: { id: "abc" } });
+
+  it("calls next() for a valid signature", async () => {
+    const signature = generateWebhookSignature(payload, secret);
+    const req = makeReq(payload, signature);
+    const mock = makeRes();
+    const next = vi.fn() as unknown as NextFunction;
+
+    const middleware = verifyInboundWebhookSignature(async () => secret);
+    await middleware(req as Request, mock.res as Response, next);
+
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it("returns 401 when the signature header is missing", async () => {
+    const req = makeReq(payload);
+    const mock = makeRes();
+    const next = vi.fn() as unknown as NextFunction;
+
+    const middleware = verifyInboundWebhookSignature(async () => secret);
+    await middleware(req as Request, mock.res as Response, next);
+
+    expect(mock.statusCode).toBe(401);
+    expect(mock.jsonBody.error).toMatch(/missing/i);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when the signature is invalid (wrong secret)", async () => {
+    const signature = generateWebhookSignature(payload, "wrong-secret");
+    const req = makeReq(payload, signature);
+    const mock = makeRes();
+    const next = vi.fn() as unknown as NextFunction;
+
+    const middleware = verifyInboundWebhookSignature(async () => secret);
+    await middleware(req as Request, mock.res as Response, next);
+
+    expect(mock.statusCode).toBe(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when the payload has been tampered with", async () => {
+    const signature = generateWebhookSignature(payload, secret);
+    const tampered = payload.replace("abc", "xyz");
+    const req = makeReq(tampered, signature);
+    const mock = makeRes();
+    const next = vi.fn() as unknown as NextFunction;
+
+    const middleware = verifyInboundWebhookSignature(async () => secret);
+    await middleware(req as Request, mock.res as Response, next);
+
+    expect(mock.statusCode).toBe(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when the subscription secret cannot be resolved", async () => {
+    const signature = generateWebhookSignature(payload, secret);
+    const req = makeReq(payload, signature);
+    const mock = makeRes();
+    const next = vi.fn() as unknown as NextFunction;
+
+    const middleware = verifyInboundWebhookSignature(async () => null);
+    await middleware(req as Request, mock.res as Response, next);
+
+    expect(mock.statusCode).toBe(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 for a replayed (old) signature", async () => {
+    const oldTimestamp = Math.floor(Date.now() / 1000) - 600; // 10 min ago
+    const signature = generateWebhookSignature(payload, secret, oldTimestamp);
+    const req = makeReq(payload, signature);
+    const mock = makeRes();
+    const next = vi.fn() as unknown as NextFunction;
+
+    const middleware = verifyInboundWebhookSignature(async () => secret);
+    await middleware(req as Request, mock.res as Response, next);
+
+    expect(mock.statusCode).toBe(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/__tests__/ipfs-pin-monitor.integration.test.ts
+++ b/backend/src/__tests__/ipfs-pin-monitor.integration.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Integration tests for IPFS pin-status monitoring (#1158).
+ * Pinata API calls are mocked — no live network required.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  checkPinStatus,
+  verifyPin,
+  startPinMonitor,
+} from "../lib/ipfs/pinMonitor";
+
+const API_KEY = "test-api-key";
+const API_SECRET = "test-api-secret";
+
+describe("checkPinStatus (#1158)", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns pinned=true when Pinata reports count > 0", async () => {
+    (fetch as any).mockResolvedValue({
+      ok: true,
+      json: async () => ({ count: 1, rows: [{ ipfs_pin_hash: "QmABC" }] }),
+    });
+
+    const result = await checkPinStatus("QmABC", API_KEY, API_SECRET);
+
+    expect(result.pinned).toBe(true);
+    expect(result.cid).toBe("QmABC");
+    expect(result.error).toBeUndefined();
+  });
+
+  it("returns pinned=false when Pinata reports count=0", async () => {
+    (fetch as any).mockResolvedValue({
+      ok: true,
+      json: async () => ({ count: 0, rows: [] }),
+    });
+
+    const result = await checkPinStatus("QmMISSING", API_KEY, API_SECRET);
+
+    expect(result.pinned).toBe(false);
+  });
+
+  it("returns pinned=false with error on non-OK HTTP response", async () => {
+    (fetch as any).mockResolvedValue({ ok: false, status: 401 });
+
+    const result = await checkPinStatus("QmABC", API_KEY, API_SECRET);
+
+    expect(result.pinned).toBe(false);
+    expect(result.error).toMatch(/401/);
+  });
+
+  it("returns pinned=false with error on network failure", async () => {
+    (fetch as any).mockRejectedValue(new Error("network error"));
+
+    const result = await checkPinStatus("QmABC", API_KEY, API_SECRET);
+
+    expect(result.pinned).toBe(false);
+    expect(result.error).toMatch(/network error/);
+  });
+});
+
+describe("verifyPin (#1158)", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("resolves without error when the CID is pinned", async () => {
+    (fetch as any).mockResolvedValue({
+      ok: true,
+      json: async () => ({ count: 1 }),
+    });
+
+    await expect(verifyPin("QmABC", API_KEY, API_SECRET)).resolves.toBeUndefined();
+  });
+
+  it("throws when the CID is not pinned", async () => {
+    (fetch as any).mockResolvedValue({
+      ok: true,
+      json: async () => ({ count: 0 }),
+    });
+
+    await expect(verifyPin("QmMISSING", API_KEY, API_SECRET)).rejects.toThrow(
+      /Pin verification failed/
+    );
+  });
+});
+
+describe("startPinMonitor (#1158)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("calls onUnpinned for CIDs that are no longer pinned", async () => {
+    (fetch as any).mockResolvedValue({
+      ok: true,
+      json: async () => ({ count: 0 }),
+    });
+
+    const cids = new Set(["QmUNPINNED"]);
+    const onUnpinned = vi.fn();
+    const stop = startPinMonitor(cids, API_KEY, API_SECRET, onUnpinned, 1000);
+
+    await vi.advanceTimersByTimeAsync(1100);
+
+    expect(onUnpinned).toHaveBeenCalledWith("QmUNPINNED", undefined);
+    stop();
+  });
+
+  it("does not call onUnpinned for pinned CIDs", async () => {
+    (fetch as any).mockResolvedValue({
+      ok: true,
+      json: async () => ({ count: 1 }),
+    });
+
+    const cids = new Set(["QmPINNED"]);
+    const onUnpinned = vi.fn();
+    const stop = startPinMonitor(cids, API_KEY, API_SECRET, onUnpinned, 1000);
+
+    await vi.advanceTimersByTimeAsync(1100);
+
+    expect(onUnpinned).not.toHaveBeenCalled();
+    stop();
+  });
+
+  it("stops checking after stop() is called", async () => {
+    (fetch as any).mockResolvedValue({
+      ok: true,
+      json: async () => ({ count: 0 }),
+    });
+
+    const cids = new Set(["QmABC"]);
+    const onUnpinned = vi.fn();
+    const stop = startPinMonitor(cids, API_KEY, API_SECRET, onUnpinned, 1000);
+
+    stop();
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(onUnpinned).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/__tests__/networkConfigValidation.integration.test.ts
+++ b/backend/src/__tests__/networkConfigValidation.integration.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Integration tests for multi-network Stellar configuration validation (#1160).
+ */
+
+import { describe, it, expect } from "vitest";
+import { validateNetworkConfig } from "../config/startupValidation";
+import { BackendEnv } from "../config/env";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeEnv(overrides: Partial<BackendEnv> = {}): BackendEnv {
+  return {
+    NODE_ENV: "test",
+    PORT: 3001,
+    STELLAR_NETWORK: "testnet",
+    STELLAR_HORIZON_URL: "https://horizon-testnet.stellar.org",
+    STELLAR_SOROBAN_RPC_URL: "https://soroban-testnet.stellar.org",
+    STELLAR_NETWORK_PASSPHRASE: "Test SDF Network ; September 2015",
+    FACTORY_CONTRACT_ID: "",
+    DATABASE_URL: "postgresql://localhost/test",
+    JWT_SECRET: "test-secret",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("validateNetworkConfig (#1160)", () => {
+  it("passes for a consistent testnet configuration", () => {
+    expect(() => validateNetworkConfig(makeEnv())).not.toThrow();
+  });
+
+  it("passes for a consistent mainnet configuration", () => {
+    const env = makeEnv({
+      STELLAR_NETWORK: "mainnet",
+      STELLAR_HORIZON_URL: "https://horizon.stellar.org",
+      STELLAR_SOROBAN_RPC_URL: "https://soroban-mainnet.stellar.org",
+      STELLAR_NETWORK_PASSPHRASE: "Public Global Stellar Network ; September 2015",
+      FACTORY_CONTRACT_ID: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+    });
+    expect(() => validateNetworkConfig(env)).not.toThrow();
+  });
+
+  it("throws when the passphrase does not match the network", () => {
+    const env = makeEnv({
+      STELLAR_NETWORK_PASSPHRASE: "Public Global Stellar Network ; September 2015",
+    });
+    expect(() => validateNetworkConfig(env)).toThrow(/passphrase mismatch/i);
+  });
+
+  it("throws when Horizon URL points at the opposite network", () => {
+    const env = makeEnv({
+      STELLAR_HORIZON_URL: "https://horizon.stellar.org", // mainnet URL on testnet config
+    });
+    expect(() => validateNetworkConfig(env)).toThrow(/mainnet/);
+  });
+
+  it("throws when Soroban RPC URL points at the opposite network", () => {
+    const env = makeEnv({
+      STELLAR_SOROBAN_RPC_URL: "https://soroban-mainnet.stellar.org",
+    });
+    expect(() => validateNetworkConfig(env)).toThrow(/mainnet/);
+  });
+
+  it("throws when mainnet is configured without a contract address", () => {
+    const env = makeEnv({
+      STELLAR_NETWORK: "mainnet",
+      STELLAR_HORIZON_URL: "https://horizon.stellar.org",
+      STELLAR_SOROBAN_RPC_URL: "https://soroban-mainnet.stellar.org",
+      STELLAR_NETWORK_PASSPHRASE: "Public Global Stellar Network ; September 2015",
+      FACTORY_CONTRACT_ID: "", // missing
+    });
+    expect(() => validateNetworkConfig(env)).toThrow(/FACTORY_CONTRACT_ID/);
+  });
+
+  it("throws for an unknown network value", () => {
+    const env = makeEnv({ STELLAR_NETWORK: "devnet" as any });
+    expect(() => validateNetworkConfig(env)).toThrow(/Unknown STELLAR_NETWORK/);
+  });
+});

--- a/backend/src/config/startupValidation.ts
+++ b/backend/src/config/startupValidation.ts
@@ -1,7 +1,18 @@
 /**
- * Backend startup validation — checks live reachability of external dependencies.
+ * Backend startup validation — checks live reachability of external dependencies
+ * and validates that the multi-network Stellar configuration is internally
+ * consistent (passphrase ↔ RPC URL ↔ contract address).
+ *
  * Call runStartupValidation() after validateEnv() and before app.listen().
- * Throws with a clear message if any critical dependency is unreachable.
+ * Throws with a clear message if any critical dependency is unreachable or
+ * if the network configuration is mismatched.
+ *
+ * Validation rules (#1160):
+ *  1. STELLAR_NETWORK_PASSPHRASE must match the canonical passphrase for the
+ *     configured STELLAR_NETWORK (testnet / mainnet).
+ *  2. STELLAR_HORIZON_URL and STELLAR_SOROBAN_RPC_URL must not point at the
+ *     opposite network's well-known hostnames.
+ *  3. FACTORY_CONTRACT_ID must be set when STELLAR_NETWORK is "mainnet".
  */
 import { BackendEnv } from './env';
 
@@ -44,8 +55,76 @@ async function checkDatabase(url: string): Promise<void> {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Multi-network Stellar configuration validation (#1160)
+// ---------------------------------------------------------------------------
+
+const NETWORK_CANONICAL: Record<string, { passphrase: string; horizonHost: string; sorobanHost: string }> = {
+  testnet: {
+    passphrase: 'Test SDF Network ; September 2015',
+    horizonHost: 'horizon-testnet.stellar.org',
+    sorobanHost: 'soroban-testnet.stellar.org',
+  },
+  mainnet: {
+    passphrase: 'Public Global Stellar Network ; September 2015',
+    horizonHost: 'horizon.stellar.org',
+    sorobanHost: 'soroban-mainnet.stellar.org',
+  },
+};
+
+/**
+ * Validate that the Stellar network passphrase, RPC URLs, and contract address
+ * are mutually consistent.  Throws with a descriptive message on mismatch.
+ */
+export function validateNetworkConfig(env: BackendEnv): void {
+  const network = env.STELLAR_NETWORK;
+  const canonical = NETWORK_CANONICAL[network];
+
+  if (!canonical) {
+    throw new Error(`Unknown STELLAR_NETWORK value: "${network}". Must be "testnet" or "mainnet".`);
+  }
+
+  // 1. Passphrase must match the canonical value for the network
+  if (env.STELLAR_NETWORK_PASSPHRASE !== canonical.passphrase) {
+    throw new Error(
+      `Network passphrase mismatch for "${network}".\n` +
+      `  Expected : "${canonical.passphrase}"\n` +
+      `  Configured: "${env.STELLAR_NETWORK_PASSPHRASE}"\n` +
+      `Ensure STELLAR_NETWORK_PASSPHRASE matches STELLAR_NETWORK.`
+    );
+  }
+
+  // 2. Horizon URL must not point at the opposite network
+  const oppositeNetwork = network === 'testnet' ? 'mainnet' : 'testnet';
+  const opposite = NETWORK_CANONICAL[oppositeNetwork];
+
+  if (env.STELLAR_HORIZON_URL.includes(opposite.horizonHost)) {
+    throw new Error(
+      `STELLAR_HORIZON_URL points at ${oppositeNetwork} ("${env.STELLAR_HORIZON_URL}") ` +
+      `but STELLAR_NETWORK is "${network}". Fix the URL or the network setting.`
+    );
+  }
+
+  if (env.STELLAR_SOROBAN_RPC_URL.includes(opposite.sorobanHost)) {
+    throw new Error(
+      `STELLAR_SOROBAN_RPC_URL points at ${oppositeNetwork} ("${env.STELLAR_SOROBAN_RPC_URL}") ` +
+      `but STELLAR_NETWORK is "${network}". Fix the URL or the network setting.`
+    );
+  }
+
+  // 3. Contract address must be set on mainnet
+  if (network === 'mainnet' && !env.FACTORY_CONTRACT_ID) {
+    throw new Error(
+      'FACTORY_CONTRACT_ID must be set when STELLAR_NETWORK is "mainnet".'
+    );
+  }
+}
+
 export async function runStartupValidation(env: BackendEnv): Promise<void> {
   const isProduction = env.NODE_ENV === 'production';
+
+  // Fail fast on network config mismatch — always, regardless of environment
+  validateNetworkConfig(env);
 
   const checks = await Promise.all([
     probe('Stellar Horizon', () => checkHorizon(env.STELLAR_HORIZON_URL)),

--- a/backend/src/lib/ipfs/pinMonitor.ts
+++ b/backend/src/lib/ipfs/pinMonitor.ts
@@ -1,0 +1,104 @@
+/**
+ * IPFS pin-status monitor (#1158).
+ *
+ * Responsibilities:
+ *  1. Verify a pin succeeded immediately after upload (verifyPin).
+ *  2. Periodically check that tracked CIDs remain pinned (startMonitor).
+ *  3. Emit an alert (via the onUnpinned callback) when content is not pinned.
+ *
+ * Check interval: controlled by PIN_MONITOR_INTERVAL_MS env var (default 5 min).
+ */
+
+const DEFAULT_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+const PINATA_GATEWAY = "https://api.pinata.cloud";
+
+export interface PinStatusResult {
+  cid: string;
+  pinned: boolean;
+  error?: string;
+}
+
+export type UnpinnedAlertHandler = (cid: string, error?: string) => void;
+
+/**
+ * Check whether a single CID is currently pinned via the Pinata API.
+ */
+export async function checkPinStatus(
+  cid: string,
+  apiKey: string,
+  apiSecret: string
+): Promise<PinStatusResult> {
+  try {
+    const url = `${PINATA_GATEWAY}/data/pinList?hashContains=${encodeURIComponent(cid)}&status=pinned`;
+    const res = await fetch(url, {
+      headers: {
+        pinata_api_key: apiKey,
+        pinata_secret_api_key: apiSecret,
+      },
+      signal: AbortSignal.timeout(10_000),
+    });
+
+    if (!res.ok) {
+      return { cid, pinned: false, error: `Pinata API error: HTTP ${res.status}` };
+    }
+
+    const data = (await res.json()) as { count: number };
+    return { cid, pinned: data.count > 0 };
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return { cid, pinned: false, error };
+  }
+}
+
+/**
+ * Verify that a CID is pinned immediately after upload.
+ * Throws if the pin cannot be confirmed.
+ */
+export async function verifyPin(
+  cid: string,
+  apiKey: string,
+  apiSecret: string
+): Promise<void> {
+  const result = await checkPinStatus(cid, apiKey, apiSecret);
+  if (!result.pinned) {
+    throw new Error(
+      `Pin verification failed for CID ${cid}${result.error ? `: ${result.error}` : ""}`
+    );
+  }
+}
+
+/**
+ * Start a periodic monitor that checks all tracked CIDs and calls
+ * onUnpinned for any that are no longer pinned.
+ *
+ * @param cids         Set of CIDs to monitor (mutated externally to add/remove)
+ * @param apiKey       Pinata API key
+ * @param apiSecret    Pinata API secret
+ * @param onUnpinned   Alert handler called when a CID is found unpinned
+ * @param intervalMs   Check interval in milliseconds (default: 5 min)
+ * @returns            A stop function that cancels the monitor
+ */
+export function startPinMonitor(
+  cids: Set<string>,
+  apiKey: string,
+  apiSecret: string,
+  onUnpinned: UnpinnedAlertHandler,
+  intervalMs: number = parseInt(
+    process.env.PIN_MONITOR_INTERVAL_MS ?? String(DEFAULT_INTERVAL_MS),
+    10
+  )
+): () => void {
+  const timer = setInterval(async () => {
+    for (const cid of cids) {
+      const result = await checkPinStatus(cid, apiKey, apiSecret);
+      if (!result.pinned) {
+        onUnpinned(cid, result.error);
+      }
+    }
+  }, intervalMs);
+
+  // Allow the process to exit even if the timer is still running
+  if (timer.unref) timer.unref();
+
+  return () => clearInterval(timer);
+}

--- a/backend/src/middleware/webhookSignature.ts
+++ b/backend/src/middleware/webhookSignature.ts
@@ -1,0 +1,73 @@
+/**
+ * Middleware: verify HMAC signature on inbound webhook payloads (#1157).
+ *
+ * Usage:
+ *   router.post('/inbound', verifyInboundWebhookSignature(getSecret), handler)
+ *
+ * The caller supplies a `getSecret` function that resolves the shared secret
+ * for the given request (e.g. looked up by subscription ID in the path/query).
+ * The middleware reads the raw body, verifies the `X-Webhook-Signature` header,
+ * and rejects with 401 if the signature is missing or invalid.
+ *
+ * Signing scheme (identical to outbound):
+ *   header = "v1.<timestamp>.<hmac-sha256-hex>"
+ *   signed_message = "<timestamp>.<raw_body_string>"
+ */
+
+import { Request, Response, NextFunction } from "express";
+import { verifyWebhookSignature } from "../utils/crypto";
+
+export const WEBHOOK_SIGNATURE_HEADER = "x-webhook-signature";
+
+/**
+ * Returns an Express middleware that verifies the inbound HMAC signature.
+ *
+ * @param getSecret  Async function that receives the request and returns the
+ *                   shared secret to verify against, or null/undefined to skip
+ *                   verification (e.g. when the subscription is not found).
+ */
+export function verifyInboundWebhookSignature(
+  getSecret: (req: Request) => Promise<string | null | undefined>
+): (req: Request, res: Response, next: NextFunction) => Promise<void> {
+  return async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    const signatureHeader =
+      req.headers[WEBHOOK_SIGNATURE_HEADER] as string | undefined;
+
+    if (!signatureHeader) {
+      res.status(401).json({
+        success: false,
+        error: "Missing webhook signature header",
+      });
+      return;
+    }
+
+    // Raw body must be available (set by express.raw() or similar)
+    const rawBody: string =
+      (req as any).rawBody ??
+      (typeof req.body === "string"
+        ? req.body
+        : JSON.stringify(req.body));
+
+    const secret = await getSecret(req);
+
+    if (!secret) {
+      res.status(401).json({
+        success: false,
+        error: "Unknown webhook subscription",
+      });
+      return;
+    }
+
+    const valid = verifyWebhookSignature(rawBody, signatureHeader, secret);
+
+    if (!valid) {
+      res.status(401).json({
+        success: false,
+        error: "Invalid webhook signature",
+      });
+      return;
+    }
+
+    next();
+  };
+}

--- a/backend/src/stellar-service-integration/feeBump.service.ts
+++ b/backend/src/stellar-service-integration/feeBump.service.ts
@@ -1,0 +1,140 @@
+/**
+ * Fee-bump service for stuck Stellar transactions (#1159).
+ *
+ * A transaction is considered "stuck" when it has been pending for longer than
+ * pendingThresholdMs (default 60 s). The service wraps the original envelope in
+ * a fee-bump transaction that pays a higher fee, then submits it.
+ * If the original confirms before the bump is submitted the service detects the
+ * success and skips the bump to avoid double-submission.
+ *
+ * Threshold: controlled by FEE_BUMP_PENDING_THRESHOLD_MS env var (default 60 s).
+ *
+ * The service accepts a HorizonServer interface so callers (and tests) can
+ * inject any compatible implementation without importing the SDK directly.
+ */
+
+import { sleep } from "./rate-limiter";
+
+// ---------------------------------------------------------------------------
+// Minimal interface — only the Horizon methods we actually call
+// ---------------------------------------------------------------------------
+
+export interface HorizonTransactionRecord {
+  successful?: boolean;
+  hash: string;
+}
+
+export interface HorizonServer {
+  transactions(): {
+    transaction(hash: string): { call(): Promise<HorizonTransactionRecord> };
+  };
+  submitTransaction(tx: unknown): Promise<{ hash: string }>;
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface FeeBumpConfig {
+  /** How long (ms) to wait before considering a tx stuck. Default: 60_000 */
+  pendingThresholdMs: number;
+  /** Multiplier applied to the original fee. Default: 10 */
+  feeMultiplier: number;
+  /** How many times to poll before giving up. Default: 20 */
+  maxPollAttempts: number;
+  /** Interval between polls (ms). Default: 3_000 */
+  pollIntervalMs: number;
+  /** Stellar network passphrase */
+  networkPassphrase: string;
+}
+
+export const DEFAULT_FEE_BUMP_CONFIG: FeeBumpConfig = {
+  pendingThresholdMs:
+    parseInt(process.env.FEE_BUMP_PENDING_THRESHOLD_MS ?? "60000", 10),
+  feeMultiplier: 10,
+  maxPollAttempts: 20,
+  pollIntervalMs: 3_000,
+  networkPassphrase: "Test SDF Network ; September 2015",
+};
+
+export type FeeBumpResult =
+  | { outcome: "confirmed_original"; hash: string }
+  | { outcome: "fee_bumped"; originalHash: string; feeBumpHash: string }
+  | { outcome: "timeout"; hash: string };
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+async function pollUntilConfirmedOrStuck(
+  horizon: HorizonServer,
+  txHash: string,
+  config: FeeBumpConfig
+): Promise<boolean> {
+  const deadline = Date.now() + config.pendingThresholdMs;
+
+  for (let i = 0; i < config.maxPollAttempts; i++) {
+    if (Date.now() >= deadline) break;
+
+    try {
+      const tx = await horizon.transactions().transaction(txHash).call();
+      if (tx.successful !== undefined) return true;
+    } catch (err: any) {
+      if (err?.response?.status !== 404) throw err;
+    }
+
+    await sleep(config.pollIntervalMs);
+  }
+
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Submit a fee-bump wrapping the given inner transaction.
+ *
+ * @param innerTx          The original (inner) transaction object
+ * @param originalHash     Hex hash of the inner transaction
+ * @param originalFee      Fee string of the inner transaction (in stroops)
+ * @param buildFeeBumpTx   Factory that builds and signs the fee-bump tx
+ * @param horizon          Horizon server instance
+ * @param config           Fee-bump configuration
+ */
+export async function submitFeeBump(
+  originalHash: string,
+  originalFee: string,
+  buildFeeBumpTx: (bumpFee: string) => unknown,
+  horizon: HorizonServer,
+  config: FeeBumpConfig = DEFAULT_FEE_BUMP_CONFIG
+): Promise<FeeBumpResult> {
+  // Poll to see if the original already confirmed
+  const alreadyConfirmed = await pollUntilConfirmedOrStuck(
+    horizon,
+    originalHash,
+    config
+  );
+
+  if (alreadyConfirmed) {
+    return { outcome: "confirmed_original", hash: originalHash };
+  }
+
+  // Build the fee-bump transaction
+  const bumpFee = String(parseInt(originalFee, 10) * config.feeMultiplier);
+  const feeBumpTx = buildFeeBumpTx(bumpFee);
+
+  // Race-condition guard: check once more before submitting
+  try {
+    const check = await horizon.transactions().transaction(originalHash).call();
+    if (check.successful !== undefined) {
+      return { outcome: "confirmed_original", hash: originalHash };
+    }
+  } catch (err: any) {
+    if (err?.response?.status !== 404) throw err;
+  }
+
+  const response = await horizon.submitTransaction(feeBumpTx);
+  return { outcome: "fee_bumped", originalHash, feeBumpHash: response.hash };
+}


### PR DESCRIPTION
## Summary

This PR implements four integration tasks in a single focused change. All 26 new tests pass with fully mocked external services.

---

### #1159 — Fee-bump transactions for stuck Stellar submissions

**File:** `backend/src/stellar-service-integration/feeBump.service.ts`

- `submitFeeBump()` polls Horizon until `pendingThresholdMs` elapses (default 60 s, configurable via `FEE_BUMP_PENDING_THRESHOLD_MS`), then wraps the original transaction in a fee-bump paying `originalFee × feeMultiplier` (default ×10).
- Race-condition guard: performs a final check before submitting to avoid double-submission if the original confirms between the last poll and the bump.
- Returns a discriminated union: `confirmed_original | fee_bumped | timeout`.
- Accepts a `HorizonServer` interface for easy injection/mocking.

**Tests:** `backend/src/__tests__/feeBump.integration.test.ts` (4 tests)

---

### #1157 — HMAC signature verification for inbound/outbound webhook payloads

**File:** `backend/src/middleware/webhookSignature.ts`

- `verifyInboundWebhookSignature(getSecret)` Express middleware verifies the `X-Webhook-Signature` header using the existing `v1.<timestamp>.<hmac-sha256-hex>` scheme already used for outbound payloads.
- Rejects with **401** on: missing header, invalid signature, unknown subscription, or replayed payload (timestamp > 5 min old).
- Outbound signing was already implemented in `webhookService.ts` and `utils/crypto.ts`.

**Tests:** `backend/src/__tests__/inbound-webhook-hmac.integration.test.ts` (6 tests)

---

### #1158 — Monitor IPFS pin status and alert on unpinned metadata

**File:** `backend/src/lib/ipfs/pinMonitor.ts`

- `checkPinStatus(cid, apiKey, apiSecret)` — queries Pinata `/data/pinList` to verify a CID is pinned.
- `verifyPin(cid, ...)` — throws immediately after upload if the pin is not confirmed.
- `startPinMonitor(cids, ..., onUnpinned, intervalMs)` — periodic monitor (default 5 min, configurable via `PIN_MONITOR_INTERVAL_MS`) that calls `onUnpinned(cid, error?)` for any unpinned CID. Returns a `stop()` function.

**Tests:** `backend/src/__tests__/ipfs-pin-monitor.integration.test.ts` (9 tests)

---

### #1160 — Validate multi-network Stellar configuration at startup

**File:** `backend/src/config/startupValidation.ts`

- New `validateNetworkConfig(env)` (synchronous, exported) enforces three rules:
  1. `STELLAR_NETWORK_PASSPHRASE` must match the canonical passphrase for `STELLAR_NETWORK`.
  2. `STELLAR_HORIZON_URL` and `STELLAR_SOROBAN_RPC_URL` must not point at the opposite network's well-known hostnames.
  3. `FACTORY_CONTRACT_ID` must be set when `STELLAR_NETWORK` is `mainnet`.
- `runStartupValidation()` now calls `validateNetworkConfig()` first — mismatches fail fast in all environments before any live probes.

**Tests:** `backend/src/__tests__/networkConfigValidation.integration.test.ts` (7 tests)

---

## Verification

```
Test Files  4 passed (4)
Tests       26 passed (26)
```

All tests use mocked external services (Horizon, Pinata, Express). No live network required.

Closes #1159
Closes #1157
Closes #1158
Closes #1160