### PR TITLE
feat(contracts): per-item failure isolation for batch mint operations

### DIFF
--- a/contracts/token-factory/src/batch_operations.rs
+++ b/contracts/token-factory/src/batch_operations.rs
@@ -6,7 +6,7 @@
 use soroban_sdk::{Address, Env, Vec};
 
 use crate::storage;
-use crate::types::{Error, TokenCreationParams};
+use crate::types::{Error, MintOutcome, TokenCreationParams};
 
 /// Maximum number of items allowed in a single batch call.
 pub const MAX_BATCH_SIZE: u32 = 50;
@@ -189,6 +189,95 @@ pub fn batch_settle(
     crate::events::emit_batch_settle(env, token_index, &creator, batch_len, total_mint);
 
     Ok(total_mint)
+}
+
+/// Batch-mint to multiple recipients with **per-item failure isolation**.
+///
+/// Unlike [`batch_settle`], a single failing mint does not abort the batch.
+/// Each `(recipient, amount)` pair is processed independently: successful
+/// mints commit their state, while failed ones are reported in the returned
+/// vector and via a `mnt_fail` event — leaving every other item unaffected.
+///
+/// # Isolation guarantee
+/// [`crate::mint::mint`] performs all of its validation (amount, token pause,
+/// existence, max-supply, arithmetic) *before* writing any storage. A returned
+/// `Err` therefore implies no partial write for that item, so capturing the
+/// per-item `Result` yields true state isolation without sub-transactions.
+///
+/// # Batch-level errors (fail fast, before any item is processed)
+/// * `ContractPaused`    – Factory is paused.
+/// * `InvalidParameters` – Empty `mints` list.
+/// * `BatchTooLarge`     – More than `MAX_BATCH_SIZE` items.
+/// * `TokenNotFound`     – `token_index` does not exist.
+/// * `Unauthorized`      – Caller is not the token creator.
+/// * `TokenPaused`       – Token is paused.
+///
+/// # Returns
+/// One [`MintOutcome`] per input item, in input order. `outcomes.get(i)`
+/// describes the result of `mints.get(i)`.
+pub fn batch_mint_isolated(
+    env: &Env,
+    caller: Address,
+    token_index: u32,
+    mints: Vec<(Address, i128)>,
+) -> Result<Vec<MintOutcome>, Error> {
+    if storage::is_paused(env) {
+        return Err(Error::ContractPaused);
+    }
+
+    caller.require_auth();
+
+    let batch_len = mints.len();
+    if batch_len == 0 {
+        return Err(Error::InvalidParameters);
+    }
+    if batch_len > MAX_BATCH_SIZE {
+        return Err(Error::BatchTooLarge);
+    }
+
+    // Batch-level preconditions are checked once up front; only per-item mint
+    // failures are isolated and reported individually below.
+    let token_info = storage::get_token_info(env, token_index).ok_or(Error::TokenNotFound)?;
+    if token_info.creator != caller {
+        return Err(Error::Unauthorized);
+    }
+    if storage::is_token_paused(env, token_index) {
+        return Err(Error::TokenPaused);
+    }
+
+    let mut outcomes = Vec::new(env);
+    for (i, (recipient, amount)) in mints.iter().enumerate() {
+        let index = i as u32;
+        match crate::mint::mint(env, token_index, &recipient, amount) {
+            Ok(()) => {
+                crate::events::emit_mint_succeeded(env, token_index, index, &recipient, amount);
+                outcomes.push_back(MintOutcome {
+                    index,
+                    success: true,
+                    error_code: 0,
+                });
+            }
+            Err(e) => {
+                // `Error` is a thin wrapper over its u32 contract code.
+                let error_code = e.0;
+                crate::events::emit_mint_failed(
+                    env,
+                    token_index,
+                    index,
+                    &recipient,
+                    amount,
+                    error_code,
+                );
+                outcomes.push_back(MintOutcome {
+                    index,
+                    success: false,
+                    error_code,
+                });
+            }
+        }
+    }
+
+    Ok(outcomes)
 }
 
 // ── helpers ───────────────────────────────────────────────────────────────────
@@ -468,5 +557,129 @@ mod tests {
         assert_eq!(err, crate::types::Error::InvalidTokenParams.into());
         // No token should have been created.
         assert!(client.get_token_info(&0_u32).is_err());
+    }
+
+    // ── batch_mint_isolated (#1360) ───────────────────────────────────────
+
+    /// Create a single uncapped token owned by `admin` at index 0.
+    fn create_iso_token(env: &Env, client: &crate::TokenFactoryClient, admin: &Address) {
+        client.create_token(
+            admin,
+            &String::from_str(env, "Iso"),
+            &String::from_str(env, "ISO"),
+            &7_u32,
+            &1_000_000_i128,
+            &None,
+            &1_000_000_i128,
+        );
+    }
+
+    #[test]
+    fn batch_mint_isolated_all_success() {
+        let (env, contract_id, admin, _treasury) = setup();
+        let client = crate::TokenFactoryClient::new(&env, &contract_id);
+        create_iso_token(&env, &client, &admin);
+
+        let r1 = Address::generate(&env);
+        let r2 = Address::generate(&env);
+        let mints = vec![&env, (r1.clone(), 100_i128), (r2.clone(), 200_i128)];
+
+        let outcomes = client.batch_mint_isolated(&admin, &0_u32, &mints);
+
+        assert_eq!(outcomes.len(), 2);
+        assert!(outcomes.get(0).unwrap().success);
+        assert!(outcomes.get(1).unwrap().success);
+        assert_eq!(outcomes.get(0).unwrap().error_code, 0);
+
+        // All mints committed.
+        let (b1, b2, supply) = env.as_contract(&contract_id, || {
+            (
+                storage::get_balance(&env, 0, &r1),
+                storage::get_balance(&env, 0, &r2),
+                storage::get_token_info(&env, 0).unwrap().total_supply,
+            )
+        });
+        assert_eq!(b1, 100);
+        assert_eq!(b2, 200);
+        assert_eq!(supply, 1_000_300);
+    }
+
+    #[test]
+    fn batch_mint_isolated_mixed_success_failure() {
+        let (env, contract_id, admin, _treasury) = setup();
+        let client = crate::TokenFactoryClient::new(&env, &contract_id);
+        create_iso_token(&env, &client, &admin);
+
+        let r1 = Address::generate(&env);
+        let bad = Address::generate(&env);
+        let r3 = Address::generate(&env);
+        // The middle item has a non-positive amount → isolated InvalidAmount failure.
+        let mints = vec![
+            &env,
+            (r1.clone(), 100_i128),
+            (bad.clone(), 0_i128),
+            (r3.clone(), 300_i128),
+        ];
+
+        let outcomes = client.batch_mint_isolated(&admin, &0_u32, &mints);
+
+        assert_eq!(outcomes.len(), 3);
+        assert!(outcomes.get(0).unwrap().success);
+        assert!(!outcomes.get(1).unwrap().success, "middle item must fail in isolation");
+        assert!(outcomes.get(2).unwrap().success, "item after a failure must still commit");
+        assert_eq!(
+            outcomes.get(1).unwrap().error_code,
+            crate::types::Error::InvalidAmount.0
+        );
+
+        // Successful items committed; the failed one did not, and supply only
+        // grew by the successful amounts.
+        let (b1, b_bad, b3, supply) = env.as_contract(&contract_id, || {
+            (
+                storage::get_balance(&env, 0, &r1),
+                storage::get_balance(&env, 0, &bad),
+                storage::get_balance(&env, 0, &r3),
+                storage::get_token_info(&env, 0).unwrap().total_supply,
+            )
+        });
+        assert_eq!(b1, 100);
+        assert_eq!(b_bad, 0);
+        assert_eq!(b3, 300);
+        assert_eq!(supply, 1_000_400);
+    }
+
+    #[test]
+    fn batch_mint_isolated_rejects_oversized_batch() {
+        let (env, contract_id, admin, _treasury) = setup();
+        let client = crate::TokenFactoryClient::new(&env, &contract_id);
+
+        // 51 items — one over the cap. Rejected before any token lookup.
+        let mut mints = Vec::new(&env);
+        for _ in 0..(MAX_BATCH_SIZE + 1) {
+            mints.push_back((Address::generate(&env), 1_i128));
+        }
+
+        let res = client.try_batch_mint_isolated(&admin, &0_u32, &mints);
+        assert_eq!(
+            res.unwrap_err().unwrap(),
+            crate::types::Error::BatchTooLarge.into()
+        );
+    }
+
+    #[test]
+    fn batch_mint_isolated_rejects_non_creator() {
+        let (env, contract_id, admin, _treasury) = setup();
+        let client = crate::TokenFactoryClient::new(&env, &contract_id);
+        create_iso_token(&env, &client, &admin);
+
+        let impostor = Address::generate(&env);
+        let r1 = Address::generate(&env);
+        let mints = vec![&env, (r1, 100_i128)];
+
+        let res = client.try_batch_mint_isolated(&impostor, &0_u32, &mints);
+        assert_eq!(
+            res.unwrap_err().unwrap(),
+            crate::types::Error::Unauthorized.into()
+        );
     }
 }

--- a/contracts/token-factory/src/events.rs
+++ b/contracts/token-factory/src/events.rs
@@ -417,6 +417,41 @@ pub fn emit_mint(env: &Env, token_index: u32, to: &Address, amount: i128) {
         .publish((symbol_short!("mint"), token_index), (to, amount));
 }
 
+/// Emit a per-item success event for an isolated batch mint (#1360).
+///
+/// Topic `mnt_ok` corresponds to a `MintSucceeded` outcome. `index` is the
+/// item's position in the input batch.
+pub fn emit_mint_succeeded(
+    env: &Env,
+    token_index: u32,
+    index: u32,
+    to: &Address,
+    amount: i128,
+) {
+    env.events().publish(
+        (symbol_short!("mnt_ok"), token_index),
+        (index, to, amount),
+    );
+}
+
+/// Emit a per-item failure event for an isolated batch mint (#1360).
+///
+/// Topic `mnt_fail` corresponds to a `MintFailed` outcome. `error_code` is the
+/// contract error code that caused this item to be isolated out of the batch.
+pub fn emit_mint_failed(
+    env: &Env,
+    token_index: u32,
+    index: u32,
+    to: &Address,
+    amount: i128,
+    error_code: u32,
+) {
+    env.events().publish(
+        (symbol_short!("mnt_fail"), token_index),
+        (index, to, amount, error_code),
+    );
+}
+
 // ── Treasury events ─────────────────────────────────────────
 
 /// Emit treasury withdrawal event

--- a/contracts/token-factory/src/lib.rs
+++ b/contracts/token-factory/src/lib.rs
@@ -157,8 +157,8 @@ mod vault_deposit_withdraw_test;
 use soroban_sdk::{contract, contractimpl, symbol_short, Address, Bytes, BytesN, Env, String, Symbol, Vec};
 use types::{
     AuctionStatus, BurnAuction, BuybackCampaign, CampaignStatus, ContractMetadata,
-    DynamicQuorumConfig, Error, FactoryState, PaginationCursor, StreamInfo, StreamPage,
-    StreamParams, TokenCreationParams, TokenInfo, TokenStats, Vault, VaultStatus,
+    DynamicQuorumConfig, Error, FactoryState, MintOutcome, PaginationCursor, StreamInfo,
+    StreamPage, StreamParams, TokenCreationParams, TokenInfo, TokenStats, Vault, VaultStatus,
 };
 use crate::milestone_verification::MilestoneVerifier;
 use crate::snapshot;
@@ -1328,6 +1328,36 @@ impl TokenFactory {
     ) -> Result<i128, Error> {
         storage::acquire_reentrancy_lock(&env)?;
         let result = batch_operations::batch_settle(&env, creator, token_index, recipients);
+        storage::release_reentrancy_lock(&env);
+        result
+    }
+
+    /// Batch-mint to multiple recipients with per-item failure isolation.
+    ///
+    /// Unlike [`batch_settle`](Self::batch_settle), a single failing mint does
+    /// not revert the whole batch: successful mints commit while failed items
+    /// are reported individually in the returned vector and via per-item
+    /// `mnt_ok` / `mnt_fail` events.
+    ///
+    /// # Arguments
+    /// * `caller`      – Token creator (must auth).
+    /// * `token_index` – Index of the token to mint.
+    /// * `mints`       – `(address, amount)` pairs; max `MAX_BATCH_SIZE` (50).
+    ///
+    /// # Returns
+    /// One [`MintOutcome`] per input item, in input order.
+    ///
+    /// # Errors (batch-level, fail fast)
+    /// `ContractPaused`, `InvalidParameters`, `BatchTooLarge`, `TokenNotFound`,
+    /// `Unauthorized`, `TokenPaused`.
+    pub fn batch_mint_isolated(
+        env: Env,
+        caller: Address,
+        token_index: u32,
+        mints: Vec<(Address, i128)>,
+    ) -> Result<Vec<MintOutcome>, Error> {
+        storage::acquire_reentrancy_lock(&env)?;
+        let result = batch_operations::batch_mint_isolated(&env, caller, token_index, mints);
         storage::release_reentrancy_lock(&env);
         result
     }

--- a/contracts/token-factory/src/types.rs
+++ b/contracts/token-factory/src/types.rs
@@ -107,6 +107,24 @@ pub struct MetadataRecord {
     pub updated_by: Address,
 }
 
+/// Per-item outcome of an isolated batch-mint operation (#1360).
+///
+/// Soroban cannot return `Vec<Result<(), Error>>` across the contract boundary,
+/// so each input item's outcome is expressed as a value type. Outcomes are
+/// returned in input order, so `outcomes.get(i)` corresponds to `mints.get(i)`.
+///
+/// # Fields
+/// * `index`      – Position of the item in the input batch (0-based).
+/// * `success`    – `true` if the mint committed, `false` if it was isolated out.
+/// * `error_code` – Contract error code on failure; `0` when `success` is true.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MintOutcome {
+    pub index: u32,
+    pub success: bool,
+    pub error_code: u32,
+}
+
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct StreamInfo {


### PR DESCRIPTION
## Summary

Adds `batch_mint_isolated` to the token-factory contract so that a single failing mint no longer reverts the entire batch. Each `(recipient, amount)` item is processed independently — successful mints commit while failed ones are reported individually, both in the return value and via per-item events.

- **`batch_mint_isolated(env, caller, token_index, mints)`** processes items independently.
- Returns **`Vec<MintOutcome>`** — one result per input item, in input order. (Soroban cannot return `Vec<Result<(), Error>>` across the contract boundary, so `MintOutcome { index, success, error_code }` is the value-type equivalent; `outcomes.get(i)` corresponds to `mints.get(i)`.)
- **50-item cap** — rejects with `Error::BatchTooLarge` above it.
- Emits per-item **`mnt_ok` / `mnt_fail`** events (MintSucceeded / MintFailed) instead of one bulk event.

## Isolation guarantee

`mint::mint` performs all validation (amount, token pause, existence, max-supply, arithmetic) **before** writing any storage. A returned `Err` therefore implies no partial write for that item, so capturing the per-item `Result` yields true state isolation without sub-transactions. Batch-level preconditions (factory paused, empty list, oversized, token-not-found, unauthorized, token-paused) fail fast before any item is processed.

## Changes

- `types.rs`: add `MintOutcome` contracttype.
- `events.rs`: add `emit_mint_succeeded` (`mnt_ok`) / `emit_mint_failed` (`mnt_fail`).
- `batch_operations.rs`: add `batch_mint_isolated` (cap `MAX_BATCH_SIZE` = 50).
- `lib.rs`: expose the reentrancy-guarded `batch_mint_isolated` entry point.
- Tests (in `batch_operations::tests`): all-success batch, mixed success/failure batch (failed item reports `InvalidAmount` while neighbors commit), oversized-batch rejection (`BatchTooLarge`), non-creator rejection.

## Testing

Intended command: `cargo test batch_mint`.

> ⚠️ **Repository build state:** the `token-factory` crate currently has **pre-existing compilation errors in unrelated modules** (multisig, fractionalization, freeze, streams, a stray merge-artifact in `campaign.rs`, "symbol too long" in `events.rs`, etc.) that prevent the crate from building, so the suite cannot be run as-is. This PR's code was verified to introduce **zero new compile errors**: with the unrelated `campaign.rs` parse error temporarily patched locally, `cargo build --lib` reports errors only in those unrelated modules — none in `batch_operations.rs`, `types.rs::MintOutcome`, or the new event/entry-point code. A formal gas benchmark vs. `batch_settle` is deferred until the crate builds.

Closes #1360