### PR TITLE
feat/integration-pinata-queue

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -8,6 +8,7 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "test": "vitest",
+    "test:pinata-queue": "vitest run src/__tests__/pinataQueue.test.ts --reporter=verbose",
     "test:migration-compatibility": "vitest run src/__tests__/migrationUpgrade.test.ts src/__tests__/projectionMigration.compatibility.test.ts",
     "test:security": "vitest run src/__tests__/security",
     "test:security:auth": "vitest run src/__tests__/security.auth",

--- a/backend/src/__tests__/pinataQueue.test.ts
+++ b/backend/src/__tests__/pinataQueue.test.ts
@@ -1,0 +1,439 @@
+/**
+ * Tests for the Pinata request queue (#1153).
+ *
+ * Covers:
+ *  - Token-bucket throttling: max-concurrent cap is respected under burst load.
+ *  - 429 back-off: tasks are retried with exponential delay on HTTP 429.
+ *  - Max-retries exceeded: PinataRateLimitError is thrown after max retries.
+ *  - Queue depth metric: queueDepth reflects waiting tasks and drains to 0.
+ *  - Latency metric: avgLatencyMs is populated after requests complete.
+ *  - Successful pass-through: non-429 results resolve correctly.
+ *  - Re-queue ordering: 429-retried tasks are re-queued at the front.
+ *  - Token refill: requests blocked on tokens eventually drain after refill.
+ *
+ * All tests are fully synchronous / fake-timer based — no live network.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  PinataQueue,
+  PinataRateLimitError,
+  type PinataQueueOptions,
+} from "../lib/ipfs/pinataQueue";
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+/** Build an options object that's fast for tests (no real delays). */
+function opts(overrides: Partial<PinataQueueOptions> = {}): PinataQueueOptions {
+  return {
+    requestsPerSecond: 100, // effectively no throttle unless overridden
+    maxBurst: 100,
+    maxConcurrent: 3,
+    maxRetries429: 3,
+    retryBaseMs: 10,
+    retryCapMs: 100,
+    ...overrides,
+  };
+}
+
+/** Creates a mock task that resolves after `delayMs`. */
+function makeTask<T>(value: T, delayMs = 0): () => Promise<T> {
+  return () =>
+    new Promise<T>((resolve) => setTimeout(() => resolve(value), delayMs));
+}
+
+/** Creates a mock task that always rejects with a 429-like error. */
+function make429Task(): () => Promise<never> {
+  return () => {
+    const err = new Error("Request failed with status 429");
+    return Promise.reject(err);
+  };
+}
+
+/** Creates a task that succeeds on the Nth call (1-indexed); throws 429 before. */
+function makeSucceedsOnN<T>(
+  value: T,
+  succeedOnAttempt: number
+): () => Promise<T> {
+  let calls = 0;
+  return () => {
+    calls++;
+    if (calls < succeedOnAttempt) {
+      return Promise.reject(new Error("Request failed with status 429"));
+    }
+    return Promise.resolve(value);
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("PinataQueue — basic enqueue & resolution", () => {
+  it("resolves with the task's return value", async () => {
+    const queue = new PinataQueue(opts());
+    const result = await queue.enqueue(makeTask("hello"));
+    expect(result).toBe("hello");
+  });
+
+  it("propagates non-429 errors without retrying", async () => {
+    const queue = new PinataQueue(opts());
+    const task = vi.fn().mockRejectedValue(new Error("generic error"));
+    await expect(queue.enqueue(task)).rejects.toThrow("generic error");
+    // Should NOT have been called more than once (no retries for non-429).
+    expect(task).toHaveBeenCalledTimes(1);
+  });
+
+  it("handles multiple sequential tasks", async () => {
+    const queue = new PinataQueue(opts());
+    const results = await Promise.all([
+      queue.enqueue(makeTask(1)),
+      queue.enqueue(makeTask(2)),
+      queue.enqueue(makeTask(3)),
+    ]);
+    expect(results).toEqual([1, 2, 3]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("PinataQueue — concurrency cap", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("never exceeds maxConcurrent in-flight tasks", async () => {
+    const maxConcurrent = 2;
+    const queue = new PinataQueue(opts({ maxConcurrent, maxBurst: 20 }));
+
+    let peakInFlight = 0;
+    let currentInFlight = 0;
+
+    const trackingTask = () =>
+      new Promise<void>((resolve) => {
+        currentInFlight++;
+        peakInFlight = Math.max(peakInFlight, currentInFlight);
+        // Simulate async work that finishes after a tick.
+        Promise.resolve().then(() => {
+          currentInFlight--;
+          resolve();
+        });
+      });
+
+    // Enqueue more tasks than maxConcurrent.
+    const promises = Array.from({ length: 6 }, () =>
+      queue.enqueue(trackingTask)
+    );
+
+    // Drain all timers / microtasks.
+    await vi.runAllTimersAsync();
+    await Promise.all(promises);
+
+    expect(peakInFlight).toBeLessThanOrEqual(maxConcurrent);
+  });
+
+  it("queues tasks when maxConcurrent is reached and drains them afterwards", async () => {
+    const queue = new PinataQueue(
+      opts({ maxConcurrent: 1, requestsPerSecond: 1000, maxBurst: 100 })
+    );
+
+    const order: number[] = [];
+    const makeOrderedTask = (n: number) => async () => {
+      order.push(n);
+    };
+
+    const p1 = queue.enqueue(makeOrderedTask(1));
+    const p2 = queue.enqueue(makeOrderedTask(2));
+    const p3 = queue.enqueue(makeOrderedTask(3));
+
+    await vi.runAllTimersAsync();
+    await Promise.all([p1, p2, p3]);
+
+    // All three must have run, though ordering depends on resolution order.
+    expect(order).toHaveLength(3);
+    expect(order).toContain(1);
+    expect(order).toContain(2);
+    expect(order).toContain(3);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("PinataQueue — token-bucket throttling", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("throttles when tokens are exhausted and refills over time", async () => {
+    // 1 rps, burst=1 → only 1 token initially; second task must wait for refill.
+    const queue = new PinataQueue(
+      opts({ requestsPerSecond: 1, maxBurst: 1, maxConcurrent: 10 })
+    );
+
+    const completionOrder: number[] = [];
+    const task1 = queue.enqueue(async () => {
+      completionOrder.push(1);
+    });
+    const task2 = queue.enqueue(async () => {
+      completionOrder.push(2);
+    });
+
+    // After 0 ms, task1 should start (has token).
+    await vi.advanceTimersByTimeAsync(0);
+
+    // task2 is still waiting for a token.
+    expect(completionOrder).toHaveLength(1);
+    expect(completionOrder[0]).toBe(1);
+
+    // Advance 1 second — token refills.
+    await vi.advanceTimersByTimeAsync(1100);
+    await Promise.all([task1, task2]);
+
+    expect(completionOrder).toHaveLength(2);
+    expect(completionOrder[1]).toBe(2);
+  });
+
+  it("increments throttledCount when tasks wait for tokens", async () => {
+    const queue = new PinataQueue(
+      opts({ requestsPerSecond: 1, maxBurst: 1, maxConcurrent: 10 })
+    );
+
+    // Enqueue more tasks than available tokens.
+    queue.enqueue(makeTask("a")); // uses the one token
+    queue.enqueue(makeTask("b")); // must wait → throttled
+
+    await vi.advanceTimersByTimeAsync(50);
+
+    expect(queue.getMetrics().throttledCount).toBeGreaterThanOrEqual(1);
+
+    // Let everything drain.
+    await vi.runAllTimersAsync();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("PinataQueue — 429 back-off and retries", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("retries a 429 task and eventually resolves", async () => {
+    // Succeeds on attempt 3 (fails with 429 on attempts 1 and 2).
+    const queue = new PinataQueue(
+      opts({ maxRetries429: 5, retryBaseMs: 10, retryCapMs: 50 })
+    );
+
+    const taskFn = makeSucceedsOnN("success", 3);
+    const promise = queue.enqueue(taskFn);
+
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result).toBe("success");
+    expect(queue.getMetrics().retried429Count).toBe(2);
+  });
+
+  it("throws PinataRateLimitError after maxRetries429 exhausted", async () => {
+    const queue = new PinataQueue(
+      opts({ maxRetries429: 2, retryBaseMs: 10, retryCapMs: 50 })
+    );
+
+    const promise = queue.enqueue(make429Task());
+    // Attach catch immediately to prevent unhandled rejection before timers fire.
+    const caught = promise.catch((e) => e);
+    await vi.runAllTimersAsync();
+    const err = await caught;
+
+    expect(err).toBeInstanceOf(PinataRateLimitError);
+  });
+
+  it("PinataRateLimitError message contains retry count", async () => {
+    const queue = new PinataQueue(
+      opts({ maxRetries429: 2, retryBaseMs: 10, retryCapMs: 50 })
+    );
+
+    const promise = queue.enqueue(make429Task());
+    const caught = promise.catch((e: Error) => e);
+    await vi.runAllTimersAsync();
+    const err = await caught;
+
+    expect(err.message).toMatch(/after 2 retries/i);
+  });
+
+  it("increments retried429Count for each retry attempt", async () => {
+    const queue = new PinataQueue(
+      opts({ maxRetries429: 3, retryBaseMs: 10, retryCapMs: 50 })
+    );
+
+    const promise = queue.enqueue(make429Task());
+    const caught = promise.catch(() => {});
+    await vi.runAllTimersAsync();
+    await caught;
+
+    expect(queue.getMetrics().retried429Count).toBe(3);
+  });
+
+  it("does not retry non-429 errors", async () => {
+    const queue = new PinataQueue(opts());
+    const task = vi.fn().mockRejectedValue(new Error("Internal Server Error"));
+
+    const promise = queue.enqueue(task);
+    // Attach catch synchronously so no unhandled rejection warning fires.
+    const caught = promise.catch(() => {});
+    await vi.runAllTimersAsync();
+    await caught;
+
+    // Called exactly once — no retry.
+    expect(task).toHaveBeenCalledTimes(1);
+    expect(queue.getMetrics().retried429Count).toBe(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("PinataQueue — metrics", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("queueDepth reflects waiting tasks", async () => {
+    // maxConcurrent=1, burst=10 → second task queues immediately.
+    const queue = new PinataQueue(
+      opts({ maxConcurrent: 1, requestsPerSecond: 1000, maxBurst: 100 })
+    );
+
+    // Make task1 a long-running task so task2 ends up in the queue.
+    let resolveTask1!: () => void;
+    const longTask = () =>
+      new Promise<void>((res) => {
+        resolveTask1 = res;
+      });
+
+    queue.enqueue(longTask);
+    queue.enqueue(makeTask("queued"));
+
+    // At this point: task1 is in-flight, task2 is in the queue.
+    const metricsWhileQueued = queue.getMetrics();
+    expect(metricsWhileQueued.queueDepth).toBe(1);
+    expect(metricsWhileQueued.inFlight).toBe(1);
+
+    // Complete task1 → task2 starts → queue empties.
+    resolveTask1();
+    await vi.runAllTimersAsync();
+
+    expect(queue.getMetrics().queueDepth).toBe(0);
+  });
+
+  it("avgLatencyMs is positive after requests complete", async () => {
+    const queue = new PinataQueue(opts());
+
+    // Use zero-delay tasks so fake timers handle everything.
+    const p1 = queue.enqueue(makeTask("a", 0));
+    const p2 = queue.enqueue(makeTask("b", 0));
+    await vi.runAllTimersAsync();
+    await Promise.all([p1, p2]);
+
+    expect(queue.getMetrics().avgLatencyMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("inFlight returns to 0 once all tasks finish", async () => {
+    const queue = new PinataQueue(opts());
+
+    const promises = Array.from({ length: 5 }, (_, i) =>
+      queue.enqueue(makeTask(i))
+    );
+    await vi.runAllTimersAsync();
+    await Promise.all(promises);
+
+    expect(queue.getMetrics().inFlight).toBe(0);
+  });
+
+  it("initial metrics are all zero", () => {
+    const queue = new PinataQueue(opts());
+    const m = queue.getMetrics();
+    expect(m.queueDepth).toBe(0);
+    expect(m.inFlight).toBe(0);
+    expect(m.throttledCount).toBe(0);
+    expect(m.retried429Count).toBe(0);
+    expect(m.avgLatencyMs).toBe(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("PinataQueue — 429 detection variants", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("detects 429 from Error message containing '429'", async () => {
+    const queue = new PinataQueue(
+      opts({ maxRetries429: 1, retryBaseMs: 10, retryCapMs: 50 })
+    );
+    // Axios-style error with message "Request failed with status code 429"
+    const task = vi
+      .fn()
+      .mockRejectedValue(new Error("Request failed with status code 429"));
+    const promise = queue.enqueue(task);
+    const caught = promise.catch(() => {});
+    await vi.runAllTimersAsync();
+    await caught;
+
+    expect(queue.getMetrics().retried429Count).toBeGreaterThanOrEqual(1);
+  });
+
+  it("detects 429 from object with status property", async () => {
+    const queue = new PinataQueue(
+      opts({ maxRetries429: 1, retryBaseMs: 10, retryCapMs: 50 })
+    );
+    const err = Object.assign(new Error("Too Many Requests"), { status: 429 });
+    const task = vi.fn().mockRejectedValue(err);
+    const promise = queue.enqueue(task);
+    const caught = promise.catch(() => {});
+    await vi.runAllTimersAsync();
+    await caught;
+
+    expect(queue.getMetrics().retried429Count).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("PinataQueue — burst and high-concurrency load", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("all 20 tasks eventually resolve under burst load", async () => {
+    const queue = new PinataQueue(
+      opts({ maxConcurrent: 3, requestsPerSecond: 10, maxBurst: 10 })
+    );
+
+    const promises = Array.from({ length: 20 }, (_, i) =>
+      queue.enqueue(makeTask(i))
+    );
+
+    await vi.runAllTimersAsync();
+    const results = await Promise.all(promises);
+
+    expect(results).toHaveLength(20);
+    expect(results).toEqual(Array.from({ length: 20 }, (_, i) => i));
+  });
+});

--- a/backend/src/lib/ipfs/pinata.ts
+++ b/backend/src/lib/ipfs/pinata.ts
@@ -2,6 +2,7 @@ import pinataSDK from "@pinata/sdk";
 import NodeCache from "node-cache";
 import { CircuitBreaker } from "../circuitBreaker.js";
 import { verifyCIDContent, verifyMetadataCID } from "./cidVerification.js";
+import { pinataQueue, type PinataQueueMetrics } from "./pinataQueue.js";
 
 const cache = new NodeCache({ stdTTL: 3600 }); // 1 hour cache
 
@@ -20,45 +21,49 @@ export async function uploadImageToIPFS(
   buffer: Buffer,
   filename: string
 ): Promise<string> {
-  return ipfsCircuitBreaker.execute(async () => {
-    const pinata = new pinataSDK(
-      process.env.PINATA_API_KEY!,
-      process.env.PINATA_API_SECRET!
-    );
+  return ipfsCircuitBreaker.execute(() =>
+    pinataQueue.enqueue(async () => {
+      const pinata = new pinataSDK(
+        process.env.PINATA_API_KEY!,
+        process.env.PINATA_API_SECRET!
+      );
 
-    const result = await pinata.pinFileToIPFS(buffer, {
-      pinataMetadata: { name: filename },
-    });
+      const result = await pinata.pinFileToIPFS(buffer, {
+        pinataMetadata: { name: filename },
+      });
 
-    const cid = result.IpfsHash;
+      const cid = result.IpfsHash;
 
-    if (CID_VERIFY_ENABLED) {
-      await verifyCIDContent(buffer, cid, CID_VERIFY_GATEWAY);
-    }
+      if (CID_VERIFY_ENABLED) {
+        await verifyCIDContent(buffer, cid, CID_VERIFY_GATEWAY);
+      }
 
-    return cid;
-  });
+      return cid;
+    })
+  );
 }
 
 export async function uploadMetadataToIPFS(metadata: any): Promise<string> {
-  return ipfsCircuitBreaker.execute(async () => {
-    const pinata = new pinataSDK(
-      process.env.PINATA_API_KEY!,
-      process.env.PINATA_API_SECRET!
-    );
+  return ipfsCircuitBreaker.execute(() =>
+    pinataQueue.enqueue(async () => {
+      const pinata = new pinataSDK(
+        process.env.PINATA_API_KEY!,
+        process.env.PINATA_API_SECRET!
+      );
 
-    const result = await pinata.pinJSONToIPFS(metadata);
-    const cid = result.IpfsHash;
+      const result = await pinata.pinJSONToIPFS(metadata);
+      const cid = result.IpfsHash;
 
-    if (CID_VERIFY_ENABLED) {
-      await verifyMetadataCID(metadata, cid, CID_VERIFY_GATEWAY);
-    }
+      if (CID_VERIFY_ENABLED) {
+        await verifyMetadataCID(metadata, cid, CID_VERIFY_GATEWAY);
+      }
 
-    // Cache the metadata
-    cache.set(cid, metadata);
+      // Cache the metadata
+      cache.set(cid, metadata);
 
-    return cid;
-  });
+      return cid;
+    })
+  );
 }
 
 export async function getMetadataFromIPFS(cid: string): Promise<any> {
@@ -66,16 +71,20 @@ export async function getMetadataFromIPFS(cid: string): Promise<any> {
   const cached = cache.get(cid);
   if (cached) return cached;
 
-  // Fetch from IPFS with circuit breaker
-  return ipfsCircuitBreaker.execute(async () => {
-    const response = await fetch(`https://gateway.pinata.cloud/ipfs/${cid}`);
-    if (!response.ok) throw new Error("Metadata not found");
+  // Fetch from IPFS with circuit breaker + queue throttle
+  return ipfsCircuitBreaker.execute(() =>
+    pinataQueue.enqueue(async () => {
+      const response = await fetch(
+        `https://gateway.pinata.cloud/ipfs/${cid}`
+      );
+      if (!response.ok) throw new Error("Metadata not found");
 
-    const metadata = await response.json();
-    cache.set(cid, metadata);
+      const metadata = await response.json();
+      cache.set(cid, metadata);
 
-    return metadata;
-  });
+      return metadata;
+    })
+  );
 }
 
 /**
@@ -90,4 +99,14 @@ export function getIPFSCircuitBreakerMetrics() {
  */
 export function resetIPFSCircuitBreaker(): void {
   ipfsCircuitBreaker.reset();
+}
+
+/**
+ * Get a snapshot of the Pinata request queue metrics.
+ * Useful for observability dashboards and health checks.
+ *
+ * Returns: { queueDepth, inFlight, throttledCount, retried429Count, avgLatencyMs }
+ */
+export function getPinataQueueMetrics(): PinataQueueMetrics {
+  return pinataQueue.getMetrics();
 }

--- a/backend/src/lib/ipfs/pinataQueue.ts
+++ b/backend/src/lib/ipfs/pinataQueue.ts
@@ -1,0 +1,261 @@
+/**
+ * PinataQueue — client-side request queue for the Pinata IPFS API (#1153).
+ *
+ * Features
+ * ────────
+ *  • Token-bucket throttle (configurable rps + max-burst).
+ *  • Concurrency cap — at most N requests in-flight at once.
+ *  • Automatic 429 back-off with exponential delay (jittered, capped).
+ *  • Observable metrics: queueDepth, inFlight, throttledCount, retried429Count,
+ *    avgLatencyMs.
+ *
+ * Configuration (env vars → PinataQueueOptions)
+ * ─────────────────────────────────────────────
+ *  PINATA_RPS               Requests allowed per second      (default 5)
+ *  PINATA_MAX_CONCURRENT    Max parallel in-flight requests  (default 3)
+ *  PINATA_MAX_BURST         Token-bucket burst capacity      (default 10)
+ *  PINATA_MAX_RETRIES_429   Max 429 retries per request      (default 5)
+ *  PINATA_RETRY_BASE_MS     Base delay for backoff (ms)      (default 1000)
+ *  PINATA_RETRY_CAP_MS      Max delay cap for backoff (ms)   (default 60000)
+ */
+
+export class PinataRateLimitError extends Error {
+  constructor(retries: number) {
+    super(
+      `Pinata rate limit exceeded after ${retries} retries (HTTP 429). ` +
+        `Adjust PINATA_RPS / PINATA_MAX_RETRIES_429 or retry later.`
+    );
+    this.name = "PinataRateLimitError";
+  }
+}
+
+export interface PinataQueueOptions {
+  /** Allowed requests per second (token-bucket refill rate). */
+  requestsPerSecond: number;
+  /** Token-bucket burst capacity — allows short spikes above rps. */
+  maxBurst: number;
+  /** Maximum concurrent in-flight Pinata requests. */
+  maxConcurrent: number;
+  /** Maximum number of times a single request is retried on HTTP 429. */
+  maxRetries429: number;
+  /** Base delay (ms) for exponential 429 back-off. */
+  retryBaseMs: number;
+  /** Upper cap (ms) for exponential 429 back-off delay. */
+  retryCapMs: number;
+}
+
+export interface PinataQueueMetrics {
+  /** Number of tasks waiting in the queue (not yet started). */
+  queueDepth: number;
+  /** Number of tasks currently executing. */
+  inFlight: number;
+  /** Total number of tasks that had to wait for a token. */
+  throttledCount: number;
+  /** Total number of 429 retries across all requests since creation. */
+  retried429Count: number;
+  /** Rolling average latency (ms) of the last 100 completed requests. */
+  avgLatencyMs: number;
+}
+
+interface QueuedTask<T> {
+  fn: () => Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason: unknown) => void;
+  retries: number;
+  /** Timestamp (ms) when the task was first enqueued. */
+  enqueuedAt: number;
+}
+
+const DEFAULT_OPTIONS: PinataQueueOptions = {
+  requestsPerSecond: Number(process.env.PINATA_RPS ?? 5),
+  maxBurst: Number(process.env.PINATA_MAX_BURST ?? 10),
+  maxConcurrent: Number(process.env.PINATA_MAX_CONCURRENT ?? 3),
+  maxRetries429: Number(process.env.PINATA_MAX_RETRIES_429 ?? 5),
+  retryBaseMs: Number(process.env.PINATA_RETRY_BASE_MS ?? 1000),
+  retryCapMs: Number(process.env.PINATA_RETRY_CAP_MS ?? 60_000),
+};
+
+/**
+ * Token-bucket + concurrency-limited queue for outgoing Pinata API calls.
+ *
+ * Usage
+ * ─────
+ *   const result = await pinataQueue.enqueue(() => pinata.pinJSONToIPFS(data));
+ */
+export class PinataQueue {
+  private readonly opts: PinataQueueOptions;
+
+  // ── token bucket ──────────────────────────────────────────────────────────
+  private tokens: number;
+  private lastRefillAt: number;
+
+  // ── queue state ───────────────────────────────────────────────────────────
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private readonly queue: QueuedTask<any>[] = [];
+  private inFlight = 0;
+
+  // ── metrics ───────────────────────────────────────────────────────────────
+  private throttledCount = 0;
+  private retried429Count = 0;
+  /** Circular buffer of recent latency samples (last 100). */
+  private readonly latencySamples: number[] = [];
+
+  constructor(opts: Partial<PinataQueueOptions> = {}) {
+    this.opts = { ...DEFAULT_OPTIONS, ...opts };
+    this.tokens = this.opts.maxBurst;
+    this.lastRefillAt = Date.now();
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Public API
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Enqueue an async task.  Returns a promise that resolves / rejects with the
+   * same value the task would have, but after throttle & retry logic is applied.
+   *
+   * The supplied `fn` must be a *factory* — it will be called (possibly
+   * multiple times on 429) by the queue, not immediately.
+   */
+  enqueue<T>(fn: () => Promise<T>): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      this.queue.push({
+        fn,
+        resolve,
+        reject,
+        retries: 0,
+        enqueuedAt: Date.now(),
+      });
+      this.drain();
+    });
+  }
+
+  /** Snapshot of current queue metrics (non-blocking). */
+  getMetrics(): PinataQueueMetrics {
+    const avgLatencyMs =
+      this.latencySamples.length === 0
+        ? 0
+        : this.latencySamples.reduce((a, b) => a + b, 0) /
+          this.latencySamples.length;
+
+    return {
+      queueDepth: this.queue.length,
+      inFlight: this.inFlight,
+      throttledCount: this.throttledCount,
+      retried429Count: this.retried429Count,
+      avgLatencyMs: Math.round(avgLatencyMs),
+    };
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Internal
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /** Refill the token bucket based on elapsed wall-clock time. */
+  private refillTokens(): void {
+    const now = Date.now();
+    const elapsedMs = now - this.lastRefillAt;
+    const refill = (elapsedMs / 1000) * this.opts.requestsPerSecond;
+    this.tokens = Math.min(this.opts.maxBurst, this.tokens + refill);
+    this.lastRefillAt = now;
+  }
+
+  /**
+   * Process as many queued tasks as the token bucket and concurrency cap allow.
+   * Called after every enqueue, task completion, or retry re-schedule.
+   */
+  private drain(): void {
+    this.refillTokens();
+
+    while (
+      this.queue.length > 0 &&
+      this.inFlight < this.opts.maxConcurrent &&
+      this.tokens >= 1
+    ) {
+      const task = this.queue.shift()!;
+      this.tokens -= 1;
+      this.inFlight++;
+      this.run(task);
+    }
+
+    if (this.queue.length > 0 && this.inFlight < this.opts.maxConcurrent) {
+      // Queue has tasks but tokens are exhausted — schedule a re-drain after
+      // the next token becomes available.
+      this.throttledCount++;
+      const msUntilNextToken = Math.ceil(1000 / this.opts.requestsPerSecond);
+      setTimeout(() => this.drain(), msUntilNextToken);
+    }
+  }
+
+  /** Execute a single task, applying 429 retry logic. */
+  private async run<T>(task: QueuedTask<T>): Promise<void> {
+    const startedAt = Date.now();
+    try {
+      const result = await task.fn();
+      task.resolve(result);
+      this.recordLatency(task.enqueuedAt, startedAt);
+    } catch (err) {
+      if (this.is429(err) && task.retries < this.opts.maxRetries429) {
+        task.retries++;
+        this.retried429Count++;
+        const delay = this.backoffDelay(task.retries);
+        setTimeout(() => {
+          this.queue.unshift(task); // push to front so it runs next
+          this.drain();
+        }, delay);
+      } else if (this.is429(err)) {
+        task.reject(new PinataRateLimitError(task.retries));
+      } else {
+        task.reject(err);
+      }
+    } finally {
+      this.inFlight--;
+      this.drain(); // check whether the next task can be started
+    }
+  }
+
+  /**
+   * Returns true when the thrown value is an HTTP 429 response.
+   * Handles both raw `Response` objects and objects with a numeric `status`.
+   */
+  private is429(err: unknown): boolean {
+    if (err instanceof Response) return err.status === 429;
+    if (
+      err != null &&
+      typeof err === "object" &&
+      "status" in err &&
+      (err as { status: unknown }).status === 429
+    ) {
+      return true;
+    }
+    // Some SDKs throw an Error whose message contains "429"
+    if (err instanceof Error && /\b429\b/.test(err.message)) return true;
+    return false;
+  }
+
+  /**
+   * Full jitter exponential back-off capped at `retryCapMs`.
+   * delay = random(0, min(cap, base * 2^attempt))
+   */
+  private backoffDelay(attempt: number): number {
+    const exponential = Math.min(
+      this.opts.retryCapMs,
+      this.opts.retryBaseMs * Math.pow(2, attempt)
+    );
+    return Math.floor(Math.random() * exponential);
+  }
+
+  /** Maintain a rolling window of the last 100 latency samples. */
+  private recordLatency(enqueuedAt: number, startedAt: number): void {
+    // Use total elapsed from enqueue (includes queue-wait + execution).
+    const latency = Date.now() - enqueuedAt;
+    void startedAt; // kept for future per-phase breakdown
+    if (this.latencySamples.length >= 100) {
+      this.latencySamples.shift();
+    }
+    this.latencySamples.push(latency);
+  }
+}
+
+// ── Singleton used by pinata.ts ──────────────────────────────────────────────
+export const pinataQueue = new PinataQueue();

--- a/backend/src/lib/metrics/pinataMetrics.ts
+++ b/backend/src/lib/metrics/pinataMetrics.ts
@@ -1,0 +1,92 @@
+/**
+ * Prometheus metrics for the Pinata request queue (#1153).
+ *
+ * Registers gauges, counters, and a histogram against the project's shared
+ * prom-client registry (imported from `../metrics/index.js`).
+ *
+ * Import this module once at application startup to activate collection.
+ *
+ * Exported helpers
+ * ────────────────
+ *  recordPinataMetrics(metrics)      — sync a queue snapshot into Prometheus
+ *  observePinataRequestDuration(ms)  — record a single request duration sample
+ */
+
+import { Counter, Gauge, Histogram } from "prom-client";
+import { register } from "../metrics/index.js";
+import { type PinataQueueMetrics } from "../ipfs/pinataQueue.js";
+
+// ── Gauges ───────────────────────────────────────────────────────────────────
+
+export const pinataQueueDepthGauge = new Gauge({
+  name: "pinata_queue_depth",
+  help: "Number of Pinata API requests currently waiting in the queue.",
+  registers: [register],
+});
+
+export const pinataInFlightGauge = new Gauge({
+  name: "pinata_in_flight",
+  help: "Number of Pinata API requests currently in-flight.",
+  registers: [register],
+});
+
+// ── Counters ─────────────────────────────────────────────────────────────────
+
+export const pinataThrottledCounter = new Counter({
+  name: "pinata_throttled_total",
+  help: "Total number of times a Pinata request had to wait for a rate-limit token.",
+  registers: [register],
+});
+
+export const pinata429RetriesCounter = new Counter({
+  name: "pinata_429_retries_total",
+  help: "Total number of 429 (rate-limit) retries performed against the Pinata API.",
+  registers: [register],
+});
+
+// ── Histogram ─────────────────────────────────────────────────────────────────
+
+export const pinataRequestDurationHistogram = new Histogram({
+  name: "pinata_request_duration_ms",
+  help: "End-to-end latency of Pinata API requests (ms), including queue wait time.",
+  buckets: [50, 100, 250, 500, 1000, 2500, 5000, 10000],
+  registers: [register],
+});
+
+// ── Sync helper ──────────────────────────────────────────────────────────────
+
+let _lastThrottledCount = 0;
+let _last429Count = 0;
+
+/**
+ * Synchronise a PinataQueueMetrics snapshot into Prometheus.
+ *
+ * Designed to be called on a periodic interval:
+ *   setInterval(() => recordPinataMetrics(pinataQueue.getMetrics()), 10_000);
+ */
+export function recordPinataMetrics(metrics: PinataQueueMetrics): void {
+  pinataQueueDepthGauge.set(metrics.queueDepth);
+  pinataInFlightGauge.set(metrics.inFlight);
+
+  // Counters must only increase — compute delta since last call.
+  const throttledDelta = metrics.throttledCount - _lastThrottledCount;
+  if (throttledDelta > 0) {
+    pinataThrottledCounter.inc(throttledDelta);
+    _lastThrottledCount = metrics.throttledCount;
+  }
+
+  const retriedDelta = metrics.retried429Count - _last429Count;
+  if (retriedDelta > 0) {
+    pinata429RetriesCounter.inc(retriedDelta);
+    _last429Count = metrics.retried429Count;
+  }
+}
+
+/**
+ * Record a single request's end-to-end duration into the histogram.
+ *
+ * @param durationMs  Elapsed milliseconds (queue wait + execution).
+ */
+export function observePinataRequestDuration(durationMs: number): void {
+  pinataRequestDurationHistogram.observe(durationMs);
+}


### PR DESCRIPTION
Implement issue-#1153: Add request queueing and rate limiting for the Pinata API client Ref: issue-1153

## 🚀 Pull Request: Nova Launch

### Description
Added request queueing and rate limiting for the Pinata API client

closes #1153 