### PR TITLE
feat(search): phonetic similarity search for token symbol typo recovery

### DIFF
--- a/backend/src/app/api/tokens/search/phonetic.test.ts
+++ b/backend/src/app/api/tokens/search/phonetic.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { soundex, phoneticMatch } from "./phonetic";
+
+describe("soundex", () => {
+  it("returns empty string for empty input", () => {
+    expect(soundex("")).toBe("");
+  });
+
+  it("pads short words with zeros", () => {
+    expect(soundex("A")).toBe("A000");
+  });
+
+  it("truncates to 4 characters", () => {
+    expect(soundex("LONGERNAME")).toHaveLength(4);
+  });
+
+  it("known equivalence: ROBERT and RUPERT share the same code", () => {
+    expect(soundex("ROBERT")).toBe(soundex("RUPERT"));
+    expect(soundex("ROBERT")).toBe("R163");
+  });
+
+  it("STELR and STLR share the same soundex code (typo recovery)", () => {
+    // Both should produce the same code since the vowel E is ignored
+    expect(soundex("STELR")).toBe(soundex("STLR"));
+  });
+
+  it("removes consecutive duplicate codes", () => {
+    // PF — both map to '1'; consecutive duplicates are collapsed so only one '1' is emitted
+    // PFISTER -> P + (F=1 collapsed with P=1) + S=2 + T=3 + R=6 -> P236
+    expect(soundex("PFISTER")).toBe("P236");
+    // Verify the collapse: without collapse P+F would give two '1's
+    expect(soundex("PFISTER")).not.toBe("P123");
+  });
+
+  it("is case-insensitive", () => {
+    expect(soundex("robert")).toBe(soundex("ROBERT"));
+    expect(soundex("Robert")).toBe(soundex("robert"));
+  });
+
+  it("ignores non-alphabetic characters", () => {
+    expect(soundex("R0B3RT")).toBe(soundex("RBRT"));
+  });
+
+  it("different words produce different codes", () => {
+    expect(soundex("SMITH")).not.toBe(soundex("JONES"));
+  });
+});
+
+describe("phoneticMatch", () => {
+  it("returns candidates whose soundex matches the query", () => {
+    const results = phoneticMatch("ROBERT", ["RUPERT", "SMITH", "ROBERT"]);
+    const values = results.map((r) => r.value);
+    expect(values).toContain("RUPERT");
+    expect(values).toContain("ROBERT");
+    expect(values).not.toContain("SMITH");
+  });
+
+  it("gives each matching candidate a score of 1", () => {
+    const results = phoneticMatch("ROBERT", ["RUPERT"]);
+    expect(results[0].score).toBe(1);
+  });
+
+  it("returns empty array when no candidates match", () => {
+    const results = phoneticMatch("SMITH", ["JONES", "TAYLOR"]);
+    expect(results).toHaveLength(0);
+  });
+
+  it("returns empty array for empty candidates list", () => {
+    expect(phoneticMatch("TEST", [])).toHaveLength(0);
+  });
+
+  it("handles typo recovery for STELR vs STLR", () => {
+    const results = phoneticMatch("STELR", ["STLR", "UNRELATED"]);
+    const values = results.map((r) => r.value);
+    expect(values).toContain("STLR");
+    expect(values).not.toContain("UNRELATED");
+  });
+});

--- a/backend/src/app/api/tokens/search/phonetic.ts
+++ b/backend/src/app/api/tokens/search/phonetic.ts
@@ -1,0 +1,32 @@
+export function soundex(str: string): string {
+  if (!str) return '';
+  const s = str.toUpperCase().replace(/[^A-Z]/g, '');
+  if (!s) return '';
+  const map: Record<string, string> = {
+    B: '1', F: '1', P: '1', V: '1',
+    C: '2', G: '2', J: '2', K: '2', Q: '2', S: '2', X: '2', Z: '2',
+    D: '3', T: '3',
+    L: '4',
+    M: '5', N: '5',
+    R: '6',
+  };
+  let code = s[0];
+  let prev = map[s[0]] ?? '0';
+  for (let i = 1; i < s.length; i++) {
+    const curr = map[s[i]] ?? '0';
+    if (curr !== '0' && curr !== prev) code += curr;
+    prev = curr;
+    if (code.length === 4) break;
+  }
+  return (code + '000').slice(0, 4);
+}
+
+export function phoneticMatch(
+  query: string,
+  candidates: string[],
+): { value: string; score: number }[] {
+  const qCode = soundex(query);
+  return candidates
+    .map((c) => ({ value: c, score: soundex(c) === qCode ? 1 : 0 }))
+    .filter((r) => r.score > 0);
+}

--- a/backend/src/app/api/tokens/search/query-builder.test.ts
+++ b/backend/src/app/api/tokens/search/query-builder.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { buildTokenSearchQuery } from "./query-builder";
+import { buildTokenSearchQuery, buildPhoneticSearchQuery, phoneticSearch } from "./query-builder";
 import type { ValidatedSearchTokensQuery } from "./schema";
 
 describe("Query Builder", () => {
@@ -131,6 +131,18 @@ describe("Query Builder", () => {
     expect(orderBy).toEqual({ name: "asc" });
   });
 
+  it("should not add OR clause when q is undefined", () => {
+    const params: ValidatedSearchTokensQuery = {
+      sortBy: "created",
+      sortOrder: "desc",
+      page: "1",
+      limit: "20",
+    };
+
+    const { where } = buildTokenSearchQuery(params);
+    expect(where.OR).toBeUndefined();
+  });
+
   it("should combine multiple filters", () => {
     const params: ValidatedSearchTokensQuery = {
       q: "token",
@@ -152,5 +164,84 @@ describe("Query Builder", () => {
     expect(where.totalSupply).toBeDefined();
     expect(where.burnCount).toBeDefined();
     expect(orderBy).toEqual({ totalBurned: "desc" });
+  });
+});
+
+describe("buildPhoneticSearchQuery", () => {
+  it("should return a query without OR (q) filter so phonetic post-filtering can be applied", () => {
+    const params: ValidatedSearchTokensQuery = {
+      q: "STELR",
+      sortBy: "created",
+      sortOrder: "desc",
+      page: "1",
+      limit: "20",
+    };
+
+    const { where } = buildPhoneticSearchQuery(params);
+    expect(where.OR).toBeUndefined();
+  });
+
+  it("should still apply other filters (creator, supply, etc.)", () => {
+    const params: ValidatedSearchTokensQuery = {
+      q: "TOKEN",
+      creator: "GCREATOR1",
+      minSupply: "500",
+      sortBy: "created",
+      sortOrder: "desc",
+      page: "1",
+      limit: "20",
+    };
+
+    const { where } = buildPhoneticSearchQuery(params);
+    expect(where.OR).toBeUndefined();
+    expect(where.creator).toBeDefined();
+    expect(where.totalSupply).toBeDefined();
+  });
+});
+
+describe("phoneticSearch", () => {
+  const makeToken = (symbol: string, name: string) => ({ symbol, name });
+
+  it("returns tokens that phonetically match the query", () => {
+    const tokens = [
+      makeToken("STLR", "Stellar"),
+      makeToken("JONES", "Jones Coin"),
+      makeToken("STELR", "Stelr Token"),
+    ];
+
+    const results = phoneticSearch(tokens, "STELR");
+    const symbols = results.map((t) => t.symbol);
+    // STLR and STELR share the same soundex code
+    expect(symbols).toContain("STLR");
+    expect(symbols).toContain("STELR");
+    expect(symbols).not.toContain("JONES");
+  });
+
+  it("ranks exact matches (score 2) before phonetic matches (score 1)", () => {
+    const tokens = [
+      makeToken("RUPERT", "Rupert Coin"),
+      makeToken("ROBERT", "Robert Token"),
+    ];
+
+    // ROBERT is an exact symbol match
+    const results = phoneticSearch(tokens, "ROBERT");
+    expect(results[0].symbol).toBe("ROBERT");
+  });
+
+  it("returns empty array when nothing matches", () => {
+    const tokens = [makeToken("SMITH", "Smith"), makeToken("JONES", "Jones")];
+    expect(phoneticSearch(tokens, "ZZZZ")).toHaveLength(0);
+  });
+
+  it("returns empty array for empty token list", () => {
+    expect(phoneticSearch([], "TEST")).toHaveLength(0);
+  });
+
+  it("matches by name field as well as symbol", () => {
+    const tokens = [makeToken("XYZ", "Robert Token")];
+    // soundex("Robert") === soundex("Rupert") === R163
+    const results = phoneticSearch(tokens, "Rupert");
+    expect(results).toHaveLength(1);
+    expect(results[0].symbol).toBe("XYZ");
   });
 });

--- a/backend/src/app/api/tokens/search/query-builder.ts
+++ b/backend/src/app/api/tokens/search/query-builder.ts
@@ -1,5 +1,6 @@
 import { Prisma } from "@prisma/client";
 import type { ValidatedSearchTokensQuery } from "./schema";
+import { soundex } from "./phonetic";
 
 export function buildTokenSearchQuery(params: ValidatedSearchTokensQuery) {
   const where: Prisma.TokenWhereInput = {};
@@ -67,4 +68,43 @@ export function buildTokenSearchQuery(params: ValidatedSearchTokensQuery) {
   }
 
   return { where, orderBy };
+}
+
+/**
+ * Build a Prisma query for phonetic search — identical to buildTokenSearchQuery
+ * but omits the `q` filter so the caller can fetch a broad result set and
+ * then apply application-level phonetic post-filtering via `phoneticSearch`.
+ */
+export function buildPhoneticSearchQuery(params: ValidatedSearchTokensQuery) {
+  const baseParams = { ...params, q: undefined };
+  return buildTokenSearchQuery(baseParams);
+}
+
+/**
+ * Filter and sort tokens by phonetic similarity to `query`.
+ * Exact symbol/name matches are ranked first (score 2), phonetic matches
+ * second (score 1).  Tokens with no match are excluded.
+ */
+export function phoneticSearch<
+  T extends { symbol: string; name: string },
+>(tokens: T[], query: string): T[] {
+  const q = query.toUpperCase();
+  const qCode = soundex(query);
+
+  const scored = tokens
+    .map((token) => {
+      const symbolUp = token.symbol.toUpperCase();
+      const nameUp = token.name.toUpperCase();
+      let score = 0;
+      if (symbolUp === q || nameUp === q) {
+        score = 2;
+      } else if (soundex(token.symbol) === qCode || soundex(token.name) === qCode) {
+        score = 1;
+      }
+      return { token, score };
+    })
+    .filter((r) => r.score > 0);
+
+  scored.sort((a, b) => b.score - a.score);
+  return scored.map((r) => r.token);
 }

--- a/backend/src/app/api/tokens/search/route.ts
+++ b/backend/src/app/api/tokens/search/route.ts
@@ -1,9 +1,25 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { searchTokensSchema, type SearchTokensQuery } from "./schema";
-import { buildTokenSearchQuery } from "./query-builder";
+import { buildTokenSearchQuery, buildPhoneticSearchQuery, phoneticSearch } from "./query-builder";
 import { cacheSearchResults, getCachedSearchResults } from "./cache";
 import type { TokenSearchResponse, TokenSearchErrorResponse } from "./types";
+
+const TOKEN_SELECT = {
+  id: true,
+  address: true,
+  creator: true,
+  name: true,
+  symbol: true,
+  decimals: true,
+  totalSupply: true,
+  initialSupply: true,
+  totalBurned: true,
+  burnCount: true,
+  metadataUri: true,
+  createdAt: true,
+  updatedAt: true,
+} as const;
 
 export async function GET(request: NextRequest) {
   try {
@@ -18,6 +34,7 @@ export async function GET(request: NextRequest) {
       minSupply: searchParams.get("minSupply") || undefined,
       maxSupply: searchParams.get("maxSupply") || undefined,
       hasBurns: searchParams.get("hasBurns") || undefined,
+      fuzzy: (searchParams.get("fuzzy") as "true" | "false") || undefined,
       sortBy: (searchParams.get("sortBy") as any) || "created",
       sortOrder: (searchParams.get("sortOrder") as any) || "desc",
       page: searchParams.get("page") || "1",
@@ -46,39 +63,42 @@ export async function GET(request: NextRequest) {
       return NextResponse.json(cached);
     }
 
-    // Build query
-    const { where, orderBy } = buildTokenSearchQuery(validatedParams);
-
     // Calculate pagination
     const page = parseInt(validatedParams.page);
     const limit = parseInt(validatedParams.limit);
     const skip = (page - 1) * limit;
 
-    // Execute queries in parallel
-    const [tokens, total] = await Promise.all([
-      prisma.token.findMany({
+    let tokens: any[];
+    let total: number;
+
+    if (validatedParams.fuzzy === "true" && validatedParams.q) {
+      // Fetch a broad result set without the q filter, then apply phonetic post-filtering
+      const { where, orderBy } = buildPhoneticSearchQuery(validatedParams);
+
+      const allTokens = await prisma.token.findMany({
         where,
         orderBy,
-        skip,
-        take: limit,
-        select: {
-          id: true,
-          address: true,
-          creator: true,
-          name: true,
-          symbol: true,
-          decimals: true,
-          totalSupply: true,
-          initialSupply: true,
-          totalBurned: true,
-          burnCount: true,
-          metadataUri: true,
-          createdAt: true,
-          updatedAt: true,
-        },
-      }),
-      prisma.token.count({ where }),
-    ]);
+        select: TOKEN_SELECT,
+      });
+
+      const matched = phoneticSearch(allTokens, validatedParams.q);
+      total = matched.length;
+      tokens = matched.slice(skip, skip + limit);
+    } else {
+      // Standard exact/partial match search
+      const { where, orderBy } = buildTokenSearchQuery(validatedParams);
+
+      [tokens, total] = await Promise.all([
+        prisma.token.findMany({
+          where,
+          orderBy,
+          skip,
+          take: limit,
+          select: TOKEN_SELECT,
+        }),
+        prisma.token.count({ where }),
+      ]);
+    }
 
     // Format response
     const response: TokenSearchResponse = {
@@ -105,6 +125,7 @@ export async function GET(request: NextRequest) {
         minSupply: validatedParams.minSupply,
         maxSupply: validatedParams.maxSupply,
         hasBurns: validatedParams.hasBurns,
+        fuzzy: validatedParams.fuzzy,
         sortBy: validatedParams.sortBy,
         sortOrder: validatedParams.sortOrder,
       },

--- a/backend/src/app/api/tokens/search/schema.ts
+++ b/backend/src/app/api/tokens/search/schema.ts
@@ -12,6 +12,9 @@ export const searchTokensSchema = z.object({
   maxSupply: z.string().regex(/^\d+$/).optional(),
   hasBurns: z.enum(["true", "false"]).optional(),
 
+  // Phonetic / fuzzy search
+  fuzzy: z.enum(["true", "false"]).optional(),
+
   // Sorting
   sortBy: z.enum(["created", "burned", "supply", "name"]).default("created"),
   sortOrder: z.enum(["asc", "desc"]).default("desc"),

--- a/backend/src/app/api/tokens/search/types.ts
+++ b/backend/src/app/api/tokens/search/types.ts
@@ -31,6 +31,7 @@ export interface SearchFilters {
   minSupply?: string;
   maxSupply?: string;
   hasBurns?: "true" | "false";
+  fuzzy?: "true" | "false";
   sortBy: "created" | "burned" | "supply" | "name";
   sortOrder: "asc" | "desc";
 }


### PR DESCRIPTION
## Summary
- Add Soundex phonetic algorithm in phonetic.ts for symbol typo recovery
- Add optional fuzzy=true query parameter to token search endpoint
- Phonetic results sorted by similarity score with exact matches ranked first
- Application-level post-filtering for phonetic matching (no Postgres extension needed)

## Test plan
- [ ] Run `cd backend && npm run test` — phonetic.test.ts and query-builder.test.ts pass
- [ ] Verify STELR matches STLR via soundex equivalence
- [ ] Verify exact matches ranked before phonetic matches when fuzzy=true
- [ ] Verify fuzzy=false (default) uses existing exact/partial match behavior

Closes #1341

🤖 Generated with [Claude Code](https://claude.com/claude-code)