### PR TITLE
feat(frontend): token analytics dashboard with supply and burn charts

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,7 @@ const LandingPage = lazy(() => import("./pages/LandingPage"));
 const NotFoundRoute = lazy(() => import("./routes/NotFoundRoute"));
 const RecurringPayments = lazy(() => import("./app/dashboard/RecurringPayments"));
 const CampaignDashboard = lazy(() => import("./app/dashboard/CampaignDashboard"));
+const TokenAnalyticsPage = lazy(() => import("./pages/TokenAnalyticsPage"));
 
 // Loading fallback
 function PageLoader() {
@@ -108,6 +109,22 @@ function App({ compatibilityInfo }: { compatibilityInfo?: CompatibilityInfo }) {
           currentPath={pathname}
         >
           <RecurringPayments />
+        </DashboardLayout>
+      );
+    }
+
+    // /tokens/:address/analytics
+    const analyticsMatch = pathname.match(/^\/tokens\/([^/]+)\/analytics$/);
+    if (analyticsMatch) {
+      return (
+        <DashboardLayout
+          wallet={wallet}
+          onConnect={connect}
+          onDisconnect={disconnect}
+          isConnecting={isConnecting}
+          currentPath={pathname}
+        >
+          <TokenAnalyticsPage address={analyticsMatch[1]} />
         </DashboardLayout>
       );
     }

--- a/frontend/src/components/TokenAnalytics/ActivityFeed.tsx
+++ b/frontend/src/components/TokenAnalytics/ActivityFeed.tsx
@@ -1,0 +1,60 @@
+import { Card } from '../UI/Card';
+import type { BurnRecord } from '../../services/tokenAnalyticsApi';
+import { truncateAddress } from '../../utils/formatting';
+
+interface ActivityFeedProps {
+  records: BurnRecord[];
+  symbol?: string;
+  decimals?: number;
+}
+
+function formatAmount(raw: string, decimals: number): string {
+  const n = Number(BigInt(raw)) / 10 ** decimals;
+  return n.toLocaleString(undefined, { maximumFractionDigits: 4 });
+}
+
+export function ActivityFeed({ records, symbol = 'TOKEN', decimals = 7 }: ActivityFeedProps) {
+  const recent = records
+    .slice()
+    .sort((a, b) => b.timestamp - a.timestamp)
+    .slice(0, 20);
+
+  return (
+    <Card>
+      <h3 className="text-base font-semibold text-gray-900 mb-4">Recent Burns</h3>
+
+      {recent.length === 0 ? (
+        <p className="text-sm text-gray-500 text-center py-8">No burn activity yet</p>
+      ) : (
+        <ol
+          aria-label="Recent burn activity"
+          className="divide-y divide-gray-100 text-sm"
+        >
+          {recent.map((rec) => (
+            <li key={rec.id} className="py-2 flex items-center justify-between gap-4">
+              <div className="min-w-0">
+                <span className="font-mono text-gray-700 truncate block">
+                  {truncateAddress(rec.from)}
+                </span>
+                <time
+                  className="text-xs text-gray-400"
+                  dateTime={new Date(rec.timestamp * 1000).toISOString()}
+                >
+                  {new Date(rec.timestamp * 1000).toLocaleString()}
+                </time>
+              </div>
+              <div className="text-right shrink-0">
+                <span className="font-semibold text-orange-600">
+                  −{formatAmount(rec.amount, decimals)} {symbol}
+                </span>
+                {rec.isAdminBurn && (
+                  <span className="ml-1 text-xs text-gray-500">(admin)</span>
+                )}
+              </div>
+            </li>
+          ))}
+        </ol>
+      )}
+    </Card>
+  );
+}

--- a/frontend/src/components/TokenAnalytics/BurnRateChart.tsx
+++ b/frontend/src/components/TokenAnalytics/BurnRateChart.tsx
@@ -1,0 +1,76 @@
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+import { Card } from '../UI/Card';
+import { Spinner } from '../UI/Spinner';
+import type { DailyBurnPoint } from '../../utils/analyticsTransforms';
+
+interface BurnRateChartProps {
+  data: DailyBurnPoint[];
+  symbol?: string;
+  loading?: boolean;
+}
+
+function formatCompact(v: number): string {
+  if (v >= 1e9) return `${(v / 1e9).toFixed(1)}B`;
+  if (v >= 1e6) return `${(v / 1e6).toFixed(1)}M`;
+  if (v >= 1e3) return `${(v / 1e3).toFixed(1)}K`;
+  return v.toFixed(0);
+}
+
+export function BurnRateChart({ data, symbol = 'TOKEN', loading = false }: BurnRateChartProps) {
+  return (
+    <Card>
+      <h3 className="text-base font-semibold text-gray-900 mb-4">Daily Burn Volume</h3>
+
+      {loading ? (
+        <div className="flex items-center justify-center h-52" role="status" aria-label="Loading burn rate chart">
+          <Spinner size="lg" />
+        </div>
+      ) : data.length === 0 ? (
+        <p className="text-sm text-gray-500 text-center py-12">No burn data available</p>
+      ) : (
+        <div
+          role="img"
+          aria-label={`Bar chart showing daily ${symbol} burn volume`}
+          style={{ width: '100%', height: 240 }}
+        >
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={data} margin={{ top: 4, right: 16, left: 0, bottom: 4 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+              <XAxis
+                dataKey="date"
+                tick={{ fontSize: 11, fill: '#6b7280' }}
+                tickFormatter={(d: string) => d.slice(5)}
+              />
+              <YAxis
+                tick={{ fontSize: 11, fill: '#6b7280' }}
+                tickFormatter={formatCompact}
+                width={52}
+              />
+              <Tooltip
+                formatter={(val: number, name: string) => [
+                  val.toLocaleString(undefined, { maximumFractionDigits: 2 }),
+                  name,
+                ]}
+              />
+              <Bar
+                dataKey="burned"
+                fill="#f97316"
+                name={`Burned (${symbol})`}
+                radius={[3, 3, 0, 0]}
+                maxBarSize={48}
+              />
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/frontend/src/components/TokenAnalytics/SupplyChart.tsx
+++ b/frontend/src/components/TokenAnalytics/SupplyChart.tsx
@@ -1,0 +1,78 @@
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+import { Card } from '../UI/Card';
+import { Spinner } from '../UI/Spinner';
+import type { SupplyPoint } from '../../utils/analyticsTransforms';
+
+interface SupplyChartProps {
+  data: SupplyPoint[];
+  symbol?: string;
+  loading?: boolean;
+}
+
+function formatCompact(v: number): string {
+  if (v >= 1e9) return `${(v / 1e9).toFixed(1)}B`;
+  if (v >= 1e6) return `${(v / 1e6).toFixed(1)}M`;
+  if (v >= 1e3) return `${(v / 1e3).toFixed(1)}K`;
+  return v.toFixed(0);
+}
+
+export function SupplyChart({ data, symbol = 'TOKEN', loading = false }: SupplyChartProps) {
+  return (
+    <Card>
+      <h3 className="text-base font-semibold text-gray-900 mb-4">Supply Over Time</h3>
+
+      {loading ? (
+        <div className="flex items-center justify-center h-52" role="status" aria-label="Loading supply chart">
+          <Spinner size="lg" />
+        </div>
+      ) : data.length === 0 ? (
+        <p className="text-sm text-gray-500 text-center py-12">No supply data available</p>
+      ) : (
+        <div
+          role="img"
+          aria-label={`Line chart showing ${symbol} token supply over time`}
+          style={{ width: '100%', height: 240 }}
+        >
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={data} margin={{ top: 4, right: 16, left: 0, bottom: 4 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+              <XAxis
+                dataKey="date"
+                tick={{ fontSize: 11, fill: '#6b7280' }}
+                tickFormatter={(d: string) => d.slice(5)} // "MM-DD"
+              />
+              <YAxis
+                tick={{ fontSize: 11, fill: '#6b7280' }}
+                tickFormatter={formatCompact}
+                width={52}
+              />
+              <Tooltip
+                formatter={(val: number) => [
+                  val.toLocaleString(undefined, { maximumFractionDigits: 2 }),
+                  `Supply (${symbol})`,
+                ]}
+              />
+              <Line
+                type="monotone"
+                dataKey="supply"
+                stroke="#6366f1"
+                strokeWidth={2}
+                dot={false}
+                activeDot={{ r: 5 }}
+                name={`Supply (${symbol})`}
+              />
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/frontend/src/components/TokenAnalytics/index.ts
+++ b/frontend/src/components/TokenAnalytics/index.ts
@@ -1,0 +1,3 @@
+export { SupplyChart } from './SupplyChart';
+export { BurnRateChart } from './BurnRateChart';
+export { ActivityFeed } from './ActivityFeed';

--- a/frontend/src/components/TransactionHistory/TokenCard.tsx
+++ b/frontend/src/components/TransactionHistory/TokenCard.tsx
@@ -237,7 +237,7 @@ export function TokenCard({ token, network, fetchEnrichedData = true, onDetailLo
                     </div>
                 </div>
 
-                <div className="flex gap-2">
+                <div className="flex gap-2 flex-wrap">
                     <Button
                         variant="outline"
                         size="sm"
@@ -256,6 +256,13 @@ export function TokenCard({ token, network, fetchEnrichedData = true, onDetailLo
                             View TX
                         </Button>
                     )}
+                    <a
+                        href={`/tokens/${token.address}/analytics`}
+                        className="flex-1 inline-flex items-center justify-center px-3 py-1.5 text-sm font-medium rounded-lg border border-indigo-300 text-indigo-700 hover:bg-indigo-50 transition-colors"
+                        aria-label={`View analytics for ${token.name}`}
+                    >
+                        Analytics
+                    </a>
                 </div>
             </div>
         </Card>

--- a/frontend/src/hooks/useTokenAnalytics.ts
+++ b/frontend/src/hooks/useTokenAnalytics.ts
@@ -1,0 +1,67 @@
+import { useEffect, useState } from 'react';
+import { fetchTokenStats, fetchBurnRecords } from '../services/tokenAnalyticsApi';
+import { groupBurnsByDay, normaliseSupplyHistory } from '../utils/analyticsTransforms';
+import type { TokenStats, BurnRecord } from '../services/tokenAnalyticsApi';
+import type { DailyBurnPoint, SupplyPoint } from '../utils/analyticsTransforms';
+
+export interface TokenAnalyticsData {
+  stats: TokenStats | null;
+  burnRecords: BurnRecord[];
+  dailyBurns: DailyBurnPoint[];
+  supplyHistory: SupplyPoint[];
+  loading: boolean;
+  error: string | null;
+  refresh: () => void;
+}
+
+/**
+ * Fetch token stats (REST) and burn records (GraphQL) in parallel and return
+ * a unified, chart-ready data shape.
+ */
+export function useTokenAnalytics(address: string): TokenAnalyticsData {
+  const [stats, setStats] = useState<TokenStats | null>(null);
+  const [burnRecords, setBurnRecords] = useState<BurnRecord[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [tick, setTick] = useState(0);
+
+  useEffect(() => {
+    if (!address) return;
+
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    Promise.all([fetchTokenStats(address), fetchBurnRecords(address)])
+      .then(([s, records]) => {
+        if (cancelled) return;
+        setStats(s);
+        setBurnRecords(records);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : 'Failed to load analytics');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [address, tick]);
+
+  const decimals = stats?.decimals ?? 7;
+  const dailyBurns = groupBurnsByDay(burnRecords, decimals);
+  const supplyHistory = normaliseSupplyHistory(stats?.supplyHistory ?? [], decimals);
+
+  return {
+    stats,
+    burnRecords,
+    dailyBurns,
+    supplyHistory,
+    loading,
+    error,
+    refresh: () => setTick((t) => t + 1),
+  };
+}

--- a/frontend/src/pages/TokenAnalyticsPage.tsx
+++ b/frontend/src/pages/TokenAnalyticsPage.tsx
@@ -1,0 +1,116 @@
+import { useTokenAnalytics } from '../hooks/useTokenAnalytics';
+import { SupplyChart, BurnRateChart, ActivityFeed } from '../components/TokenAnalytics';
+import { Spinner } from '../components/UI/Spinner';
+import { Button } from '../components/UI/Button';
+import { truncateAddress, formatTokenSupply } from '../utils/formatting';
+
+interface Props {
+  /** Token contract address from the route parameter */
+  address: string;
+}
+
+/** Simple KPI card */
+function KpiCard({ label, value, sub }: { label: string; value: string; sub?: string }) {
+  return (
+    <div className="bg-white rounded-xl border border-gray-200 p-4 shadow-sm">
+      <p className="text-xs text-gray-500 uppercase tracking-wide">{label}</p>
+      <p className="text-2xl font-bold text-gray-900 mt-1 truncate">{value}</p>
+      {sub && <p className="text-xs text-gray-400 mt-0.5">{sub}</p>}
+    </div>
+  );
+}
+
+export default function TokenAnalyticsPage({ address }: Props) {
+  const { stats, burnRecords, dailyBurns, supplyHistory, loading, error, refresh } =
+    useTokenAnalytics(address);
+
+  if (loading && !stats) {
+    return (
+      <div
+        className="flex items-center justify-center min-h-screen"
+        role="status"
+        aria-label="Loading analytics"
+      >
+        <Spinner size="lg" />
+        <span className="sr-only">Loading analytics…</span>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="max-w-lg mx-auto mt-24 text-center p-6">
+        <p className="text-red-600 font-medium mb-4">{error}</p>
+        <Button variant="primary" onClick={refresh}>
+          Retry
+        </Button>
+      </div>
+    );
+  }
+
+  const decimals = stats?.decimals ?? 7;
+  const symbol = stats?.symbol ?? '—';
+
+  return (
+    <main className="max-w-5xl mx-auto px-4 sm:px-6 py-8 space-y-8">
+      {/* Header */}
+      <header className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">
+            {stats?.name ?? 'Token'} Analytics
+          </h1>
+          <p className="text-sm text-gray-500 font-mono mt-1">
+            {truncateAddress(address, 10, 8)}
+          </p>
+        </div>
+        <Button variant="outline" size="sm" onClick={refresh} aria-label="Refresh analytics data">
+          Refresh
+        </Button>
+      </header>
+
+      {/* KPI cards */}
+      <section
+        aria-label="Key metrics"
+        className="grid grid-cols-2 sm:grid-cols-4 gap-4"
+      >
+        <KpiCard
+          label="Total Supply"
+          value={
+            stats
+              ? formatTokenSupply(stats.totalSupply, decimals, { compact: true })
+              : '—'
+          }
+          sub={symbol}
+        />
+        <KpiCard
+          label="Total Burned"
+          value={
+            stats
+              ? formatTokenSupply(stats.totalBurned, decimals, { compact: true })
+              : '—'
+          }
+          sub={symbol}
+        />
+        <KpiCard
+          label="Burn Events"
+          value={stats?.burnCount.toLocaleString() ?? '—'}
+        />
+        <KpiCard
+          label="Unique Burners"
+          value={stats?.burnerCount.toLocaleString() ?? '—'}
+        />
+      </section>
+
+      {/* Charts */}
+      <section aria-label="Supply and burn charts" className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <SupplyChart data={supplyHistory} symbol={symbol} loading={loading} />
+        <BurnRateChart data={dailyBurns} symbol={symbol} loading={loading} />
+      </section>
+
+      {/* Activity feed */}
+      <section aria-label="Recent burn activity">
+        <ActivityFeed records={burnRecords} symbol={symbol} decimals={decimals} />
+      </section>
+    </main>
+  );
+}

--- a/frontend/src/services/tokenAnalyticsApi.ts
+++ b/frontend/src/services/tokenAnalyticsApi.ts
@@ -1,0 +1,62 @@
+/**
+ * Token Analytics API client.
+ *
+ * REST:   GET /api/tokens/:address/stats
+ * GraphQL: burnRecords field
+ */
+
+import { apiClient } from './apiClient';
+
+export interface TokenStats {
+  address: string;
+  name: string;
+  symbol: string;
+  decimals: number;
+  totalSupply: string;
+  /** Supply over time snapshots — each point represents a ledger close */
+  supplyHistory: Array<{ timestamp: number; supply: string }>;
+  burnCount: number;
+  totalBurned: string;
+  burnerCount: number;
+  dailyBurnVolume: string;
+  weeklyBurnVolume: string;
+  monthlyBurnVolume: string;
+  burnTrend: number;
+}
+
+export interface BurnRecord {
+  id: string;
+  timestamp: number; // Unix seconds
+  from: string;
+  amount: string;
+  isAdminBurn: boolean;
+  txHash: string;
+}
+
+const GQL_ENDPOINT =
+  (import.meta as any)?.env?.VITE_GRAPHQL_URL ?? '/api/graphql';
+
+const BURN_RECORDS_QUERY = `
+  query BurnRecords($address: String!) {
+    burnRecords(tokenAddress: $address) {
+      id
+      timestamp
+      from
+      amount
+      isAdminBurn
+      txHash
+    }
+  }
+`;
+
+export async function fetchTokenStats(address: string): Promise<TokenStats> {
+  return apiClient.get<TokenStats>(`/api/tokens/${address}/stats`);
+}
+
+export async function fetchBurnRecords(address: string): Promise<BurnRecord[]> {
+  const res = await apiClient.post<{ data: { burnRecords: BurnRecord[] } }>(
+    GQL_ENDPOINT,
+    { query: BURN_RECORDS_QUERY, variables: { address } }
+  );
+  return res.data.burnRecords;
+}

--- a/frontend/src/test/integration/token-analytics-dashboard.integration.test.tsx
+++ b/frontend/src/test/integration/token-analytics-dashboard.integration.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * Integration test: TokenAnalyticsPage renders with mocked API responses.
+ * The chart library (recharts) is NOT mocked — we assert on container presence.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import TokenAnalyticsPage from '../../pages/TokenAnalyticsPage';
+import type { TokenStats, BurnRecord } from '../../services/tokenAnalyticsApi';
+
+const TEST_ADDRESS = 'CTEST1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234';
+
+const mockStats: TokenStats = {
+  address: TEST_ADDRESS,
+  name: 'Test Token',
+  symbol: 'TST',
+  decimals: 7,
+  totalSupply: '1000000000000',
+  supplyHistory: [
+    { timestamp: 1_700_000_000, supply: '1000000000000' },
+    { timestamp: 1_700_086_400, supply: '990000000000' },
+  ],
+  burnCount: 3,
+  totalBurned: '10000000000',
+  burnerCount: 2,
+  dailyBurnVolume: '1000000000',
+  weeklyBurnVolume: '7000000000',
+  monthlyBurnVolume: '30000000000',
+  burnTrend: -5,
+};
+
+const mockBurnRecords: BurnRecord[] = [
+  {
+    id: '1',
+    timestamp: 1_700_086_400,
+    from: 'GCBURNER1',
+    amount: '5000000000',
+    isAdminBurn: false,
+    txHash: 'txhash1',
+  },
+];
+
+// Mock at the module level so we control both fetch functions
+vi.mock('../../services/tokenAnalyticsApi', () => ({
+  fetchTokenStats: vi.fn(),
+  fetchBurnRecords: vi.fn(),
+}));
+
+import * as api from '../../services/tokenAnalyticsApi';
+
+beforeEach(() => {
+  vi.mocked(api.fetchTokenStats).mockResolvedValue(mockStats);
+  vi.mocked(api.fetchBurnRecords).mockResolvedValue(mockBurnRecords);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('TokenAnalyticsPage integration', () => {
+  it('renders the page heading', async () => {
+    render(<TokenAnalyticsPage address={TEST_ADDRESS} />);
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: /Test Token Analytics/i })).toBeInTheDocument()
+    );
+  });
+
+  it('renders KPI cards with data from the API', async () => {
+    render(<TokenAnalyticsPage address={TEST_ADDRESS} />);
+    await waitFor(() => expect(screen.getByText(/Total Burned/i)).toBeInTheDocument());
+    expect(screen.getByText(/Burn Events/i)).toBeInTheDocument();
+    expect(screen.getByText(/Unique Burners/i)).toBeInTheDocument();
+  });
+
+  it('renders the supply chart container', async () => {
+    render(<TokenAnalyticsPage address={TEST_ADDRESS} />);
+    await waitFor(() =>
+      expect(screen.getByRole('img', { name: /supply over time/i })).toBeInTheDocument()
+    );
+  });
+
+  it('renders the burn rate chart container', async () => {
+    render(<TokenAnalyticsPage address={TEST_ADDRESS} />);
+    await waitFor(() =>
+      expect(screen.getByRole('img', { name: /daily.*burn volume/i })).toBeInTheDocument()
+    );
+  });
+
+  it('renders the activity feed with burn records', async () => {
+    render(<TokenAnalyticsPage address={TEST_ADDRESS} />);
+    await waitFor(() =>
+      expect(screen.getByRole('list', { name: /recent burn activity/i })).toBeInTheDocument()
+    );
+    expect(screen.getAllByRole('listitem').length).toBeGreaterThan(0);
+  });
+
+  it('shows error state when API fails', async () => {
+    vi.mocked(api.fetchTokenStats).mockRejectedValue(new Error('Network error'));
+    vi.mocked(api.fetchBurnRecords).mockRejectedValue(new Error('Network error'));
+
+    render(<TokenAnalyticsPage address={TEST_ADDRESS} />);
+    await waitFor(() => expect(screen.getByText(/Network error/i)).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/utils/__tests__/analyticsTransforms.test.ts
+++ b/frontend/src/utils/__tests__/analyticsTransforms.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { groupBurnsByDay, normaliseSupplyHistory } from '../analyticsTransforms';
+import type { BurnRecord } from '../../services/tokenAnalyticsApi';
+
+// Helper: build a minimal BurnRecord
+function rec(overrides: Partial<BurnRecord> & { timestamp: number; amount: string }): BurnRecord {
+  return {
+    id: overrides.timestamp.toString(),
+    from: 'GCTEST',
+    isAdminBurn: false,
+    txHash: 'txhash',
+    ...overrides,
+  };
+}
+
+const DAY = 86400; // seconds
+
+describe('groupBurnsByDay', () => {
+  it('returns empty array for empty input', () => {
+    expect(groupBurnsByDay([], 7)).toEqual([]);
+  });
+
+  it('aggregates two burns on the same day', () => {
+    const base = 1_700_000_000; // 2023-11-14 (arbitrary)
+    const records = [
+      rec({ timestamp: base, amount: '10_0000000'.replace('_', '') }),
+      rec({ timestamp: base + 3600, amount: '5_0000000'.replace('_', '') }),
+    ];
+    const result = groupBurnsByDay(records, 7);
+    expect(result).toHaveLength(1);
+    expect(result[0].burned).toBeCloseTo(15);
+    expect(result[0].count).toBe(2);
+  });
+
+  it('separates burns on different days', () => {
+    const base = 1_700_000_000;
+    const records = [
+      rec({ timestamp: base, amount: '10000000' }),
+      rec({ timestamp: base + DAY, amount: '20000000' }),
+    ];
+    const result = groupBurnsByDay(records, 7);
+    expect(result).toHaveLength(2);
+    // sorted ascending by date
+    expect(result[0].burned).toBeCloseTo(1);
+    expect(result[1].burned).toBeCloseTo(2);
+  });
+
+  it('normalises amounts using decimals', () => {
+    const records = [rec({ timestamp: 1_700_000_000, amount: '1000' })];
+    expect(groupBurnsByDay(records, 3)[0].burned).toBeCloseTo(1);
+    expect(groupBurnsByDay(records, 0)[0].burned).toBe(1000);
+  });
+
+  it('returns result sorted by date ascending', () => {
+    const base = 1_700_000_000;
+    const records = [
+      rec({ timestamp: base + DAY * 2, amount: '1' }),
+      rec({ timestamp: base, amount: '1' }),
+      rec({ timestamp: base + DAY, amount: '1' }),
+    ];
+    const result = groupBurnsByDay(records, 0);
+    expect(result[0].date < result[1].date).toBe(true);
+    expect(result[1].date < result[2].date).toBe(true);
+  });
+});
+
+describe('normaliseSupplyHistory', () => {
+  it('returns empty array for empty input', () => {
+    expect(normaliseSupplyHistory([], 7)).toEqual([]);
+  });
+
+  it('normalises supply using decimals', () => {
+    const history = [{ timestamp: 1_700_000_000, supply: '10000000' }];
+    const result = normaliseSupplyHistory(history, 7);
+    expect(result[0].supply).toBeCloseTo(1);
+  });
+
+  it('produces ISO date strings sliced to YYYY-MM-DD', () => {
+    const result = normaliseSupplyHistory([{ timestamp: 1_700_000_000, supply: '1' }], 0);
+    expect(result[0].date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it('sorts by date ascending', () => {
+    const history = [
+      { timestamp: 1_700_000_000 + DAY, supply: '1' },
+      { timestamp: 1_700_000_000, supply: '2' },
+    ];
+    const result = normaliseSupplyHistory(history, 0);
+    expect(result[0].date < result[1].date).toBe(true);
+  });
+});

--- a/frontend/src/utils/analyticsTransforms.ts
+++ b/frontend/src/utils/analyticsTransforms.ts
@@ -1,0 +1,63 @@
+/**
+ * Data-transformation utilities for the Token Analytics Dashboard.
+ *
+ * These are pure functions with no side-effects so they are easy to unit-test.
+ */
+
+import type { BurnRecord } from '../services/tokenAnalyticsApi';
+
+export interface DailyBurnPoint {
+  date: string;       // ISO date "YYYY-MM-DD"
+  burned: number;
+  count: number;
+}
+
+export interface SupplyPoint {
+  date: string;
+  supply: number;
+}
+
+/**
+ * Group burn records by calendar day (UTC) and sum amounts.
+ *
+ * @param records  Raw burn records with Unix-second timestamps and string amounts
+ * @param decimals Token decimals used to normalise the raw amount
+ */
+export function groupBurnsByDay(
+  records: BurnRecord[],
+  decimals: number
+): DailyBurnPoint[] {
+  const map = new Map<string, DailyBurnPoint>();
+
+  for (const rec of records) {
+    const date = new Date(rec.timestamp * 1000).toISOString().slice(0, 10);
+    const amount = Number(BigInt(rec.amount)) / 10 ** decimals;
+    const existing = map.get(date);
+    if (existing) {
+      existing.burned += amount;
+      existing.count += 1;
+    } else {
+      map.set(date, { date, burned: amount, count: 1 });
+    }
+  }
+
+  return Array.from(map.values()).sort((a, b) => a.date.localeCompare(b.date));
+}
+
+/**
+ * Convert raw supply-history snapshots into chart-ready points.
+ *
+ * @param history   Array of { timestamp, supply } from the REST stats endpoint
+ * @param decimals  Token decimals
+ */
+export function normaliseSupplyHistory(
+  history: Array<{ timestamp: number; supply: string }>,
+  decimals: number
+): SupplyPoint[] {
+  return history
+    .map(({ timestamp, supply }) => ({
+      date: new Date(timestamp * 1000).toISOString().slice(0, 10),
+      supply: Number(BigInt(supply)) / 10 ** decimals,
+    }))
+    .sort((a, b) => a.date.localeCompare(b.date));
+}


### PR DESCRIPTION
## Summary

Adds a **Token Analytics Dashboard** at `/tokens/:address/analytics` that lets token creators monitor their token's health at a glance. Closes #1259 

## Changes

### New files
| File | Purpose |
|------|---------|
| `services/tokenAnalyticsApi.ts` | REST `GET /api/tokens/:address/stats` + GraphQL `burnRecords` |
| `utils/analyticsTransforms.ts` | Pure data-transform utilities (`groupBurnsByDay`, `normaliseSupplyHistory`) |
| `hooks/useTokenAnalytics.ts` | Hook fetching both endpoints in parallel, returns unified shape |
| `components/TokenAnalytics/SupplyChart.tsx` | Line chart of supply over time (Recharts) |
| `components/TokenAnalytics/BurnRateChart.tsx` | Bar chart of daily burn volume (Recharts) |
| `components/TokenAnalytics/ActivityFeed.tsx` | Ordered list of recent burn events |
| `components/TokenAnalytics/index.ts` | Barrel export |
| `pages/TokenAnalyticsPage.tsx` | Dashboard page with KPI cards + charts + feed |

### Modified files
- `App.tsx` — lazy-loaded route `/tokens/:address/analytics`
- `components/TransactionHistory/TokenCard.tsx` — 'Analytics' deep-link per token card

### Tests
- **9 unit tests** for `analyticsTransforms.ts`
- **6 integration tests** for `TokenAnalyticsPage` with mocked API layer

## Verified
- `tsc --noEmit` — 0 errors
- 15/15 tests pass

## No new required environment variables
Reads `VITE_API_BASE_URL` (existing) and optionally `VITE_GRAPHQL_URL` (falls back to `/api/graphql`).