### PR TITLE
feat(wallet): add network mismatch warning banner in WalletConnect

### DIFF
--- a/frontend/src/components/WalletConnect/WalletInfo.test.tsx
+++ b/frontend/src/components/WalletConnect/WalletInfo.test.tsx
@@ -1,21 +1,23 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { WalletInfo } from './WalletInfo';
-import type { WalletState } from '../../types';
+﻿import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { WalletInfo } from "./WalletInfo";
+import type { WalletState } from "../../types";
 
-vi.mock('../../services/wallet', () => ({
+vi.mock("../../services/wallet", () => ({
     WalletService: {
-        getBalance: vi.fn(() => Promise.resolve('125.5000000')),
+        getBalance: vi.fn(() => Promise.resolve("125.5000000")),
     },
 }));
 
+vi.mock("../../../vite-env.d.ts", () => ({}));
+
 const mockWallet: WalletState = {
     connected: true,
-    address: 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5',
-    network: 'testnet',
+    address: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+    network: "testnet",
 };
 
-describe('WalletInfo', () => {
+describe("WalletInfo", () => {
     const mockDisconnect = vi.fn();
 
     beforeEach(() => {
@@ -23,13 +25,15 @@ describe('WalletInfo', () => {
         Object.assign(navigator, {
             clipboard: { writeText: vi.fn(() => Promise.resolve()) },
         });
+        // Reset env default
+        (import.meta.env as Record<string, unknown>).VITE_NETWORK = "testnet";
     });
 
-    it('renders nothing when wallet is not connected', () => {
+    it("renders nothing when wallet is not connected", () => {
         const disconnectedWallet: WalletState = {
             connected: false,
             address: null,
-            network: 'testnet',
+            network: "testnet",
         };
         const { container } = render(
             <WalletInfo wallet={disconnectedWallet} onDisconnect={mockDisconnect} />
@@ -37,64 +41,91 @@ describe('WalletInfo', () => {
         expect(container.firstChild).toBeNull();
     });
 
-    it('displays truncated wallet address', () => {
+    it("displays truncated wallet address", () => {
         render(<WalletInfo wallet={mockWallet} onDisconnect={mockDisconnect} />);
-        expect(screen.getByText('GBBD47...FLA5')).toBeInTheDocument();
+        expect(screen.getByText("GBBD47...FLA5")).toBeInTheDocument();
     });
 
-    it('shows the full address in a tooltip on hover', async () => {
+    it("shows the full address in a tooltip on hover", async () => {
         render(<WalletInfo wallet={mockWallet} onDisconnect={mockDisconnect} />);
-        const truncated = screen.getByText('GBBD47...FLA5');
+        const truncated = screen.getByText("GBBD47...FLA5");
         fireEvent.mouseEnter(truncated.parentElement!);
-
         await waitFor(() => {
-            expect(screen.getByRole('tooltip')).toHaveTextContent(mockWallet.address!);
+            expect(screen.getByRole("tooltip")).toHaveTextContent(mockWallet.address!);
         });
     });
 
-    it('displays XLM balance after loading', async () => {
+    it("displays XLM balance after loading", async () => {
         render(<WalletInfo wallet={mockWallet} onDisconnect={mockDisconnect} />);
-
         await waitFor(() => {
             expect(screen.getByText(/125\.50/)).toBeInTheDocument();
-            expect(screen.getByText('XLM')).toBeInTheDocument();
+            expect(screen.getByText("XLM")).toBeInTheDocument();
         });
     });
 
-    it('copies address to clipboard when copy button is clicked', async () => {
+    it("copies address to clipboard when copy button is clicked", async () => {
         render(<WalletInfo wallet={mockWallet} onDisconnect={mockDisconnect} />);
-
-        const copyButton = screen.getByLabelText('Copy address to clipboard');
+        const copyButton = screen.getByLabelText("Copy address to clipboard");
         fireEvent.click(copyButton);
-
         await waitFor(() => {
             expect(navigator.clipboard.writeText).toHaveBeenCalledWith(mockWallet.address);
         });
-
         await waitFor(() => {
-            expect(screen.getByLabelText('Address copied')).toBeInTheDocument();
+            expect(screen.getByLabelText("Address copied")).toBeInTheDocument();
         });
     });
 
-    it('calls onDisconnect when disconnect button is clicked', () => {
+    it("calls onDisconnect when disconnect button is clicked", () => {
         render(<WalletInfo wallet={mockWallet} onDisconnect={mockDisconnect} />);
-
-        const disconnectButton = screen.getByLabelText('Disconnect wallet');
+        const disconnectButton = screen.getByLabelText("Disconnect wallet");
         fireEvent.click(disconnectButton);
-
         expect(mockDisconnect).toHaveBeenCalledTimes(1);
     });
 
-    it('has proper accessibility attributes', () => {
+    it("has proper accessibility attributes", () => {
         render(<WalletInfo wallet={mockWallet} onDisconnect={mockDisconnect} />);
-
-        expect(screen.getByRole('region', { name: 'Wallet information' })).toBeInTheDocument();
-        expect(screen.getByLabelText('Disconnect wallet')).toBeInTheDocument();
-        expect(screen.getByLabelText('Copy address to clipboard')).toBeInTheDocument();
+        expect(screen.getByRole("region", { name: "Wallet information" })).toBeInTheDocument();
+        expect(screen.getByLabelText("Disconnect wallet")).toBeInTheDocument();
+        expect(screen.getByLabelText("Copy address to clipboard")).toBeInTheDocument();
     });
 
-    it('shows loading indicator while fetching balance', () => {
+    it("shows loading indicator while fetching balance", () => {
         render(<WalletInfo wallet={mockWallet} onDisconnect={mockDisconnect} />);
-        expect(screen.getByText('Loading...')).toBeInTheDocument();
+        expect(screen.getByText("Loading...")).toBeInTheDocument();
     });
+
+    // ── Network mismatch banner tests ──────────────────────────────────────
+
+    it("does NOT show mismatch banner when wallet network matches app network", () => {
+        (import.meta.env as Record<string, unknown>).VITE_NETWORK = "testnet";
+        render(<WalletInfo wallet={mockWallet} onDisconnect={mockDisconnect} />);
+        expect(screen.queryByRole("alert")).toBeNull();
+    });
+
+    it("shows mismatch banner when wallet network differs from app network", () => {
+        (import.meta.env as Record<string, unknown>).VITE_NETWORK = "mainnet";
+        render(<WalletInfo wallet={mockWallet} onDisconnect={mockDisconnect} />);
+        const banner = screen.getByRole("alert");
+        expect(banner).toBeInTheDocument();
+        expect(banner).toHaveTextContent("testnet");
+        expect(banner).toHaveTextContent("mainnet");
+        expect(banner).toHaveTextContent("Please switch networks in Freighter before continuing.");
+    });
+
+    it("hides the banner when dismiss button is clicked", () => {
+        (import.meta.env as Record<string, unknown>).VITE_NETWORK = "mainnet";
+        render(<WalletInfo wallet={mockWallet} onDisconnect={mockDisconnect} />);
+        expect(screen.getByRole("alert")).toBeInTheDocument();
+        const dismissBtn = screen.getByLabelText("Dismiss network mismatch warning");
+        fireEvent.click(dismissBtn);
+        expect(screen.queryByRole("alert")).toBeNull();
+    });
+
+    it("banner is case-insensitive when comparing networks", () => {
+        (import.meta.env as Record<string, unknown>).VITE_NETWORK = "TESTNET";
+        render(<WalletInfo wallet={mockWallet} onDisconnect={mockDisconnect} />);
+        // wallet.network is "testnet", VITE_NETWORK is "TESTNET" — should NOT show banner
+        expect(screen.queryByRole("alert")).toBeNull();
+    });
+
 });

--- a/frontend/src/components/WalletConnect/WalletInfo.tsx
+++ b/frontend/src/components/WalletConnect/WalletInfo.tsx
@@ -1,8 +1,8 @@
-import { useState, useEffect, useCallback } from 'react';
-import { Button, Tooltip } from '../UI';
-import { WalletService } from '../../services/wallet';
-import { truncateAddress, formatXLM } from '../../utils/formatting';
-import type { WalletState } from '../../types';
+﻿import { useState, useEffect, useCallback } from "react";
+import { Button, Tooltip } from "../UI";
+import { WalletService } from "../../services/wallet";
+import { truncateAddress, formatXLM } from "../../utils/formatting";
+import type { WalletState } from "../../types";
 
 interface WalletInfoProps {
     wallet: WalletState;
@@ -10,22 +10,30 @@ interface WalletInfoProps {
     className?: string;
 }
 
-export function WalletInfo({ wallet, onDisconnect, className = '' }: WalletInfoProps) {
+export function WalletInfo({ wallet, onDisconnect, className = "" }: WalletInfoProps) {
     const [balance, setBalance] = useState<string | null>(null);
     const [isLoadingBalance, setIsLoadingBalance] = useState(false);
     const [copied, setCopied] = useState(false);
     const [balanceError, setBalanceError] = useState<string | null>(null);
+    const [bannerDismissed, setBannerDismissed] = useState(false);
+
+    const appNetwork = import.meta.env.VITE_NETWORK as string | undefined;
+    const walletNetwork = wallet.network;
+    const showMismatchBanner =
+        !bannerDismissed &&
+        !!appNetwork &&
+        !!walletNetwork &&
+        appNetwork.toLowerCase() !== walletNetwork.toLowerCase();
 
     const fetchBalance = useCallback(async () => {
         if (!wallet.address) return;
-
         setIsLoadingBalance(true);
         setBalanceError(null);
         try {
             const bal = await WalletService.getBalance(wallet.address);
             setBalance(bal);
         } catch (err) {
-            const message = err instanceof Error ? err.message : 'Failed to fetch balance';
+            const message = err instanceof Error ? err.message : "Failed to fetch balance";
             setBalanceError(message);
             setBalance(null);
         } finally {
@@ -46,14 +54,13 @@ export function WalletInfo({ wallet, onDisconnect, className = '' }: WalletInfoP
             setCopied(true);
             setTimeout(() => setCopied(false), 2000);
         } catch {
-            // Fallback for older browsers
-            const textArea = document.createElement('textarea');
+            const textArea = document.createElement("textarea");
             textArea.value = wallet.address;
-            textArea.style.position = 'fixed';
-            textArea.style.opacity = '0';
+            textArea.style.position = "fixed";
+            textArea.style.opacity = "0";
             document.body.appendChild(textArea);
             textArea.select();
-            document.execCommand('copy');
+            document.execCommand("copy");
             document.body.removeChild(textArea);
             setCopied(true);
             setTimeout(() => setCopied(false), 2000);
@@ -65,88 +72,112 @@ export function WalletInfo({ wallet, onDisconnect, className = '' }: WalletInfoP
     }
 
     return (
-        <div
-            className={`flex items-center gap-2 rounded-xl bg-white/80 backdrop-blur-sm border border-gray-200 px-3 py-2 shadow-sm ${className}`}
-            role="region"
-            aria-label="Wallet information"
-        >
-            {/* Wallet icon */}
-            <div className="flex-shrink-0 w-8 h-8 rounded-full bg-blue-100 flex items-center justify-center">
-                <svg className="w-4 h-4 text-blue-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M21 12a2.25 2.25 0 00-2.25-2.25H15a3 3 0 11-6 0H5.25A2.25 2.25 0 003 12m18 0v6a2.25 2.25 0 01-2.25 2.25H5.25A2.25 2.25 0 013 18v-6m18 0V9M3 12V9m18 0a2.25 2.25 0 00-2.25-2.25H5.25A2.25 2.25 0 013 9m18 0V6a2.25 2.25 0 00-2.25-2.25H5.25A2.25 2.25 0 013 6v3" />
-                </svg>
-            </div>
-
-            {/* Address with copy */}
-            <div className="flex flex-col min-w-0">
-                <div className="flex items-center gap-1">
-                    <Tooltip content={wallet.address} position="bottom">
-                        <span
-                            className="text-sm font-mono font-medium text-gray-800 cursor-default"
-                            aria-label={`Wallet address: ${wallet.address}`}
-                        >
-                            {truncateAddress(wallet.address)}
+        <div className={`flex flex-col gap-2 ${className}`}>
+            {showMismatchBanner && (
+                <div
+                    role="alert"
+                    aria-live="polite"
+                    className="flex items-start justify-between gap-2 rounded-lg bg-yellow-50 border border-yellow-400 text-yellow-800 px-3 py-2 text-sm"
+                >
+                    <div className="flex items-start gap-2">
+                        <svg className="w-4 h-4 mt-0.5 flex-shrink-0 text-yellow-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
+                        </svg>
+                        <span>
+                            Your wallet is connected to <strong>{walletNetwork}</strong> but this app is configured for <strong>{appNetwork}</strong>. Please switch networks in Freighter before continuing.
                         </span>
-                    </Tooltip>
+                    </div>
                     <button
-                        onClick={copyAddress}
-                        className="p-1 rounded-md hover:bg-gray-100 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-1"
-                        aria-label={copied ? 'Address copied' : 'Copy address to clipboard'}
-                        title={copied ? 'Copied!' : 'Copy address'}
+                        onClick={() => setBannerDismissed(true)}
+                        className="flex-shrink-0 p-0.5 rounded hover:bg-yellow-100 focus:outline-none focus:ring-2 focus:ring-yellow-500"
+                        aria-label="Dismiss network mismatch warning"
                     >
-                        {copied ? (
-                            <svg className="w-3.5 h-3.5 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
-                                <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
-                            </svg>
-                        ) : (
-                            <svg className="w-3.5 h-3.5 text-gray-400 hover:text-gray-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                                <path strokeLinecap="round" strokeLinejoin="round" d="M15.666 3.888A2.25 2.25 0 0013.5 2.25h-3c-1.03 0-1.9.693-2.166 1.638m7.332 0c.055.194.084.4.084.612v0a.75.75 0 01-.75.75H9.75a.75.75 0 01-.75-.75v0c0-.212.03-.418.084-.612m7.332 0c.646.049 1.288.11 1.927.184 1.1.128 1.907 1.077 1.907 2.185V19.5a2.25 2.25 0 01-2.25 2.25H6.75A2.25 2.25 0 014.5 19.5V6.257c0-1.108.806-2.057 1.907-2.185a48.208 48.208 0 011.927-.184" />
-                            </svg>
-                        )}
+                        <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                        </svg>
                     </button>
                 </div>
+            )}
 
-                {/* Balance */}
-                <div className="text-xs text-gray-500">
-                    {isLoadingBalance ? (
-                        <span className="inline-flex items-center gap-1">
-                            <svg className="animate-spin h-3 w-3" viewBox="0 0 24 24">
-                                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
-                                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
-                            </svg>
-                            Loading...
-                        </span>
-                    ) : balanceError ? (
-                        <Tooltip content={balanceError} position="bottom">
-                            <button
-                                onClick={fetchBalance}
-                                className="text-amber-600 hover:text-amber-700 underline decoration-dotted cursor-pointer"
-                                aria-label="Balance unavailable, click to retry"
-                            >
-                                Balance unavailable
-                            </button>
-                        </Tooltip>
-                    ) : balance !== null ? (
-                        <span aria-label={`Balance: ${formatXLM(balance)} XLM`}>
-                            {formatXLM(balance)} <span className="text-gray-400 font-medium">XLM</span>
-                        </span>
-                    ) : null}
-                </div>
-            </div>
-
-            {/* Disconnect */}
-            <Button
-                variant="outline"
-                size="sm"
-                onClick={onDisconnect}
-                className="ml-1 flex-shrink-0 !border-gray-200 !text-gray-500 hover:!text-red-600 hover:!border-red-200 hover:!bg-red-50"
-                aria-label="Disconnect wallet"
+            <div
+                className="flex items-center gap-2 rounded-xl bg-white/80 backdrop-blur-sm border border-gray-200 px-3 py-2 shadow-sm"
+                role="region"
+                aria-label="Wallet information"
             >
-                <svg className="w-4 h-4 sm:mr-1.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0013.5 3h-6a2.25 2.25 0 00-2.25 2.25v13.5A2.25 2.25 0 007.5 21h6a2.25 2.25 0 002.25-2.25V15m3 0l3-3m0 0l-3-3m3 3H9" />
-                </svg>
-                <span className="hidden sm:inline">Disconnect</span>
-            </Button>
+                <div className="flex-shrink-0 w-8 h-8 rounded-full bg-blue-100 flex items-center justify-center">
+                    <svg className="w-4 h-4 text-blue-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M21 12a2.25 2.25 0 00-2.25-2.25H15a3 3 0 11-6 0H5.25A2.25 2.25 0 003 12m18 0v6a2.25 2.25 0 01-2.25 2.25H5.25A2.25 2.25 0 013 18v-6m18 0V9M3 12V9m18 0a2.25 2.25 0 00-2.25-2.25H5.25A2.25 2.25 0 013 9m18 0V6a2.25 2.25 0 00-2.25-2.25H5.25A2.25 2.25 0 013 6v3" />
+                    </svg>
+                </div>
+
+                <div className="flex flex-col min-w-0">
+                    <div className="flex items-center gap-1">
+                        <Tooltip content={wallet.address} position="bottom">
+                            <span
+                                className="text-sm font-mono font-medium text-gray-800 cursor-default"
+                                aria-label={`Wallet address: ${wallet.address}`}
+                            >
+                                {truncateAddress(wallet.address)}
+                            </span>
+                        </Tooltip>
+                        <button
+                            onClick={copyAddress}
+                            className="p-1 rounded-md hover:bg-gray-100 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-1"
+                            aria-label={copied ? "Address copied" : "Copy address to clipboard"}
+                            title={copied ? "Copied!" : "Copy address"}
+                        >
+                            {copied ? (
+                                <svg className="w-3.5 h-3.5 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+                                    <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
+                                </svg>
+                            ) : (
+                                <svg className="w-3.5 h-3.5 text-gray-400 hover:text-gray-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                                    <path strokeLinecap="round" strokeLinejoin="round" d="M15.666 3.888A2.25 2.25 0 0013.5 2.25h-3c-1.03 0-1.9.693-2.166 1.638m7.332 0c.055.194.084.4.084.612v0a.75.75 0 01-.75.75H9.75a.75.75 0 01-.75-.75v0c0-.212.03-.418.084-.612m7.332 0c.646.049 1.288.11 1.927.184 1.1.128 1.907 1.077 1.907 2.185V19.5a2.25 2.25 0 01-2.25 2.25H6.75A2.25 2.25 0 014.5 19.5V6.257c0-1.108.806-2.057 1.907-2.185a48.208 48.208 0 011.927-.184" />
+                                </svg>
+                            )}
+                        </button>
+                    </div>
+
+                    <div className="text-xs text-gray-500">
+                        {isLoadingBalance ? (
+                            <span className="inline-flex items-center gap-1">
+                                <svg className="animate-spin h-3 w-3" viewBox="0 0 24 24">
+                                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
+                                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+                                </svg>
+                                Loading...
+                            </span>
+                        ) : balanceError ? (
+                            <Tooltip content={balanceError} position="bottom">
+                                <button
+                                    onClick={fetchBalance}
+                                    className="text-amber-600 hover:text-amber-700 underline decoration-dotted cursor-pointer"
+                                    aria-label="Balance unavailable, click to retry"
+                                >
+                                    Balance unavailable
+                                </button>
+                            </Tooltip>
+                        ) : balance !== null ? (
+                            <span aria-label={`Balance: ${formatXLM(balance)} XLM`}>
+                                {formatXLM(balance)} <span className="text-gray-400 font-medium">XLM</span>
+                            </span>
+                        ) : null}
+                    </div>
+                </div>
+
+                <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={onDisconnect}
+                    className="ml-1 flex-shrink-0 !border-gray-200 !text-gray-500 hover:!text-red-600 hover:!border-red-200 hover:!bg-red-50"
+                    aria-label="Disconnect wallet"
+                >
+                    <svg className="w-4 h-4 sm:mr-1.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0013.5 3h-6a2.25 2.25 0 00-2.25 2.25v13.5A2.25 2.25 0 007.5 21h6a2.25 2.25 0 002.25-2.25V15m3 0l3-3m0 0l-3-3m3 3H9" />
+                    </svg>
+                    <span className="hidden sm:inline">Disconnect</span>
+                </Button>
+            </div>
         </div>
     );
 }


### PR DESCRIPTION
>> - Compare wallet.network against VITE_NETWORK env var
>> - Render amber warning banner when networks differ
>> - Banner includes wallet network, app network, and instructions
>> - Dismiss button hides banner for current session only
>> - Case-insensitive network comparison
>> - Add tests for match, mismatch, dismiss, and case-insensitivity
>>
>> Close #1218