### PR TITLE
feat(ui): add live character counter to MetadataStep description field

### DIFF
--- a/frontend/src/components/TokenDeployForm/MetadataStep.tsx
+++ b/frontend/src/components/TokenDeployForm/MetadataStep.tsx
@@ -128,8 +128,8 @@ export function MetadataStep({ onNext, onBack, initialData }: MetadataStepProps)
                                 />
                                 <div className="flex justify-between text-xs">
                                     <span className="text-gray-500">Optional</span>
-                                    <span className={remainingChars < 50 ? 'text-orange-600' : 'text-gray-500'}>
-                                        {remainingChars} characters remaining
+                                    <span className={remainingChars <= 50 ? 'text-red-500' : 'text-gray-500'}>
+                                        {remainingChars === 0 ? 'Character limit reached' : `${remainingChars} characters remaining`}
                                     </span>
                                 </div>
                             </div>

--- a/frontend/src/components/TokenDeployForm/__tests__/MetadataStep.test.tsx
+++ b/frontend/src/components/TokenDeployForm/__tests__/MetadataStep.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MetadataStep } from '../MetadataStep';
+import type { ImageValidationResult } from '../../../utils/imageValidation';
+
+// Mock ImageUpload to avoid file-picker complexity
+vi.mock('../../UI/ImageUpload', () => ({
+    ImageUpload: ({
+        onImageSelect,
+    }: {
+        onImageSelect: (file: File, result: ImageValidationResult) => void;
+        onImageRemove: () => void;
+        label: string;
+        helperText?: string;
+        required?: boolean;
+    }) => (
+        <button
+            data-testid="mock-image-upload"
+            onClick={() => {
+                const file = new File(['img'], 'token.png', { type: 'image/png' });
+                onImageSelect(file, { valid: true, warnings: [] });
+            }}
+        >
+            Select Image
+        </button>
+    ),
+}));
+
+const defaultProps = {
+    onNext: vi.fn(),
+    onBack: vi.fn(),
+};
+
+beforeEach(() => vi.clearAllMocks());
+
+// Helper: enable metadata toggle and return the textarea
+function enableMetadata() {
+    render(<MetadataStep {...defaultProps} />);
+    fireEvent.click(screen.getByRole('checkbox'));
+    return screen.getByRole('textbox', { name: /description/i });
+}
+
+describe('MetadataStep – character counter', () => {
+    it('shows "500 characters remaining" when description is empty', () => {
+        enableMetadata();
+        expect(screen.getByText('500 characters remaining')).toBeInTheDocument();
+    });
+
+    it('decrements the counter as the user types', () => {
+        const textarea = enableMetadata();
+        fireEvent.change(textarea, { target: { value: 'Hello' } });
+        expect(screen.getByText('495 characters remaining')).toBeInTheDocument();
+    });
+
+    it('applies text-red-500 when remainingChars <= 50', () => {
+        const textarea = enableMetadata();
+        const longText = 'a'.repeat(460); // 500 - 460 = 40 remaining
+        fireEvent.change(textarea, { target: { value: longText } });
+        const counter = screen.getByText('40 characters remaining');
+        expect(counter.className).toContain('text-red-500');
+    });
+
+    it('does NOT apply text-red-500 when remainingChars > 50', () => {
+        const textarea = enableMetadata();
+        fireEvent.change(textarea, { target: { value: 'a'.repeat(100) } }); // 400 remaining
+        const counter = screen.getByText('400 characters remaining');
+        expect(counter.className).not.toContain('text-red-500');
+    });
+
+    it('shows "Character limit reached" when remainingChars === 0', () => {
+        const textarea = enableMetadata();
+        fireEvent.change(textarea, { target: { value: 'a'.repeat(500) } });
+        expect(screen.getByText('Character limit reached')).toBeInTheDocument();
+    });
+
+    it('counter is not visible when metadata toggle is off', () => {
+        render(<MetadataStep {...defaultProps} />);
+        expect(screen.queryByText(/characters remaining/i)).not.toBeInTheDocument();
+        expect(screen.queryByText('Character limit reached')).not.toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
## Summary

Closes #1212

The description textarea in `MetadataStep` already computed `remainingChars` but the counter had the wrong warning color and no limit-reached message. This PR fixes both and adds tests.

## Changes

**`MetadataStep.tsx`**
- Warning color changed from `text-orange-600` to `text-red-500`
- Warning threshold changed from `< 50` to `<= 50` (inclusive, as specified)
- Shows `'Character limit reached'` instead of the counter when `remainingChars === 0`
- Counter remains hidden when the metadata toggle is off

**`MetadataStep.test.tsx`** (new file)
- 6 tests covering: initial counter value, decrement on typing, `text-red-500` at `<= 50`, no red class above 50, `'Character limit reached'` at 0, and counter hidden when toggle is off

## Testing

All 6 new tests pass. Pre-existing failures in other test files are unrelated to this change.