### PR TITLE
feat(frontend): add governance proposal creation form with multi-step validation

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -39,6 +39,8 @@
     "@sentry/browser": "^10.40.0",
     "@stellar/freighter-api": "^6.0.1",
     "@stellar/stellar-sdk": "^15.0.1",
+    "@types/dompurify": "^3.0.5",
+    "dompurify": "^3.4.11",
     "i18next": "^25.8.12",
     "i18next-browser-languagedetector": "^8.2.1",
     "lucide-react": "^0.575.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,7 @@ const LandingPage = lazy(() => import("./pages/LandingPage"));
 const NotFoundRoute = lazy(() => import("./routes/NotFoundRoute"));
 const RecurringPayments = lazy(() => import("./app/dashboard/RecurringPayments"));
 const CampaignDashboard = lazy(() => import("./app/dashboard/CampaignDashboard"));
+const GovernancePage = lazy(() => import("./pages/GovernancePage"));
 
 // Loading fallback
 function PageLoader() {
@@ -108,6 +109,20 @@ function App({ compatibilityInfo }: { compatibilityInfo?: CompatibilityInfo }) {
           currentPath={pathname}
         >
           <RecurringPayments />
+        </DashboardLayout>
+      );
+    }
+
+    if (pathname === "/governance") {
+      return (
+        <DashboardLayout
+          wallet={wallet}
+          onConnect={connect}
+          onDisconnect={disconnect}
+          isConnecting={isConnecting}
+          currentPath={pathname}
+        >
+          <GovernancePage wallet={wallet} />
         </DashboardLayout>
       );
     }

--- a/frontend/src/components/Governance/CreateProposalForm.tsx
+++ b/frontend/src/components/Governance/CreateProposalForm.tsx
@@ -1,0 +1,604 @@
+/**
+ * Governance Proposal Creation Form
+ * Multi-step form for submitting on-chain governance proposals.
+ * Steps: type selection → parameters → description → preview → submit
+ */
+
+import { useState } from 'react';
+import DOMPurify from 'dompurify';
+import { Card } from '../UI/Card';
+import { Button } from '../UI/Button';
+import { Spinner } from '../UI/Spinner';
+import { truncateAddress } from '../../utils/formatting';
+import { useGovernance } from '../../hooks/useGovernance';
+import type { WalletState } from '../../types';
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+export const PROPOSAL_TYPES = [
+  {
+    value: 'PARAMETER_CHANGE',
+    label: 'Parameter Change',
+    description: 'Modify on-chain protocol parameters such as fees or limits.',
+  },
+  {
+    value: 'ADMIN_TRANSFER',
+    label: 'Admin Transfer',
+    description: 'Transfer admin authority to a new address.',
+  },
+  {
+    value: 'TREASURY_SPEND',
+    label: 'Treasury Spend',
+    description: 'Authorize a treasury disbursement to a specified recipient.',
+  },
+  {
+    value: 'CONTRACT_UPGRADE',
+    label: 'Contract Upgrade',
+    description: 'Upgrade the smart contract to a new implementation.',
+  },
+  {
+    value: 'CUSTOM',
+    label: 'Custom',
+    description: 'A general-purpose proposal with arbitrary payload data.',
+  },
+] as const;
+
+export type ProposalTypeValue = (typeof PROPOSAL_TYPES)[number]['value'];
+
+/** Minimum voting period: 1 day in seconds */
+export const MIN_VOTING_PERIOD_SECONDS = 86_400;
+/** Maximum voting period: 30 days in seconds */
+export const MAX_VOTING_PERIOD_SECONDS = 2_592_000;
+/** Maximum title length */
+export const MAX_TITLE_LENGTH = 200;
+/** Minimum quorum percentage */
+export const MIN_QUORUM_PERCENT = 1;
+/** Maximum quorum percentage */
+export const MAX_QUORUM_PERCENT = 100;
+
+// ─── Validation ───────────────────────────────────────────────────────────────
+
+export interface ValidationErrors {
+  title?: string;
+  votingPeriodDays?: string;
+  description?: string;
+  payload?: string;
+}
+
+export function validateProposalForm(fields: {
+  title: string;
+  votingPeriodDays: number;
+  description: string;
+  payload: string;
+}): ValidationErrors {
+  const errors: ValidationErrors = {};
+
+  if (!fields.title.trim()) {
+    errors.title = 'Title is required.';
+  } else if (fields.title.trim().length > MAX_TITLE_LENGTH) {
+    errors.title = `Title must be ${MAX_TITLE_LENGTH} characters or fewer.`;
+  }
+
+  const periodSeconds = fields.votingPeriodDays * 86_400;
+  if (
+    !Number.isFinite(fields.votingPeriodDays) ||
+    fields.votingPeriodDays <= 0 ||
+    periodSeconds < MIN_VOTING_PERIOD_SECONDS
+  ) {
+    errors.votingPeriodDays = `Voting period must be at least ${MIN_VOTING_PERIOD_SECONDS / 86_400} day(s).`;
+  } else if (periodSeconds > MAX_VOTING_PERIOD_SECONDS) {
+    errors.votingPeriodDays = `Voting period must be at most ${MAX_VOTING_PERIOD_SECONDS / 86_400} days.`;
+  }
+
+  if (!fields.description.trim()) {
+    errors.description = 'Description is required.';
+  }
+
+  if (!fields.payload.trim()) {
+    errors.payload = 'Payload is required.';
+  }
+
+  return errors;
+}
+
+// ─── Sanitize helper ─────────────────────────────────────────────────────────
+
+export function sanitizeHtml(input: string): string {
+  return DOMPurify.sanitize(input, { ALLOWED_TAGS: [], ALLOWED_ATTR: [] });
+}
+
+// ─── Step types ───────────────────────────────────────────────────────────────
+
+type Step = 'type' | 'parameters' | 'description' | 'preview' | 'submit';
+
+const STEPS: Step[] = ['type', 'parameters', 'description', 'preview', 'submit'];
+
+const STEP_LABELS: Record<Step, string> = {
+  type: 'Type',
+  parameters: 'Parameters',
+  description: 'Description',
+  preview: 'Preview',
+  submit: 'Submit',
+};
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export interface CreateProposalFormProps {
+  /** Token address used to scope governance power checks */
+  tokenAddress: string;
+  /** Connected wallet state */
+  wallet: WalletState;
+  /** Called after a proposal is successfully submitted */
+  onSuccess?: (proposalId: string, txHash: string) => void;
+  /** Called when the user cancels the form */
+  onCancel?: () => void;
+}
+
+export function CreateProposalForm({
+  tokenAddress,
+  wallet,
+  onSuccess,
+  onCancel,
+}: CreateProposalFormProps) {
+  const { createProposal, reset, status, error, txHash, proposalId, isSubmitting } =
+    useGovernance(tokenAddress);
+
+  const [step, setStep] = useState<Step>('type');
+  const [proposalType, setProposalType] = useState<ProposalTypeValue>('PARAMETER_CHANGE');
+  const [title, setTitle] = useState('');
+  const [votingPeriodDays, setVotingPeriodDays] = useState(7);
+  const [description, setDescription] = useState('');
+  const [payload, setPayload] = useState('{}');
+  const [fieldErrors, setFieldErrors] = useState<ValidationErrors>({});
+
+  const currentStepIndex = STEPS.indexOf(step);
+
+  // ── Navigation ──────────────────────────────────────────────────────────────
+
+  const goNext = () => {
+    if (step === 'parameters') {
+      const errors = validateProposalForm({ title, votingPeriodDays, description, payload });
+      const stepErrors: ValidationErrors = {};
+      if (errors.title) stepErrors.title = errors.title;
+      if (errors.votingPeriodDays) stepErrors.votingPeriodDays = errors.votingPeriodDays;
+      if (errors.payload) stepErrors.payload = errors.payload;
+      if (Object.keys(stepErrors).length > 0) {
+        setFieldErrors(stepErrors);
+        return;
+      }
+      setFieldErrors({});
+    }
+
+    if (step === 'description') {
+      const errors = validateProposalForm({ title, votingPeriodDays, description, payload });
+      if (errors.description) {
+        setFieldErrors({ description: errors.description });
+        return;
+      }
+      setFieldErrors({});
+    }
+
+    const nextIndex = currentStepIndex + 1;
+    if (nextIndex < STEPS.length) {
+      setStep(STEPS[nextIndex]);
+    }
+  };
+
+  const goBack = () => {
+    const prevIndex = currentStepIndex - 1;
+    if (prevIndex >= 0) {
+      setStep(STEPS[prevIndex]);
+    }
+  };
+
+  // ── Submit ──────────────────────────────────────────────────────────────────
+
+  const handleSubmit = async () => {
+    const errors = validateProposalForm({ title, votingPeriodDays, description, payload });
+    if (Object.keys(errors).length > 0) {
+      setFieldErrors(errors);
+      return;
+    }
+
+    const sanitizedDescription = sanitizeHtml(description);
+
+    await createProposal(
+      {
+        title: title.trim(),
+        description: sanitizedDescription,
+        payloadType: proposalType,
+        payload: payload.trim(),
+        votingPeriod: votingPeriodDays * 86_400,
+      },
+      wallet
+    );
+  };
+
+  // ── Success screen ──────────────────────────────────────────────────────────
+
+  if (status === 'success' && proposalId && txHash) {
+    return (
+      <Card className="p-6">
+        <div className="text-center py-8">
+          <div className="w-16 h-16 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-4">
+            <svg className="w-8 h-8 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+            </svg>
+          </div>
+          <h2 className="text-2xl font-bold text-gray-900 mb-2">Proposal Created</h2>
+          <p className="text-gray-600 mb-6">Your proposal has been submitted on-chain.</p>
+          <div className="bg-gray-50 rounded-lg p-4 text-left mb-6 space-y-2">
+            <div className="flex justify-between text-sm">
+              <span className="text-gray-500">Proposal ID</span>
+              <span className="font-medium">{proposalId}</span>
+            </div>
+            <div className="flex justify-between text-sm">
+              <span className="text-gray-500">Transaction</span>
+              <span className="font-mono text-xs">{truncateAddress(txHash)}</span>
+            </div>
+          </div>
+          <div className="flex gap-3 justify-center">
+            <Button
+              variant="outline"
+              onClick={() => {
+                reset();
+                setStep('type');
+                setTitle('');
+                setDescription('');
+                setPayload('{}');
+                setVotingPeriodDays(7);
+                setProposalType('PARAMETER_CHANGE');
+              }}
+            >
+              Create Another
+            </Button>
+            {onSuccess && (
+              <Button variant="primary" onClick={() => onSuccess(proposalId, txHash)}>
+                View Proposal
+              </Button>
+            )}
+          </div>
+        </div>
+      </Card>
+    );
+  }
+
+  // ── Step progress indicator ─────────────────────────────────────────────────
+
+  const selectedType = PROPOSAL_TYPES.find((p) => p.value === proposalType);
+  const safeDescription = sanitizeHtml(description);
+
+  // ── Render ──────────────────────────────────────────────────────────────────
+
+  const isLastStep = step === 'submit';
+  const isFirstStep = step === 'type';
+
+  return (
+    <Card className="p-6">
+      <div className="mb-4 flex items-center justify-between">
+        <h1 className="text-xl font-bold text-gray-900">Create Proposal</h1>
+        {onCancel && (
+          <button
+            onClick={onCancel}
+            className="text-sm text-gray-500 hover:text-gray-700"
+            aria-label="Cancel form"
+          >
+            ✕
+          </button>
+        )}
+      </div>
+
+      {/* Step progress indicator */}
+      <div className="flex items-center gap-1 mb-6" aria-label="Form progress">
+        {STEPS.map((s, i) => (
+          <div key={s} className="flex items-center gap-1">
+            <div
+              className={`w-7 h-7 rounded-full flex items-center justify-center text-xs font-medium transition-colors ${
+                i < currentStepIndex
+                  ? 'bg-blue-600 text-white'
+                  : i === currentStepIndex
+                  ? 'bg-blue-100 text-blue-700 ring-2 ring-blue-600'
+                  : 'bg-gray-100 text-gray-400'
+              }`}
+              aria-current={i === currentStepIndex ? 'step' : undefined}
+            >
+              {i < currentStepIndex ? (
+                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                </svg>
+              ) : (
+                i + 1
+              )}
+            </div>
+            <span
+              className={`text-xs hidden sm:inline ${
+                i === currentStepIndex ? 'text-blue-700 font-medium' : 'text-gray-400'
+              }`}
+            >
+              {STEP_LABELS[s]}
+            </span>
+            {i < STEPS.length - 1 && (
+              <div
+                className={`flex-1 h-px w-4 mx-1 ${
+                  i < currentStepIndex ? 'bg-blue-600' : 'bg-gray-200'
+                }`}
+              />
+            )}
+          </div>
+        ))}
+      </div>
+
+      {/* Step content — rendered as JSX (not sub-components) to avoid unmount on re-render */}
+      <div className="min-h-[280px]">
+        {step === 'type' && (
+          <div>
+            <h2 className="text-lg font-semibold text-gray-900 mb-1">Select Proposal Type</h2>
+            <p className="text-sm text-gray-500 mb-4">
+              Choose the category that best describes your proposal.
+            </p>
+            <div className="space-y-3">
+              {PROPOSAL_TYPES.map((pt) => (
+                <label
+                  key={pt.value}
+                  className={`flex items-start gap-3 p-4 rounded-lg border-2 cursor-pointer transition-colors ${
+                    proposalType === pt.value
+                      ? 'border-blue-600 bg-blue-50'
+                      : 'border-gray-200 hover:border-gray-300'
+                  }`}
+                >
+                  <input
+                    type="radio"
+                    name="proposalType"
+                    value={pt.value}
+                    checked={proposalType === pt.value}
+                    onChange={() => setProposalType(pt.value)}
+                    className="mt-0.5 accent-blue-600"
+                  />
+                  <div>
+                    <p className="font-medium text-gray-900">{pt.label}</p>
+                    <p className="text-sm text-gray-500">{pt.description}</p>
+                  </div>
+                </label>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {step === 'parameters' && (
+          <div>
+            <h2 className="text-lg font-semibold text-gray-900 mb-1">Set Parameters</h2>
+            <p className="text-sm text-gray-500 mb-4">
+              Define the title, voting period, and payload for your proposal.
+            </p>
+
+            <div className="bg-amber-50 border border-amber-200 rounded-lg p-3 mb-4 text-sm text-amber-800">
+              <strong>On-chain constraints:</strong> Voting period must be between{' '}
+              {MIN_VOTING_PERIOD_SECONDS / 86_400} and {MAX_VOTING_PERIOD_SECONDS / 86_400} days.
+              Minimum quorum is enforced by the contract.
+            </div>
+
+            <div className="mb-4">
+              <label
+                className="block text-sm font-medium text-gray-700 mb-1"
+                htmlFor="proposal-title"
+              >
+                Title <span className="text-red-500">*</span>
+              </label>
+              <input
+                id="proposal-title"
+                type="text"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                maxLength={MAX_TITLE_LENGTH}
+                placeholder="e.g. Increase base fee to 10 XLM"
+                className={`w-full rounded-lg border px-3 py-2 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+                  fieldErrors.title ? 'border-red-400' : 'border-gray-300'
+                }`}
+              />
+              <div className="flex justify-between mt-1">
+                {fieldErrors.title ? (
+                  <p className="text-xs text-red-600">{fieldErrors.title}</p>
+                ) : (
+                  <span />
+                )}
+                <span className="text-xs text-gray-400">
+                  {title.length}/{MAX_TITLE_LENGTH}
+                </span>
+              </div>
+            </div>
+
+            <div className="mb-4">
+              <label
+                className="block text-sm font-medium text-gray-700 mb-1"
+                htmlFor="voting-period"
+              >
+                Voting Period (days) <span className="text-red-500">*</span>
+              </label>
+              <input
+                id="voting-period"
+                type="number"
+                min={1}
+                max={30}
+                value={votingPeriodDays}
+                onChange={(e) => setVotingPeriodDays(Number(e.target.value))}
+                className={`w-full rounded-lg border px-3 py-2 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+                  fieldErrors.votingPeriodDays ? 'border-red-400' : 'border-gray-300'
+                }`}
+              />
+              {fieldErrors.votingPeriodDays && (
+                <p className="text-xs text-red-600 mt-1">{fieldErrors.votingPeriodDays}</p>
+              )}
+            </div>
+
+            <div className="mb-2">
+              <label
+                className="block text-sm font-medium text-gray-700 mb-1"
+                htmlFor="proposal-payload"
+              >
+                Payload (JSON) <span className="text-red-500">*</span>
+              </label>
+              <textarea
+                id="proposal-payload"
+                value={payload}
+                onChange={(e) => setPayload(e.target.value)}
+                rows={4}
+                placeholder='{ "key": "value" }'
+                className={`w-full rounded-lg border px-3 py-2 text-sm font-mono text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+                  fieldErrors.payload ? 'border-red-400' : 'border-gray-300'
+                }`}
+              />
+              {fieldErrors.payload && (
+                <p className="text-xs text-red-600 mt-1">{fieldErrors.payload}</p>
+              )}
+            </div>
+          </div>
+        )}
+
+        {step === 'description' && (
+          <div>
+            <h2 className="text-lg font-semibold text-gray-900 mb-1">Write Description</h2>
+            <p className="text-sm text-gray-500 mb-4">
+              Explain the motivation, context, and expected outcome of your proposal. HTML is
+              stripped before storage.
+            </p>
+            <label
+              className="block text-sm font-medium text-gray-700 mb-1"
+              htmlFor="proposal-description"
+            >
+              Description <span className="text-red-500">*</span>
+            </label>
+            <textarea
+              id="proposal-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              rows={10}
+              placeholder="Describe your proposal in detail…"
+              className={`w-full rounded-lg border px-3 py-2 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+                fieldErrors.description ? 'border-red-400' : 'border-gray-300'
+              }`}
+            />
+            {fieldErrors.description && (
+              <p className="text-xs text-red-600 mt-1">{fieldErrors.description}</p>
+            )}
+          </div>
+        )}
+
+        {step === 'preview' && (
+          <div>
+            <h2 className="text-lg font-semibold text-gray-900 mb-1">Preview Proposal</h2>
+            <p className="text-sm text-gray-500 mb-4">
+              Review the finalized proposal before signing the transaction.
+            </p>
+
+            {/* Mirrors ProposalDetail layout */}
+            <div className="border rounded-lg p-5 space-y-5 bg-gray-50" data-testid="proposal-preview">
+              <div className="flex items-start justify-between">
+                <div>
+                  <h1 className="text-xl font-bold text-gray-900">{title || '(no title)'}</h1>
+                  <p className="text-sm text-gray-500 mt-0.5">Draft — not yet submitted</p>
+                </div>
+                <span className="px-3 py-1 text-sm font-medium rounded-full bg-gray-100 text-gray-700">
+                  Draft
+                </span>
+              </div>
+
+              <div>
+                <span className="inline-block px-2 py-1 text-xs font-medium rounded bg-blue-100 text-blue-700">
+                  {selectedType?.label ?? proposalType}
+                </span>
+              </div>
+
+              <div>
+                <h2 className="text-base font-medium text-gray-900 mb-1">Description</h2>
+                <p className="text-gray-600 whitespace-pre-wrap text-sm">
+                  {safeDescription || '(no description)'}
+                </p>
+              </div>
+
+              <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+                <div className="p-3 bg-white rounded-lg border">
+                  <div className="text-xs text-gray-500">Proposer</div>
+                  <div className="font-medium text-sm">
+                    {wallet.address ? truncateAddress(wallet.address) : '—'}
+                  </div>
+                </div>
+                <div className="p-3 bg-white rounded-lg border">
+                  <div className="text-xs text-gray-500">Voting Period</div>
+                  <div className="font-medium text-sm">{votingPeriodDays} day(s)</div>
+                </div>
+                <div className="p-3 bg-white rounded-lg border">
+                  <div className="text-xs text-gray-500">Type</div>
+                  <div className="font-medium text-sm">{selectedType?.label ?? proposalType}</div>
+                </div>
+              </div>
+
+              <div>
+                <h2 className="text-base font-medium text-gray-900 mb-1">Payload</h2>
+                <pre className="text-xs bg-white border rounded p-3 overflow-x-auto text-gray-700">
+                  {payload}
+                </pre>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {step === 'submit' && (
+          <div>
+            <h2 className="text-lg font-semibold text-gray-900 mb-1">Sign &amp; Submit</h2>
+            <p className="text-sm text-gray-500 mb-4">
+              Your wallet will prompt you to sign the transaction. Once signed, the proposal will
+              be submitted on-chain.
+            </p>
+
+            {!wallet.connected && (
+              <div className="bg-amber-50 border border-amber-200 rounded-lg p-3 mb-4 text-sm text-amber-800">
+                Please connect your wallet before submitting.
+              </div>
+            )}
+
+            {error && (
+              <div className="bg-red-50 border border-red-200 rounded-lg p-3 mb-4 text-sm text-red-700">
+                {error}
+              </div>
+            )}
+
+            {isSubmitting && (
+              <div className="flex items-center gap-3 py-6 justify-center">
+                <Spinner size="md" />
+                <span className="text-gray-600 text-sm">Submitting proposal to the network…</span>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Navigation buttons */}
+      <div className="flex justify-between mt-6 pt-4 border-t border-gray-100">
+        <Button
+          variant="outline"
+          onClick={isFirstStep ? onCancel : goBack}
+          disabled={isSubmitting}
+        >
+          {isFirstStep ? 'Cancel' : 'Back'}
+        </Button>
+
+        {isLastStep ? (
+          <Button
+            variant="primary"
+            onClick={handleSubmit}
+            disabled={isSubmitting || !wallet.connected}
+            loading={isSubmitting}
+          >
+            Submit Proposal
+          </Button>
+        ) : (
+          <Button variant="primary" onClick={goNext}>
+            Next
+          </Button>
+        )}
+      </div>
+    </Card>
+  );
+}
+
+export default CreateProposalForm;

--- a/frontend/src/components/Governance/__tests__/CreateProposalForm.test.tsx
+++ b/frontend/src/components/Governance/__tests__/CreateProposalForm.test.tsx
@@ -1,0 +1,337 @@
+/**
+ * Tests for CreateProposalForm
+ *
+ * Covers:
+ *  1. Form validation — title length, voting period bounds, description, payload
+ *  2. XSS sanitization of description fields
+ *  3. Integration flow — simulates a full proposal creation with a mocked API call
+ *  4. Step navigation — next/back behaviour
+ *  5. Submit button disabled when wallet disconnected
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {
+  CreateProposalForm,
+  validateProposalForm,
+  sanitizeHtml,
+  MAX_TITLE_LENGTH,
+  MIN_VOTING_PERIOD_SECONDS,
+  MAX_VOTING_PERIOD_SECONDS,
+} from '../CreateProposalForm';
+import * as governanceApi from '../../../services/governanceApi';
+import type { WalletState } from '../../../types';
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+const CONNECTED_WALLET: WalletState = {
+  connected: true,
+  address: 'GBUQWP3BOUZX34ULNQG23RQ6F4YUSXHTQSXUSMIQSTBE2EURIDVXL6B',
+  network: 'testnet',
+};
+
+const DISCONNECTED_WALLET: WalletState = {
+  connected: false,
+  address: null,
+  network: 'testnet',
+};
+
+// ─── 1. Validation unit tests ────────────────────────────────────────────────
+
+describe('validateProposalForm', () => {
+  const BASE = {
+    title: 'Valid title',
+    votingPeriodDays: 7,
+    description: 'A valid description.',
+    payload: '{}',
+  };
+
+  it('returns no errors for valid inputs', () => {
+    expect(validateProposalForm(BASE)).toEqual({});
+  });
+
+  it('requires a non-empty title', () => {
+    const errors = validateProposalForm({ ...BASE, title: '   ' });
+    expect(errors.title).toBeDefined();
+  });
+
+  it(`rejects titles longer than ${MAX_TITLE_LENGTH} characters`, () => {
+    const errors = validateProposalForm({ ...BASE, title: 'x'.repeat(MAX_TITLE_LENGTH + 1) });
+    expect(errors.title).toMatch(/200/);
+  });
+
+  it(`accepts titles of exactly ${MAX_TITLE_LENGTH} characters`, () => {
+    const errors = validateProposalForm({ ...BASE, title: 'x'.repeat(MAX_TITLE_LENGTH) });
+    expect(errors.title).toBeUndefined();
+  });
+
+  it(`rejects voting period below ${MIN_VOTING_PERIOD_SECONDS / 86_400} day`, () => {
+    const errors = validateProposalForm({ ...BASE, votingPeriodDays: 0 });
+    expect(errors.votingPeriodDays).toBeDefined();
+  });
+
+  it(`rejects voting period above ${MAX_VOTING_PERIOD_SECONDS / 86_400} days`, () => {
+    const errors = validateProposalForm({ ...BASE, votingPeriodDays: 31 });
+    expect(errors.votingPeriodDays).toBeDefined();
+  });
+
+  it('accepts voting period of 1 day (minimum)', () => {
+    const errors = validateProposalForm({ ...BASE, votingPeriodDays: 1 });
+    expect(errors.votingPeriodDays).toBeUndefined();
+  });
+
+  it('accepts voting period of 30 days (maximum)', () => {
+    const errors = validateProposalForm({ ...BASE, votingPeriodDays: 30 });
+    expect(errors.votingPeriodDays).toBeUndefined();
+  });
+
+  it('requires a non-empty description', () => {
+    const errors = validateProposalForm({ ...BASE, description: '' });
+    expect(errors.description).toBeDefined();
+  });
+
+  it('requires a non-empty payload', () => {
+    const errors = validateProposalForm({ ...BASE, payload: '   ' });
+    expect(errors.payload).toBeDefined();
+  });
+});
+
+// ─── 2. XSS sanitization tests ───────────────────────────────────────────────
+
+describe('sanitizeHtml', () => {
+  it('strips script tags from input', () => {
+    const malicious = '<script>alert("xss")</script>Hello';
+    expect(sanitizeHtml(malicious)).toBe('Hello');
+  });
+
+  it('strips img onerror attributes', () => {
+    const malicious = '<img src=x onerror="alert(1)">text';
+    expect(sanitizeHtml(malicious)).toBe('text');
+  });
+
+  it('strips all HTML tags, preserving text content', () => {
+    const input = '<b>Bold</b> and <em>italic</em>';
+    expect(sanitizeHtml(input)).toBe('Bold and italic');
+  });
+
+  it('passes through plain text unchanged', () => {
+    const plain = 'No HTML here, just text.';
+    expect(sanitizeHtml(plain)).toBe(plain);
+  });
+
+  it('handles empty string', () => {
+    expect(sanitizeHtml('')).toBe('');
+  });
+});
+
+// ─── 3. Component rendering and step navigation ───────────────────────────────
+
+describe('CreateProposalForm — rendering', () => {
+  it('renders the type selection step by default', () => {
+    render(
+      <CreateProposalForm
+        tokenAddress=""
+        wallet={CONNECTED_WALLET}
+      />
+    );
+    expect(screen.getByText('Select Proposal Type')).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: /Parameter Change/i })).toBeInTheDocument();
+  });
+
+  it('navigates to parameters step on Next', async () => {
+    const user = userEvent.setup();
+    render(<CreateProposalForm tokenAddress="" wallet={CONNECTED_WALLET} />);
+
+    await user.click(screen.getByRole('button', { name: /Next/i }));
+    expect(screen.getByText('Set Parameters')).toBeInTheDocument();
+  });
+
+  it('shows validation errors when advancing from parameters with empty title', async () => {
+    const user = userEvent.setup();
+    render(<CreateProposalForm tokenAddress="" wallet={CONNECTED_WALLET} />);
+
+    // Go to parameters step
+    await user.click(screen.getByRole('button', { name: /Next/i }));
+
+    // Clear title and try to advance
+    const titleInput = screen.getByLabelText(/Title/i);
+    await user.clear(titleInput);
+    await user.click(screen.getByRole('button', { name: /Next/i }));
+
+    expect(screen.getByText(/Title is required/i)).toBeInTheDocument();
+  });
+
+  it('shows error when voting period exceeds 30 days', async () => {
+    const user = userEvent.setup();
+    render(<CreateProposalForm tokenAddress="" wallet={CONNECTED_WALLET} />);
+
+    await user.click(screen.getByRole('button', { name: /Next/i }));
+
+    const titleInput = screen.getByLabelText(/Title/i);
+    await user.type(titleInput, 'My Proposal');
+
+    const periodInput = screen.getByLabelText(/Voting Period/i);
+    fireEvent.change(periodInput, { target: { value: '31' } });
+
+    await user.click(screen.getByRole('button', { name: /Next/i }));
+    expect(screen.getByText(/at most 30 days/i)).toBeInTheDocument();
+  });
+
+  it('navigates back from parameters to type step', async () => {
+    const user = userEvent.setup();
+    render(<CreateProposalForm tokenAddress="" wallet={CONNECTED_WALLET} />);
+
+    await user.click(screen.getByRole('button', { name: /Next/i }));
+    expect(screen.getByText('Set Parameters')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /Back/i }));
+    expect(screen.getByText('Select Proposal Type')).toBeInTheDocument();
+  });
+
+  it('disables Submit Proposal button when wallet is disconnected', async () => {
+    const user = userEvent.setup();
+    render(<CreateProposalForm tokenAddress="" wallet={DISCONNECTED_WALLET} />);
+
+    // Navigate all the way to submit step
+    // Step 1 → type (default), click Next
+    await user.click(screen.getByRole('button', { name: /Next/i }));
+
+    // Step 2 → parameters: fill required fields
+    await user.type(screen.getByLabelText(/Title/i), 'Test Proposal');
+    await user.click(screen.getByRole('button', { name: /Next/i }));
+
+    // Step 3 → description
+    await user.type(screen.getByLabelText(/Description/i), 'A detailed description.');
+    await user.click(screen.getByRole('button', { name: /Next/i }));
+
+    // Step 4 → preview
+    await user.click(screen.getByRole('button', { name: /Next/i }));
+
+    // Step 5 → submit
+    const submitBtn = screen.getByRole('button', { name: /Submit Proposal/i });
+    expect(submitBtn).toBeDisabled();
+  });
+
+  it('calls onCancel when Cancel button is clicked on first step', async () => {
+    const onCancel = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <CreateProposalForm tokenAddress="" wallet={CONNECTED_WALLET} onCancel={onCancel} />
+    );
+
+    // The footer "Cancel" button is visible on the first step
+    const cancelButtons = screen.getAllByRole('button', { name: /Cancel/i });
+    // Click the visible footer Cancel button (last one found, or the one named exactly "Cancel")
+    await user.click(cancelButtons[cancelButtons.length - 1]);
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+});
+
+// ─── 4. Integration flow ──────────────────────────────────────────────────────
+
+describe('CreateProposalForm — full creation flow (mocked API)', () => {
+  beforeEach(() => {
+    vi.spyOn(governanceApi, 'submitProposal').mockResolvedValue({
+      txHash: 'tx-abc-123',
+      proposalId: 'prop-42',
+    });
+    vi.spyOn(governanceApi, 'invalidateProposalListCache').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('completes the full flow and shows the success screen', async () => {
+    const onSuccess = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <CreateProposalForm
+        tokenAddress="TOKEN_ADDR"
+        wallet={CONNECTED_WALLET}
+        onSuccess={onSuccess}
+      />
+    );
+
+    // Step 1 — type (select CUSTOM)
+    const customRadio = screen.getByRole('radio', { name: /Custom/i });
+    await user.click(customRadio);
+    await user.click(screen.getByRole('button', { name: /Next/i }));
+
+    // Step 2 — parameters
+    await user.type(screen.getByLabelText(/Title/i), 'My integration test proposal');
+    // Voting period defaults to 7 — keep it
+    await user.click(screen.getByRole('button', { name: /Next/i }));
+
+    // Step 3 — description
+    await user.type(screen.getByLabelText(/Description/i), 'Detailed description here.');
+    await user.click(screen.getByRole('button', { name: /Next/i }));
+
+    // Step 4 — preview (just advance)
+    expect(screen.getByText('Preview Proposal')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /Next/i }));
+
+    // Step 5 — submit
+    expect(screen.getByText('Sign & Submit')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /Submit Proposal/i }));
+
+    // Wait for success screen
+    await waitFor(() => {
+      expect(screen.getByText('Proposal Created')).toBeInTheDocument();
+    });
+
+    expect(governanceApi.submitProposal).toHaveBeenCalledWith(
+      'My integration test proposal',
+      'Detailed description here.',
+      'CUSTOM',
+      expect.any(String),
+      7 * 86_400,
+      CONNECTED_WALLET
+    );
+
+    expect(screen.getByText('prop-42')).toBeInTheDocument();
+  });
+
+  it('shows an error message when the API call fails', async () => {
+    vi.spyOn(governanceApi, 'submitProposal').mockRejectedValue(
+      new Error('Network error: proposal rejected')
+    );
+
+    const user = userEvent.setup();
+    render(<CreateProposalForm tokenAddress="" wallet={CONNECTED_WALLET} />);
+
+    // Navigate to submit
+    await user.click(screen.getByRole('button', { name: /Next/i }));
+    await user.type(screen.getByLabelText(/Title/i), 'Failing proposal');
+    await user.click(screen.getByRole('button', { name: /Next/i }));
+    await user.type(screen.getByLabelText(/Description/i), 'This will fail.');
+    await user.click(screen.getByRole('button', { name: /Next/i }));
+    await user.click(screen.getByRole('button', { name: /Next/i }));
+
+    await user.click(screen.getByRole('button', { name: /Submit Proposal/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Network error: proposal rejected/i)).toBeInTheDocument();
+    });
+  });
+
+  it('renders sanitized description in the preview step (XSS test)', async () => {
+    const user = userEvent.setup();
+    render(<CreateProposalForm tokenAddress="" wallet={CONNECTED_WALLET} />);
+
+    await user.click(screen.getByRole('button', { name: /Next/i }));
+    await user.type(screen.getByLabelText(/Title/i), 'XSS Test');
+    await user.click(screen.getByRole('button', { name: /Next/i }));
+
+    const xssInput = '<script>alert("xss")</script>Safe text';
+    await user.type(screen.getByLabelText(/Description/i), xssInput);
+    await user.click(screen.getByRole('button', { name: /Next/i }));
+
+    // On preview step — script tag must not be rendered
+    const preview = screen.getByTestId('proposal-preview');
+    expect(within(preview).queryByText(/alert/)).not.toBeInTheDocument();
+    expect(within(preview).getByText(/Safe text/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/Layout/DashboardLayout.tsx
+++ b/frontend/src/components/Layout/DashboardLayout.tsx
@@ -47,6 +47,15 @@ const NAV_ITEMS: NavItem[] = [
     ),
   },
   {
+    label: 'Governance',
+    href: '/governance',
+    icon: (
+      <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" />
+      </svg>
+    ),
+  },
+  {
     label: 'Webhooks',
     href: '/webhooks',
     icon: (

--- a/frontend/src/hooks/useGovernance.ts
+++ b/frontend/src/hooks/useGovernance.ts
@@ -1,0 +1,89 @@
+import { useState } from 'react';
+import type { WalletState } from '../types';
+import {
+  submitProposal,
+  fetchVoterInfo,
+  invalidateProposalListCache,
+} from '../services/governanceApi';
+
+export type GovernanceStatus = 'idle' | 'submitting' | 'success' | 'error';
+
+export interface CreateProposalInput {
+  title: string;
+  description: string;
+  payloadType: string;
+  payload: string;
+  votingPeriod: number;
+}
+
+export function useGovernance(_tokenAddress: string) {
+  const [status, setStatus] = useState<GovernanceStatus>('idle');
+  const [error, setError] = useState<string | null>(null);
+  const [txHash, setTxHash] = useState<string | null>(null);
+  const [proposalId, setProposalId] = useState<string | null>(null);
+  const [votingPower, setVotingPower] = useState<string | null>(null);
+
+  const createProposal = async (
+    params: CreateProposalInput,
+    wallet: WalletState
+  ): Promise<void> => {
+    if (!wallet.connected || !wallet.address) {
+      setError('Wallet not connected');
+      return;
+    }
+
+    setStatus('submitting');
+    setError(null);
+
+    try {
+      const result = await submitProposal(
+        params.title,
+        params.description,
+        params.payloadType,
+        params.payload,
+        params.votingPeriod,
+        wallet
+      );
+
+      setTxHash(result.txHash);
+      setProposalId(result.proposalId);
+      setStatus('success');
+      invalidateProposalListCache();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create proposal');
+      setStatus('error');
+    }
+  };
+
+  const checkGovernancePower = async (wallet: WalletState): Promise<boolean> => {
+    if (!wallet.connected || !wallet.address) return false;
+
+    try {
+      const info = await fetchVoterInfo(wallet.address);
+      const power = info.votingPower;
+      setVotingPower(power);
+      return BigInt(power) > 0n;
+    } catch {
+      return false;
+    }
+  };
+
+  const reset = () => {
+    setStatus('idle');
+    setError(null);
+    setTxHash(null);
+    setProposalId(null);
+  };
+
+  return {
+    createProposal,
+    checkGovernancePower,
+    reset,
+    status,
+    error,
+    txHash,
+    proposalId,
+    votingPower,
+    isSubmitting: status === 'submitting',
+  };
+}

--- a/frontend/src/pages/GovernancePage.tsx
+++ b/frontend/src/pages/GovernancePage.tsx
@@ -1,0 +1,85 @@
+/**
+ * Governance Page
+ * Lists proposals and conditionally shows a "Create Proposal" button for
+ * token holders who have governance power.
+ */
+
+import { useState, useEffect } from 'react';
+import { ProposalList } from '../components/Governance/ProposalList';
+import { ProposalDetail } from '../components/Governance/ProposalDetail';
+import { CreateProposalForm } from '../components/Governance/CreateProposalForm';
+import { Button } from '../components/UI/Button';
+import { useGovernance } from '../hooks/useGovernance';
+import type { GovernanceProposal, WalletState } from '../types';
+
+interface GovernancePageProps {
+  wallet: WalletState;
+}
+
+export function GovernancePage({ wallet }: GovernancePageProps) {
+  const [selectedProposal, setSelectedProposal] = useState<GovernanceProposal | null>(null);
+  const [showCreateForm, setShowCreateForm] = useState(false);
+  const [hasGovernancePower, setHasGovernancePower] = useState(false);
+  const [listKey, setListKey] = useState(0);
+
+  // Use an empty string as placeholder; in production pass the real token address
+  const { checkGovernancePower } = useGovernance('');
+
+  useEffect(() => {
+    if (!wallet.connected) {
+      setHasGovernancePower(false);
+      return;
+    }
+    checkGovernancePower(wallet).then(setHasGovernancePower).catch(() => {
+      setHasGovernancePower(false);
+    });
+  }, [wallet.connected, wallet.address]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  if (showCreateForm) {
+    return (
+      <div className="max-w-2xl mx-auto py-8 px-4">
+        <CreateProposalForm
+          tokenAddress=""
+          wallet={wallet}
+          onCancel={() => setShowCreateForm(false)}
+          onSuccess={(_proposalId, _txHash) => {
+            setShowCreateForm(false);
+            setListKey((k) => k + 1);
+          }}
+        />
+      </div>
+    );
+  }
+
+  if (selectedProposal) {
+    return (
+      <div className="max-w-3xl mx-auto py-8 px-4">
+        <ProposalDetail
+          proposalId={selectedProposal.id}
+          wallet={wallet}
+          onBack={() => setSelectedProposal(null)}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto py-8 px-4">
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-2xl font-bold text-gray-900">Governance</h1>
+        {wallet.connected && hasGovernancePower && (
+          <Button variant="primary" onClick={() => setShowCreateForm(true)}>
+            Create Proposal
+          </Button>
+        )}
+      </div>
+
+      <ProposalList
+        key={listKey}
+        onProposalSelect={(proposal) => setSelectedProposal(proposal)}
+      />
+    </div>
+  );
+}
+
+export default GovernancePage;


### PR DESCRIPTION
## Summary

- **`CreateProposalForm.tsx`** — 5-step form (type → parameters → description → preview → submit) consistent with the `TokenDeployForm` pattern. Supports all backend proposal types: `PARAMETER_CHANGE`, `ADMIN_TRANSFER`, `TREASURY_SPEND`, `CONTRACT_UPGRADE`, `CUSTOM`. Surfaces on-chain constraints (voting period 1–30 days) before submission. Uses DOMPurify to strip HTML from descriptions before they are stored or displayed.
- **`useGovernance` hook** — wraps `submitProposal` from `governanceApi` and exposes `createProposal`, `checkGovernancePower`, loading/error state, `txHash`, and `proposalId`.
- **`GovernancePage.tsx`** — wires `ProposalList`, `ProposalDetail`, and `CreateProposalForm` into one page; shows the **Create Proposal** button only when the connected wallet has governance power (`votingPower > 0`).
- **App.tsx + DashboardLayout** — adds `/governance` route and a Governance sidebar nav item.
- **`dompurify` + `@types/dompurify`** — installed as a runtime dependency for XSS sanitization.

## Test plan

- [ ] All 25 new tests in `CreateProposalForm.test.tsx` pass (validation unit tests, XSS sanitization, step navigation, full integration flow with mocked API)
- [ ] All 6 pre-existing governance tests in `ProposalList.test.tsx` and `governance-voting-flow.integration.test.tsx` still pass
- [ ] TypeScript type check (`tsc --noEmit`) passes with no errors
- [ ] Navigate to `/governance` in the running app and verify the proposal list renders
- [ ] Connect a wallet with governance power and confirm "Create Proposal" button appears
- [ ] Step through the full form and verify each validation constraint (empty title, >200 chars, period <1 day, period >30 days, empty description)
- [ ] Enter `<script>alert("xss")</script>Safe text` in the description field and verify only "Safe text" appears in the preview

Closes #1261 