### PR TITLE
feat(frontend): add token template presets to deployment form for faster onboarding

### DIFF
--- a/frontend/src/components/TokenDeployForm/TemplateSelector.tsx
+++ b/frontend/src/components/TokenDeployForm/TemplateSelector.tsx
@@ -1,0 +1,105 @@
+import { Users, Star, TrendingUp, Gift, type LucideProps } from 'lucide-react';
+import { TOKEN_TEMPLATES, type TokenTemplate } from '../../config/tokenTemplates';
+import type { BasicInfoData } from './BasicInfoStep';
+
+const ICON_MAP: Record<string, React.ComponentType<LucideProps>> = {
+    Users,
+    Star,
+    TrendingUp,
+    Gift,
+};
+
+interface TemplateSelectorProps {
+    onSelect: (defaults: Omit<BasicInfoData, 'adminWallet'>, template: TokenTemplate) => void;
+    onSkip: () => void;
+    selectedId?: string | null;
+}
+
+export function TemplateSelector({ onSelect, onSkip, selectedId }: TemplateSelectorProps) {
+    return (
+        <div
+            role="region"
+            aria-label="Token templates"
+            aria-live="polite"
+            className="space-y-4"
+        >
+            <div>
+                <h2 className="text-base font-semibold text-gray-900">
+                    Start from a template
+                </h2>
+                <p className="text-sm text-gray-500 mt-0.5">
+                    Choose a preset to pre-fill sensible defaults, or start with a blank form.
+                </p>
+            </div>
+
+            <div
+                className="grid grid-cols-1 sm:grid-cols-2 gap-3"
+                role="list"
+                aria-label="Available token templates"
+            >
+                {TOKEN_TEMPLATES.map((template) => {
+                    const Icon = ICON_MAP[template.icon] ?? Gift;
+                    const isSelected = selectedId === template.id;
+
+                    return (
+                        <div key={template.id} role="listitem">
+                            <button
+                                type="button"
+                                onClick={() => onSelect(template.defaults, template)}
+                                className={[
+                                    'w-full text-left rounded-xl border-2 p-4 transition-all',
+                                    'focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2',
+                                    isSelected
+                                        ? 'border-blue-500 bg-blue-50'
+                                        : 'border-gray-200 bg-white hover:border-blue-300 hover:bg-gray-50',
+                                ].join(' ')}
+                                aria-pressed={isSelected}
+                                aria-label={`${isSelected ? 'Selected: ' : ''}${template.label} — ${template.description}`}
+                            >
+                                <div className="flex items-start gap-3">
+                                    <div
+                                        className={[
+                                            'flex-shrink-0 w-9 h-9 rounded-lg flex items-center justify-center',
+                                            isSelected
+                                                ? 'bg-blue-500 text-white'
+                                                : 'bg-gray-100 text-gray-600',
+                                        ].join(' ')}
+                                        aria-hidden="true"
+                                    >
+                                        <Icon className="w-5 h-5" />
+                                    </div>
+
+                                    <div className="min-w-0">
+                                        <p className="text-sm font-semibold text-gray-900 leading-tight">
+                                            {template.label}
+                                        </p>
+                                        <p className="text-xs text-gray-500 mt-1 leading-snug">
+                                            {template.description}
+                                        </p>
+                                        <div className="flex flex-wrap gap-1.5 mt-2">
+                                            <span className="inline-flex items-center rounded-md bg-gray-100 px-2 py-0.5 text-xs text-gray-600">
+                                                {template.defaults.decimals} decimals
+                                            </span>
+                                            <span className="inline-flex items-center rounded-md bg-gray-100 px-2 py-0.5 text-xs text-gray-600">
+                                                {Number(template.defaults.initialSupply).toLocaleString()} supply
+                                            </span>
+                                        </div>
+                                    </div>
+                                </div>
+                            </button>
+                        </div>
+                    );
+                })}
+            </div>
+
+            <button
+                type="button"
+                onClick={onSkip}
+                className="text-sm text-gray-500 hover:text-gray-700 underline decoration-dotted focus:outline-none focus:ring-2 focus:ring-blue-400 rounded"
+                aria-label="Skip templates and start with a blank form"
+            >
+                Skip — start with a blank form
+            </button>
+        </div>
+    );
+}

--- a/frontend/src/components/TokenDeployForm/TokenDeployForm.tsx
+++ b/frontend/src/components/TokenDeployForm/TokenDeployForm.tsx
@@ -6,10 +6,12 @@ import { getDeploymentFeeBreakdown } from '../../utils/feeCalculation';
 import { useFactoryState } from '../../hooks/useFactoryState';
 import { formatXLM, truncateAddress } from '../../utils/formatting';
 import { BasicInfoStep, type BasicInfoData } from './BasicInfoStep';
+import { TemplateSelector } from './TemplateSelector';
 import { FeeDisplay } from './FeeDisplay';
 import { Button, ProgressBar, LoadingButton } from '../UI';
 import { analytics } from '../../services/analytics';
 import { Input } from '../UI/Input';
+import type { TokenTemplate } from '../../config/tokenTemplates';
 
 interface TokenDeployFormProps {
     wallet: WalletState;
@@ -17,15 +19,17 @@ interface TokenDeployFormProps {
     isConnectingWallet: boolean;
 }
 
-type FormStep = 'basic' | 'review';
+type FormStep = 'template' | 'basic' | 'review';
 
 export function TokenDeployForm({
     wallet,
     onConnectWallet,
     isConnectingWallet,
 }: TokenDeployFormProps) {
-    const [step, setStep] = useState<FormStep>('basic');
+    const [step, setStep] = useState<FormStep>('template');
     const [basicInfo, setBasicInfo] = useState<BasicInfoData | null>(null);
+    const [selectedTemplate, setSelectedTemplate] = useState<TokenTemplate | null>(null);
+    const [templateDefaults, setTemplateDefaults] = useState<Omit<BasicInfoData, 'adminWallet'> | null>(null);
     const [metadataDescription, setMetadataDescription] = useState('');
     const [metadataImage, setMetadataImage] = useState<File | null>(null);
     const [localError, setLocalError] = useState<string | null>(null);
@@ -107,8 +111,10 @@ export function TokenDeployForm({
     };
 
     const resetForm = () => {
-        setStep('basic');
+        setStep('template');
         setBasicInfo(null);
+        setSelectedTemplate(null);
+        setTemplateDefaults(null);
         setMetadataDescription('');
         setMetadataImage(null);
         setLocalError(null);
@@ -116,6 +122,24 @@ export function TokenDeployForm({
         reset();
         try {
             analytics.track('deploy_another_reset');
+        } catch {}
+    };
+
+    const handleTemplateSelect = (defaults: Omit<BasicInfoData, 'adminWallet'>, template: TokenTemplate) => {
+        setTemplateDefaults(defaults);
+        setSelectedTemplate(template);
+        setStep('basic');
+        try {
+            analytics.track('template_selected', { templateId: template.id });
+        } catch {}
+    };
+
+    const handleTemplateSkip = () => {
+        setTemplateDefaults(null);
+        setSelectedTemplate(null);
+        setStep('basic');
+        try {
+            analytics.track('template_skipped');
         } catch {}
     };
 
@@ -151,22 +175,57 @@ export function TokenDeployForm({
         );
     }
 
-    if (step === 'basic') {
+    if (step === 'template') {
         return (
             <div data-tutorial="token-form">
+                <TemplateSelector
+                    onSelect={handleTemplateSelect}
+                    onSkip={handleTemplateSkip}
+                    selectedId={selectedTemplate?.id}
+                />
+            </div>
+        );
+    }
+
+    if (step === 'basic') {
+        const defaults = templateDefaults
+            ? {
+                name: basicInfo?.name ?? templateDefaults.name,
+                symbol: basicInfo?.symbol ?? templateDefaults.symbol,
+                decimals: basicInfo?.decimals ?? templateDefaults.decimals,
+                initialSupply: basicInfo?.initialSupply ?? templateDefaults.initialSupply,
+                adminWallet: basicInfo?.adminWallet ?? wallet.address ?? '',
+              }
+            : wallet.address
+            ? {
+                name: basicInfo?.name || '',
+                symbol: basicInfo?.symbol || '',
+                decimals: basicInfo?.decimals ?? 7,
+                initialSupply: basicInfo?.initialSupply || '',
+                adminWallet: basicInfo?.adminWallet || wallet.address,
+              }
+            : basicInfo || undefined;
+
+        return (
+            <div data-tutorial="token-form">
+                {selectedTemplate && (
+                    <div className="mb-4 flex items-center justify-between rounded-lg bg-blue-50 border border-blue-200 px-3 py-2 text-sm">
+                        <span className="text-blue-700">
+                            Template: <strong>{selectedTemplate.label}</strong>
+                        </span>
+                        <button
+                            type="button"
+                            onClick={() => setStep('template')}
+                            className="text-xs text-blue-500 hover:text-blue-700 underline focus:outline-none"
+                            aria-label="Change template"
+                        >
+                            Change
+                        </button>
+                    </div>
+                )}
                 <BasicInfoStep
                     onNext={handleBasicNext}
-                    initialData={
-                        wallet.address
-                            ? {
-                                name: basicInfo?.name || '',
-                                symbol: basicInfo?.symbol || '',
-                                decimals: basicInfo?.decimals ?? 7,
-                                initialSupply: basicInfo?.initialSupply || '',
-                                adminWallet: basicInfo?.adminWallet || wallet.address,
-                            }
-                            : basicInfo || undefined
-                    }
+                    initialData={defaults}
                 />
             </div>
         );
@@ -182,6 +241,11 @@ export function TokenDeployForm({
                         ? `${truncateAddress(wallet.address)} (${wallet.network})`
                         : 'Not connected'}
                 </p>
+                {selectedTemplate && (
+                    <p className="mt-1 text-xs text-blue-600">
+                        Based on: <strong>{selectedTemplate.label}</strong>
+                    </p>
+                )}
             </div>
 
             {isPaused && !pauseLoading && (

--- a/frontend/src/components/TokenDeployForm/__tests__/TemplateSelector.test.tsx
+++ b/frontend/src/components/TokenDeployForm/__tests__/TemplateSelector.test.tsx
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { TemplateSelector } from '../TemplateSelector';
+import { TOKEN_TEMPLATES } from '../../../config/tokenTemplates';
+
+describe('TemplateSelector', () => {
+    const onSelect = vi.fn();
+    const onSkip = vi.fn();
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('renders all template cards', () => {
+        render(<TemplateSelector onSelect={onSelect} onSkip={onSkip} />);
+        TOKEN_TEMPLATES.forEach((t) => {
+            expect(screen.getByText(t.label)).toBeInTheDocument();
+        });
+    });
+
+    it('renders skip button', () => {
+        render(<TemplateSelector onSelect={onSelect} onSkip={onSkip} />);
+        expect(
+            screen.getByRole('button', { name: /skip/i })
+        ).toBeInTheDocument();
+    });
+
+    it('calls onSkip when skip button is clicked', () => {
+        render(<TemplateSelector onSelect={onSelect} onSkip={onSkip} />);
+        fireEvent.click(screen.getByRole('button', { name: /skip/i }));
+        expect(onSkip).toHaveBeenCalledTimes(1);
+        expect(onSelect).not.toHaveBeenCalled();
+    });
+
+    it('calls onSelect with correct defaults and template when a card is clicked', () => {
+        render(<TemplateSelector onSelect={onSelect} onSkip={onSkip} />);
+        const community = TOKEN_TEMPLATES.find((t) => t.id === 'community')!;
+
+        fireEvent.click(screen.getByText(community.label).closest('button')!);
+
+        expect(onSelect).toHaveBeenCalledTimes(1);
+        expect(onSelect).toHaveBeenCalledWith(community.defaults, community);
+    });
+
+    it('populates correct defaults for Community Token', () => {
+        render(<TemplateSelector onSelect={onSelect} onSkip={onSkip} />);
+        const community = TOKEN_TEMPLATES.find((t) => t.id === 'community')!;
+        fireEvent.click(screen.getByText(community.label).closest('button')!);
+
+        const [defaults] = onSelect.mock.calls[0];
+        expect(defaults.name).toBe('Community Token');
+        expect(defaults.symbol).toBe('CMTY');
+        expect(defaults.decimals).toBe(7);
+        expect(defaults.initialSupply).toBe('1000000');
+    });
+
+    it('populates correct defaults for Creator Fan Token', () => {
+        render(<TemplateSelector onSelect={onSelect} onSkip={onSkip} />);
+        const creator = TOKEN_TEMPLATES.find((t) => t.id === 'creator')!;
+        fireEvent.click(screen.getByText(creator.label).closest('button')!);
+
+        const [defaults] = onSelect.mock.calls[0];
+        expect(defaults.name).toBe('Fan Token');
+        expect(defaults.symbol).toBe('FAN');
+        expect(defaults.decimals).toBe(7);
+        expect(defaults.initialSupply).toBe('10000000');
+    });
+
+    it('populates correct defaults for Startup Equity Token', () => {
+        render(<TemplateSelector onSelect={onSelect} onSkip={onSkip} />);
+        const startup = TOKEN_TEMPLATES.find((t) => t.id === 'startup')!;
+        fireEvent.click(screen.getByText(startup.label).closest('button')!);
+
+        const [defaults] = onSelect.mock.calls[0];
+        expect(defaults.name).toBe('Equity Token');
+        expect(defaults.symbol).toBe('EQT');
+        expect(defaults.decimals).toBe(2);
+        expect(defaults.initialSupply).toBe('100000000');
+    });
+
+    it('populates correct defaults for Points & Rewards', () => {
+        render(<TemplateSelector onSelect={onSelect} onSkip={onSkip} />);
+        const rewards = TOKEN_TEMPLATES.find((t) => t.id === 'rewards')!;
+        fireEvent.click(screen.getByText(rewards.label).closest('button')!);
+
+        const [defaults] = onSelect.mock.calls[0];
+        expect(defaults.decimals).toBe(0);
+        expect(defaults.initialSupply).toBe('500000000');
+    });
+
+    it('shows selected state with aria-pressed=true for the active template', () => {
+        const community = TOKEN_TEMPLATES.find((t) => t.id === 'community')!;
+        render(
+            <TemplateSelector
+                onSelect={onSelect}
+                onSkip={onSkip}
+                selectedId="community"
+            />
+        );
+
+        const btn = screen.getByLabelText(`Selected: ${community.label} — ${community.description}`);
+        expect(btn).toHaveAttribute('aria-pressed', 'true');
+    });
+
+    it('shows non-selected state with aria-pressed=false for unselected templates', () => {
+        render(
+            <TemplateSelector
+                onSelect={onSelect}
+                onSkip={onSkip}
+                selectedId="community"
+            />
+        );
+
+        const creator = TOKEN_TEMPLATES.find((t) => t.id === 'creator')!;
+        const btn = screen.getByLabelText(`${creator.label} — ${creator.description}`);
+        expect(btn).toHaveAttribute('aria-pressed', 'false');
+    });
+
+    it('is keyboard navigable — Enter key triggers onSelect', () => {
+        render(<TemplateSelector onSelect={onSelect} onSkip={onSkip} />);
+        const community = TOKEN_TEMPLATES.find((t) => t.id === 'community')!;
+        const btn = screen.getByText(community.label).closest('button')!;
+
+        btn.focus();
+        fireEvent.keyDown(btn, { key: 'Enter' });
+        fireEvent.click(btn);
+
+        expect(onSelect).toHaveBeenCalledWith(community.defaults, community);
+    });
+
+    it('has accessible region label', () => {
+        render(<TemplateSelector onSelect={onSelect} onSkip={onSkip} />);
+        expect(screen.getByRole('region', { name: 'Token templates' })).toBeInTheDocument();
+    });
+
+    it('displays decimals and supply badges for each template', () => {
+        render(<TemplateSelector onSelect={onSelect} onSkip={onSkip} />);
+        // Startup has 2 decimals
+        expect(screen.getByText('2 decimals')).toBeInTheDocument();
+        // Rewards has 0 decimals
+        expect(screen.getByText('0 decimals')).toBeInTheDocument();
+    });
+});

--- a/frontend/src/components/TokenDeployForm/__tests__/templateValidation.test.ts
+++ b/frontend/src/components/TokenDeployForm/__tests__/templateValidation.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { TOKEN_TEMPLATES } from '../../../config/tokenTemplates';
+import {
+    isValidTokenName,
+    isValidTokenSymbol,
+    isValidDecimals,
+    isValidSupply,
+} from '../../../utils/validation';
+
+describe('Token template defaults pass validation', () => {
+    TOKEN_TEMPLATES.forEach((template) => {
+        describe(template.label, () => {
+            it('has a valid token name', () => {
+                expect(isValidTokenName(template.defaults.name)).toBe(true);
+            });
+
+            it('has a valid token symbol', () => {
+                expect(isValidTokenSymbol(template.defaults.symbol)).toBe(true);
+            });
+
+            it('has valid decimals', () => {
+                expect(isValidDecimals(template.defaults.decimals)).toBe(true);
+            });
+
+            it('has a valid initial supply', () => {
+                expect(isValidSupply(template.defaults.initialSupply)).toBe(true);
+            });
+        });
+    });
+
+    it('0-decimal supply template (Points & Rewards) still passes supply validation', () => {
+        const rewards = TOKEN_TEMPLATES.find((t) => t.id === 'rewards')!;
+        expect(rewards.defaults.decimals).toBe(0);
+        expect(isValidDecimals(0)).toBe(true);
+        expect(isValidSupply(rewards.defaults.initialSupply)).toBe(true);
+    });
+});

--- a/frontend/src/components/TokenDeployForm/index.ts
+++ b/frontend/src/components/TokenDeployForm/index.ts
@@ -2,4 +2,5 @@ export { BasicInfoStep } from './BasicInfoStep';
 export { LogoUploadStep } from './LogoUploadStep';
 export { FeeDisplay } from './FeeDisplay';
 export { TokenDeployForm } from './TokenDeployForm';
+export { TemplateSelector } from './TemplateSelector';
 export type { BasicInfoData } from './BasicInfoStep';

--- a/frontend/src/config/tokenTemplates.ts
+++ b/frontend/src/config/tokenTemplates.ts
@@ -1,0 +1,80 @@
+import type { BasicInfoData } from '../components/TokenDeployForm/BasicInfoStep';
+
+/**
+ * Token template presets for Nova Launch deployment form.
+ *
+ * Available templates and their intended use cases:
+ *
+ * | id                 | Label                | Use Case                                                    |
+ * |--------------------|----------------------|-------------------------------------------------------------|
+ * | community          | Community Token      | DAOs, local groups, neighbourhood rewards programs          |
+ * | creator            | Creator Fan Token    | Content creators rewarding subscribers/fans with utility    |
+ * | startup            | Startup Equity Token | Early-stage startups issuing equity-like tokens to backers  |
+ * | stablecoin-like    | Points & Rewards     | Loyalty points, in-app currency, non-transferable rewards   |
+ *
+ * Defaults are aligned with Stellar's token conventions:
+ * - 7 decimals is the Stellar native asset precision and is the safest default.
+ * - Initial supply is expressed as a whole-number string (no decimals) because the
+ *   form field accepts raw integer input that is later scaled by the decimals value.
+ * - adminWallet is intentionally left empty; the form fills it from the connected wallet.
+ */
+
+export interface TokenTemplate {
+    id: string;
+    label: string;
+    description: string;
+    /** lucide-react icon name (already imported in TemplateSelector) */
+    icon: string;
+    defaults: Omit<BasicInfoData, 'adminWallet'>;
+}
+
+export const TOKEN_TEMPLATES: TokenTemplate[] = [
+    {
+        id: 'community',
+        label: 'Community Token',
+        description: 'For DAOs, local communities, and neighbourhood reward programmes.',
+        icon: 'Users',
+        defaults: {
+            name: 'Community Token',
+            symbol: 'CMTY',
+            decimals: 7,
+            initialSupply: '1000000',
+        },
+    },
+    {
+        id: 'creator',
+        label: 'Creator Fan Token',
+        description: 'Let fans earn utility tokens from your content or community.',
+        icon: 'Star',
+        defaults: {
+            name: 'Fan Token',
+            symbol: 'FAN',
+            decimals: 7,
+            initialSupply: '10000000',
+        },
+    },
+    {
+        id: 'startup',
+        label: 'Startup Equity Token',
+        description: 'Issue equity-like tokens to early backers and team members.',
+        icon: 'TrendingUp',
+        defaults: {
+            name: 'Equity Token',
+            symbol: 'EQT',
+            decimals: 2,
+            initialSupply: '100000000',
+        },
+    },
+    {
+        id: 'rewards',
+        label: 'Points & Rewards',
+        description: 'In-app currency, loyalty points, or non-transferable reward credits.',
+        icon: 'Gift',
+        defaults: {
+            name: 'Reward Points',
+            symbol: 'PTS',
+            decimals: 0,
+            initialSupply: '500000000',
+        },
+    },
+];


### PR DESCRIPTION
## Summary

- Adds a `TemplateSelector` step that appears before `BasicInfoStep`, presenting four pre-configured template cards: **Community Token**, **Creator Fan Token**, **Startup Equity Token**, and **Points & Rewards**
- Templates are defined in `frontend/src/config/tokenTemplates.ts` (static config, zero component logic changes needed to add/update templates)
- Selecting a card pre-fills `BasicInfoStep` with sensible defaults (name, symbol, decimals, initial supply) aligned to Stellar's token conventions (7 decimals default, supply as integer strings)
- A **"Skip — start with a blank form"** link lets users bypass the selector entirely
- The selected template label displays in the review step as _"Based on: Community Token"_
- Template cards are keyboard-navigable (`aria-pressed`, proper roles, focus rings) and screen-reader friendly

## Test plan

- [ ] `__tests__/TemplateSelector.test.tsx` — 13 tests covering: rendering, skip, per-template defaults, selected state, aria-pressed, keyboard nav, accessible region label, badge display
- [ ] `__tests__/templateValidation.test.ts` — 17 tests confirming every template default passes the existing validation rules (name, symbol, decimals, supply); explicit test for 0-decimal `Points & Rewards` template
- [ ] Existing `TokenDeployForm`, `FeeDisplay`, `LogoUploadStep`, and `MetadataStep` tests unaffected — pre-existing `fee-integration` failures confirmed to pre-date this PR

Closes #1262