### PR TITLE
feat(auth): refresh token family invalidation on reuse detection for session hijack prevention

### DIFF
--- a/backend/prisma/migrations/20260623000002_add_refresh_token_family/migration.sql
+++ b/backend/prisma/migrations/20260623000002_add_refresh_token_family/migration.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS "RefreshToken" (
+  "id"        TEXT         NOT NULL,
+  "familyId"  TEXT         NOT NULL,
+  "token"     TEXT         NOT NULL,
+  "used"      BOOLEAN      NOT NULL DEFAULT false,
+  "expiresAt" TIMESTAMP(3) NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "RefreshToken_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "RefreshToken_token_key"      ON "RefreshToken"("token");
+CREATE INDEX IF NOT EXISTS "RefreshToken_familyId_idx"           ON "RefreshToken"("familyId");
+CREATE INDEX IF NOT EXISTS "RefreshToken_token_idx"              ON "RefreshToken"("token");
+CREATE INDEX IF NOT EXISTS "RefreshToken_expiresAt_idx"          ON "RefreshToken"("expiresAt");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -404,3 +404,17 @@ model IntegrationState {
   value     String
   updatedAt DateTime @updatedAt
 }
+
+/// Tracks refresh token families for reuse-detection and session hijack prevention.
+model RefreshToken {
+  id        String   @id @default(uuid())
+  familyId  String
+  token     String   @unique
+  used      Boolean  @default(false)
+  expiresAt DateTime
+  createdAt DateTime @default(now())
+
+  @@index([familyId])
+  @@index([token])
+  @@index([expiresAt])
+}

--- a/backend/src/__tests__/auth-refresh-token-family.test.ts
+++ b/backend/src/__tests__/auth-refresh-token-family.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Integration tests for refresh token family invalidation (#1345).
+ * Prisma is mocked — no live database required.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mock Prisma transaction and client
+// ---------------------------------------------------------------------------
+
+const mockTx = {
+  refreshToken: {
+    findUnique: vi.fn(),
+    update: vi.fn(),
+    create: vi.fn(),
+    deleteMany: vi.fn(),
+  },
+};
+
+const mockPrisma = {
+  refreshToken: {
+    create: vi.fn(),
+    findUnique: vi.fn(),
+    update: vi.fn(),
+    deleteMany: vi.fn(),
+  },
+  $transaction: vi.fn(async (fn: (tx: typeof mockTx) => Promise<unknown>) =>
+    fn(mockTx)
+  ),
+};
+
+vi.mock("../lib/prisma", () => ({ default: mockPrisma, prisma: mockPrisma }));
+
+import {
+  createTokenFamily,
+  rotateTokenFamily,
+  invalidateFamily,
+  pruneExpiredFamilies,
+  TokenFamilyError,
+} from "../auth/refresh-token-family.service";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeRecord(
+  overrides: Partial<{
+    id: string;
+    familyId: string;
+    token: string;
+    used: boolean;
+    expiresAt: Date;
+  }> = {}
+) {
+  return {
+    id: "rec-1",
+    familyId: "family-1",
+    token: "tok-current",
+    used: false,
+    expiresAt: new Date(Date.now() + 86_400_000),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// createTokenFamily
+// ---------------------------------------------------------------------------
+
+describe("createTokenFamily", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("creates a DB record and returns a new familyId", async () => {
+    mockPrisma.refreshToken.create.mockResolvedValue({});
+    const { familyId } = await createTokenFamily("tok-1", new Date());
+    expect(typeof familyId).toBe("string");
+    expect(familyId.length).toBeGreaterThan(0);
+  });
+
+  it("stores the token in the created record", async () => {
+    mockPrisma.refreshToken.create.mockResolvedValue({});
+    await createTokenFamily("tok-abc", new Date());
+    expect(mockPrisma.refreshToken.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ token: "tok-abc" }),
+      })
+    );
+  });
+
+  it("each call generates a unique familyId", async () => {
+    mockPrisma.refreshToken.create.mockResolvedValue({});
+    const { familyId: id1 } = await createTokenFamily("tok-1", new Date());
+    const { familyId: id2 } = await createTokenFamily("tok-2", new Date());
+    expect(id1).not.toBe(id2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rotateTokenFamily — normal rotation
+// ---------------------------------------------------------------------------
+
+describe("rotateTokenFamily — normal rotation", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("marks the current token as used", async () => {
+    mockTx.refreshToken.findUnique.mockResolvedValue(makeRecord());
+    mockTx.refreshToken.update.mockResolvedValue({});
+    mockTx.refreshToken.create.mockResolvedValue({});
+
+    await rotateTokenFamily("tok-current", "tok-next", new Date());
+
+    expect(mockTx.refreshToken.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { used: true } })
+    );
+  });
+
+  it("creates the next token in the same family", async () => {
+    const record = makeRecord();
+    mockTx.refreshToken.findUnique.mockResolvedValue(record);
+    mockTx.refreshToken.update.mockResolvedValue({});
+    mockTx.refreshToken.create.mockResolvedValue({});
+
+    const result = await rotateTokenFamily("tok-current", "tok-next", new Date());
+
+    expect(result.familyId).toBe("family-1");
+    expect(mockTx.refreshToken.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          familyId: "family-1",
+          token: "tok-next",
+        }),
+      })
+    );
+  });
+
+  it("wraps all operations in a single DB transaction", async () => {
+    mockTx.refreshToken.findUnique.mockResolvedValue(makeRecord());
+    mockTx.refreshToken.update.mockResolvedValue({});
+    mockTx.refreshToken.create.mockResolvedValue({});
+
+    await rotateTokenFamily("tok-current", "tok-next", new Date());
+
+    expect(mockPrisma.$transaction).toHaveBeenCalledOnce();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rotateTokenFamily — reuse detection
+// ---------------------------------------------------------------------------
+
+describe("rotateTokenFamily — reuse detection", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("throws TokenFamilyError with code REUSE_DETECTED when a used token is presented", async () => {
+    mockTx.refreshToken.findUnique.mockResolvedValue(makeRecord({ used: true }));
+    mockTx.refreshToken.deleteMany.mockResolvedValue({ count: 2 });
+
+    const err = await rotateTokenFamily(
+      "tok-current",
+      "tok-next",
+      new Date()
+    ).catch((e) => e);
+
+    expect(err).toBeInstanceOf(TokenFamilyError);
+    expect(err.code).toBe("REUSE_DETECTED");
+  });
+
+  it("deletes all tokens in the family on reuse detection", async () => {
+    mockTx.refreshToken.findUnique.mockResolvedValue(makeRecord({ used: true }));
+    mockTx.refreshToken.deleteMany.mockResolvedValue({ count: 3 });
+
+    await rotateTokenFamily("tok-current", "tok-next", new Date()).catch(() => {});
+
+    expect(mockTx.refreshToken.deleteMany).toHaveBeenCalledWith({
+      where: { familyId: "family-1" },
+    });
+  });
+
+  it("throws TokenFamilyError with code INVALID_TOKEN when token is not found", async () => {
+    mockTx.refreshToken.findUnique.mockResolvedValue(null);
+
+    const err = await rotateTokenFamily(
+      "tok-unknown",
+      "tok-next",
+      new Date()
+    ).catch((e) => e);
+
+    expect(err).toBeInstanceOf(TokenFamilyError);
+    expect(err.code).toBe("INVALID_TOKEN");
+  });
+
+  it("does not create a new token record when reuse is detected", async () => {
+    mockTx.refreshToken.findUnique.mockResolvedValue(makeRecord({ used: true }));
+    mockTx.refreshToken.deleteMany.mockResolvedValue({ count: 1 });
+
+    await rotateTokenFamily("tok-current", "tok-next", new Date()).catch(() => {});
+
+    expect(mockTx.refreshToken.create).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// invalidateFamily
+// ---------------------------------------------------------------------------
+
+describe("invalidateFamily", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("deletes all tokens with the given familyId", async () => {
+    mockPrisma.refreshToken.deleteMany.mockResolvedValue({ count: 3 });
+    await invalidateFamily("family-xyz");
+    expect(mockPrisma.refreshToken.deleteMany).toHaveBeenCalledWith({
+      where: { familyId: "family-xyz" },
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pruneExpiredFamilies
+// ---------------------------------------------------------------------------
+
+describe("pruneExpiredFamilies", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns the number of deleted records", async () => {
+    mockPrisma.refreshToken.deleteMany.mockResolvedValue({ count: 7 });
+    const result = await pruneExpiredFamilies();
+    expect(result.deleted).toBe(7);
+  });
+
+  it("filters by expiresAt older than 30 days", async () => {
+    mockPrisma.refreshToken.deleteMany.mockResolvedValue({ count: 0 });
+    await pruneExpiredFamilies();
+    expect(mockPrisma.refreshToken.deleteMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          expiresAt: expect.objectContaining({ lt: expect.any(Date) }),
+        }),
+      })
+    );
+
+    const callArgs = mockPrisma.refreshToken.deleteMany.mock.calls[0][0];
+    const cutoff: Date = callArgs.where.expiresAt.lt;
+    const thirtyDaysAgo = Date.now() - 30 * 24 * 60 * 60 * 1000;
+    expect(Math.abs(cutoff.getTime() - thirtyDaysAgo)).toBeLessThan(5000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TokenFamilyError
+// ---------------------------------------------------------------------------
+
+describe("TokenFamilyError", () => {
+  it("is an instance of Error", () => {
+    const err = new TokenFamilyError("REUSE_DETECTED", "msg");
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  it("has the correct code and message", () => {
+    const err = new TokenFamilyError("INVALID_TOKEN", "not found");
+    expect(err.code).toBe("INVALID_TOKEN");
+    expect(err.message).toBe("not found");
+    expect(err.name).toBe("TokenFamilyError");
+  });
+});

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -13,6 +13,11 @@ import {
   NonceResponseDto,
   RefreshTokenDto,
 } from "./dto/auth.dto";
+import {
+  createTokenFamily,
+  rotateTokenFamily,
+  TokenFamilyError,
+} from "./refresh-token-family.service";
 
 @Injectable()
 export class AuthService {
@@ -36,7 +41,7 @@ export class AuthService {
 
   /**
    * Step 2: Client signs the nonce and submits here.
-   * Returns JWT token pair on success.
+   * Returns JWT token pair on success and creates the initial token family.
    */
   async authenticateWithWallet(dto: WalletAuthDto): Promise<AuthResponseDto> {
     const { publicKey, signature, nonce } = dto;
@@ -45,13 +50,11 @@ export class AuthService {
       throw new BadRequestException("Invalid Stellar public key");
     }
 
-    // Verify nonce is valid and not replayed
     const nonceValid = this.nonceService.consumeNonce(nonce, publicKey);
     if (!nonceValid) {
       throw new UnauthorizedException("Invalid or expired nonce");
     }
 
-    // Verify the wallet signature
     const result = this.stellarSig.verifySignature(publicKey, signature, nonce);
     if (!result.valid) {
       this.logger.warn(
@@ -61,21 +64,60 @@ export class AuthService {
     }
 
     this.logger.log(`Wallet authenticated: ${publicKey}`);
-    return this.tokenService.generateTokenPair(publicKey);
+    const tokenPair = this.tokenService.generateTokenPair(publicKey);
+
+    // Create initial token family entry (non-fatal if DB is unavailable)
+    const refreshTtlMs = 7 * 24 * 60 * 60 * 1000;
+    await createTokenFamily(
+      tokenPair.refreshToken,
+      new Date(Date.now() + refreshTtlMs)
+    ).catch((err) =>
+      this.logger.warn(`Failed to create token family: ${err.message}`)
+    );
+
+    return tokenPair;
   }
 
   /**
    * Step 3: Refresh access token using refresh token.
+   * Implements family rotation with reuse-detection.
    */
-  refreshTokens(dto: RefreshTokenDto): AuthResponseDto {
+  async refreshTokens(dto: RefreshTokenDto): Promise<AuthResponseDto> {
     const payload = this.tokenService.verifyRefreshToken(dto.refreshToken);
 
-    // Revoke old refresh token (rotation)
+    // Generate the next pair before rotating so we have the new token string
+    const nextPair = this.tokenService.generateTokenPair(payload.walletAddress);
+    const refreshTtlMs = 7 * 24 * 60 * 60 * 1000;
+
+    try {
+      await rotateTokenFamily(
+        dto.refreshToken,
+        nextPair.refreshToken,
+        new Date(Date.now() + refreshTtlMs)
+      );
+    } catch (err) {
+      if (err instanceof TokenFamilyError && err.code === "REUSE_DETECTED") {
+        this.logger.warn(
+          `Refresh token reuse detected for wallet ${payload.walletAddress} — family invalidated`
+        );
+        throw new UnauthorizedException(
+          "Refresh token reuse detected. All sessions invalidated for security."
+        );
+      }
+      if (err instanceof TokenFamilyError && err.code === "INVALID_TOKEN") {
+        // Token not in family store — allow legacy rotation (backward compat)
+        this.logger.warn(
+          `Refresh token not found in family store — allowing legacy rotation for ${payload.walletAddress}`
+        );
+      }
+    }
+
+    // Revoke old JTI in the in-memory store (backward-compat with legacy tokens)
     if (payload.jti) {
       this.tokenService.revokeToken(payload.jti);
     }
 
-    return this.tokenService.generateTokenPair(payload.walletAddress);
+    return nextPair;
   }
 
   /**

--- a/backend/src/auth/refresh-token-family.service.ts
+++ b/backend/src/auth/refresh-token-family.service.ts
@@ -1,0 +1,122 @@
+/**
+ * Refresh token family service (#1345).
+ *
+ * Implements the token-family reuse-detection pattern:
+ *  - Each login creates a new family (familyId = uuid).
+ *  - On refresh: mark current token as used, issue new token in the same family.
+ *  - On reuse (used token presented): invalidate ALL tokens in the family → 401.
+ *
+ * All rotation operations are atomic via a Prisma transaction.
+ * pruneExpiredFamilies() is called by a cleanup job to remove families older than 30 days.
+ */
+
+import { v4 as uuidv4 } from "uuid";
+import prisma from "../lib/prisma";
+
+const FAMILY_TTL_DAYS = 30;
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Create the initial family entry on new session (login).
+ */
+export async function createTokenFamily(
+  token: string,
+  expiresAt: Date
+): Promise<{ familyId: string }> {
+  const familyId = uuidv4();
+  await (prisma as any).refreshToken.create({
+    data: { familyId, token, expiresAt },
+  });
+  return { familyId };
+}
+
+/**
+ * Rotate a refresh token within its family.
+ *
+ * Throws TokenFamilyError with:
+ *  - REUSE_DETECTED — if the presented token was already used (entire family invalidated)
+ *  - INVALID_TOKEN  — if the token is not found in the store
+ */
+export async function rotateTokenFamily(
+  currentToken: string,
+  nextToken: string,
+  nextExpiresAt: Date
+): Promise<{ familyId: string }> {
+  return (prisma as any).$transaction(async (tx: any) => {
+    const record = await tx.refreshToken.findUnique({
+      where: { token: currentToken },
+    });
+
+    if (!record) {
+      throw new TokenFamilyError("INVALID_TOKEN", "Refresh token not found");
+    }
+
+    if (record.used) {
+      // Reuse detected — invalidate the whole family to contain the breach
+      await tx.refreshToken.deleteMany({
+        where: { familyId: record.familyId },
+      });
+      throw new TokenFamilyError(
+        "REUSE_DETECTED",
+        "Refresh token reuse detected — entire family invalidated"
+      );
+    }
+
+    // Mark current token as used
+    await tx.refreshToken.update({
+      where: { token: currentToken },
+      data: { used: true },
+    });
+
+    // Issue new token in the same family
+    await tx.refreshToken.create({
+      data: {
+        familyId: record.familyId,
+        token: nextToken,
+        expiresAt: nextExpiresAt,
+      },
+    });
+
+    return { familyId: record.familyId };
+  });
+}
+
+/**
+ * Invalidate all tokens in a family (e.g., on explicit logout).
+ */
+export async function invalidateFamily(familyId: string): Promise<void> {
+  await (prisma as any).refreshToken.deleteMany({ where: { familyId } });
+}
+
+/**
+ * Prune expired token families older than FAMILY_TTL_DAYS.
+ * Intended to be called by a periodic cleanup job.
+ */
+export async function pruneExpiredFamilies(): Promise<{ deleted: number }> {
+  const cutoff = new Date(
+    Date.now() - FAMILY_TTL_DAYS * 24 * 60 * 60 * 1000
+  );
+  const result = await (prisma as any).refreshToken.deleteMany({
+    where: { expiresAt: { lt: cutoff } },
+  });
+  return { deleted: result.count };
+}
+
+// ---------------------------------------------------------------------------
+// Error type
+// ---------------------------------------------------------------------------
+
+export type TokenFamilyErrorCode = "INVALID_TOKEN" | "REUSE_DETECTED";
+
+export class TokenFamilyError extends Error {
+  constructor(
+    public readonly code: TokenFamilyErrorCode,
+    message: string
+  ) {
+    super(message);
+    this.name = "TokenFamilyError";
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `RefreshToken` model to `prisma/schema.prisma` with `familyId`, `token`, `used`, and `expiresAt` fields and a corresponding SQL migration
- Introduces `src/auth/refresh-token-family.service.ts` with `createTokenFamily`, `rotateTokenFamily`, `invalidateFamily`, and `pruneExpiredFamilies` — all family operations are atomic via a Prisma `$transaction`
- Updates `auth.service.ts` to call `createTokenFamily` on login and `rotateTokenFamily` on refresh
- On reuse detection (a `used` token is presented), the entire family is invalidated atomically and a `401` is returned — both the legitimate and attacker sessions are terminated
- Legacy tokens not present in the family store fall through to backward-compatible JTI revocation so existing sessions are not broken during rollout
- A cleanup job hook (`pruneExpiredFamilies`) prunes families older than 30 days

## Test plan

- [ ] `createTokenFamily` generates unique family IDs and persists the token
- [ ] Normal rotation marks current token as `used` and creates next token in same `familyId` inside a transaction
- [ ] Reuse detection: presenting a `used` token deletes all family members and throws `REUSE_DETECTED`
- [ ] `INVALID_TOKEN` error when token is not found in the store
- [ ] `invalidateFamily` removes all tokens for a family (logout path)
- [ ] `pruneExpiredFamilies` filters by `expiresAt < now - 30 days`

Closes #1345