### PR TITLE
feat(frontend): dead-letter queue visibility with retry/discard actions in webhook manager

### DIFF
--- a/frontend/src/components/UI/Tabs.tsx
+++ b/frontend/src/components/UI/Tabs.tsx
@@ -1,0 +1,100 @@
+import React, { ReactNode, ReactElement } from 'react';
+
+interface TabsProps {
+  defaultValue: string;
+  children: ReactNode;
+  className?: string;
+}
+
+interface TabsContextValue {
+  activeTab: string;
+  setActiveTab: (value: string) => void;
+}
+
+const TabsContext = React.createContext<TabsContextValue | undefined>(undefined);
+
+function useTabs(): TabsContextValue {
+  const context = React.useContext(TabsContext);
+  if (!context) {
+    throw new Error('Tab components must be used within a Tabs component');
+  }
+  return context;
+}
+
+export function Tabs({ defaultValue, children, className = '' }: TabsProps) {
+  const [activeTab, setActiveTab] = React.useState(defaultValue);
+
+  return (
+    <TabsContext.Provider value={{ activeTab, setActiveTab }}>
+      <div className={className}>{children}</div>
+    </TabsContext.Provider>
+  );
+}
+
+interface TabsListProps {
+  children: ReactNode;
+  className?: string;
+}
+
+export function TabsList({ children, className = '' }: TabsListProps) {
+  return (
+    <div
+      className={`flex border-b border-gray-200 ${className}`}
+      role="tablist"
+    >
+      {children}
+    </div>
+  );
+}
+
+interface TabsTriggerProps {
+  value: string;
+  children: ReactNode;
+  badge?: number;
+  className?: string;
+}
+
+export function TabsTrigger({ value, children, badge, className = '' }: TabsTriggerProps) {
+  const { activeTab, setActiveTab } = useTabs();
+  const isActive = activeTab === value;
+
+  return (
+    <button
+      role="tab"
+      aria-selected={isActive}
+      onClick={() => setActiveTab(value)}
+      className={`px-4 py-3 font-medium text-sm border-b-2 transition-colors whitespace-nowrap relative ${
+        isActive
+          ? 'border-blue-500 text-blue-600'
+          : 'border-transparent text-gray-600 hover:text-gray-900'
+      } ${className}`}
+    >
+      {children}
+      {badge !== undefined && badge > 0 && (
+        <span className="ml-2 inline-flex items-center justify-center px-2 py-1 text-xs font-bold leading-none text-white transform translate-y-px bg-red-600 rounded-full">
+          {badge}
+        </span>
+      )}
+    </button>
+  );
+}
+
+interface TabsContentProps {
+  value: string;
+  children: ReactNode;
+  className?: string;
+}
+
+export function TabsContent({ value, children, className = '' }: TabsContentProps) {
+  const { activeTab } = useTabs();
+
+  if (activeTab !== value) {
+    return null;
+  }
+
+  return (
+    <div role="tabpanel" className={className}>
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/components/UI/__tests__/Tabs.test.tsx
+++ b/frontend/src/components/UI/__tests__/Tabs.test.tsx
@@ -1,0 +1,174 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '../Tabs';
+
+describe('Tabs Component', () => {
+  it('should render tabs with default value', () => {
+    render(
+      <Tabs defaultValue="tab1">
+        <TabsList>
+          <TabsTrigger value="tab1">Tab 1</TabsTrigger>
+          <TabsTrigger value="tab2">Tab 2</TabsTrigger>
+        </TabsList>
+        <TabsContent value="tab1">Content 1</TabsContent>
+        <TabsContent value="tab2">Content 2</TabsContent>
+      </Tabs>
+    );
+
+    expect(screen.getByText('Tab 1')).toBeInTheDocument();
+    expect(screen.getByText('Tab 2')).toBeInTheDocument();
+    expect(screen.getByText('Content 1')).toBeInTheDocument();
+  });
+
+  it('should show only default tab content initially', () => {
+    render(
+      <Tabs defaultValue="tab1">
+        <TabsList>
+          <TabsTrigger value="tab1">Tab 1</TabsTrigger>
+          <TabsTrigger value="tab2">Tab 2</TabsTrigger>
+        </TabsList>
+        <TabsContent value="tab1">Content 1</TabsContent>
+        <TabsContent value="tab2">Content 2</TabsContent>
+      </Tabs>
+    );
+
+    expect(screen.getByText('Content 1')).toBeInTheDocument();
+    expect(screen.queryByText('Content 2')).not.toBeInTheDocument();
+  });
+
+  it('should switch tabs on click', async () => {
+    const user = userEvent.setup();
+    render(
+      <Tabs defaultValue="tab1">
+        <TabsList>
+          <TabsTrigger value="tab1">Tab 1</TabsTrigger>
+          <TabsTrigger value="tab2">Tab 2</TabsTrigger>
+        </TabsList>
+        <TabsContent value="tab1">Content 1</TabsContent>
+        <TabsContent value="tab2">Content 2</TabsContent>
+      </Tabs>
+    );
+
+    const tab2Button = screen.getByText('Tab 2');
+    await user.click(tab2Button);
+
+    expect(screen.queryByText('Content 1')).not.toBeInTheDocument();
+    expect(screen.getByText('Content 2')).toBeInTheDocument();
+  });
+
+  it('should display badge on trigger', () => {
+    render(
+      <Tabs defaultValue="tab1">
+        <TabsList>
+          <TabsTrigger value="tab1">Tab 1</TabsTrigger>
+          <TabsTrigger value="tab2" badge={5}>
+            Tab 2
+          </TabsTrigger>
+        </TabsList>
+        <TabsContent value="tab1">Content 1</TabsContent>
+        <TabsContent value="tab2">Content 2</TabsContent>
+      </Tabs>
+    );
+
+    expect(screen.getByText('5')).toBeInTheDocument();
+  });
+
+  it('should not display badge when count is 0', () => {
+    render(
+      <Tabs defaultValue="tab1">
+        <TabsList>
+          <TabsTrigger value="tab1">Tab 1</TabsTrigger>
+          <TabsTrigger value="tab2" badge={0}>
+            Tab 2
+          </TabsTrigger>
+        </TabsList>
+        <TabsContent value="tab1">Content 1</TabsContent>
+        <TabsContent value="tab2">Content 2</TabsContent>
+      </Tabs>
+    );
+
+    // Badge with 0 should not be visible (conditional rendering)
+    expect(screen.queryByText('0')).not.toBeInTheDocument();
+  });
+
+  it('should mark active tab with aria-selected', async () => {
+    const user = userEvent.setup();
+    render(
+      <Tabs defaultValue="tab1">
+        <TabsList>
+          <TabsTrigger value="tab1">Tab 1</TabsTrigger>
+          <TabsTrigger value="tab2">Tab 2</TabsTrigger>
+        </TabsList>
+        <TabsContent value="tab1">Content 1</TabsContent>
+        <TabsContent value="tab2">Content 2</TabsContent>
+      </Tabs>
+    );
+
+    const tab1 = screen.getByRole('tab', { name: 'Tab 1' });
+    const tab2 = screen.getByRole('tab', { name: 'Tab 2' });
+
+    expect(tab1).toHaveAttribute('aria-selected', 'true');
+    expect(tab2).toHaveAttribute('aria-selected', 'false');
+
+    await user.click(tab2);
+
+    expect(tab1).toHaveAttribute('aria-selected', 'false');
+    expect(tab2).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('should handle multiple tab switches', async () => {
+    const user = userEvent.setup();
+    render(
+      <Tabs defaultValue="tab1">
+        <TabsList>
+          <TabsTrigger value="tab1">Tab 1</TabsTrigger>
+          <TabsTrigger value="tab2">Tab 2</TabsTrigger>
+          <TabsTrigger value="tab3">Tab 3</TabsTrigger>
+        </TabsList>
+        <TabsContent value="tab1">Content 1</TabsContent>
+        <TabsContent value="tab2">Content 2</TabsContent>
+        <TabsContent value="tab3">Content 3</TabsContent>
+      </Tabs>
+    );
+
+    expect(screen.getByText('Content 1')).toBeInTheDocument();
+
+    await user.click(screen.getByText('Tab 2'));
+    expect(screen.getByText('Content 2')).toBeInTheDocument();
+
+    await user.click(screen.getByText('Tab 3'));
+    expect(screen.getByText('Content 3')).toBeInTheDocument();
+
+    await user.click(screen.getByText('Tab 1'));
+    expect(screen.getByText('Content 1')).toBeInTheDocument();
+  });
+
+  it('should apply custom className', () => {
+    const { container } = render(
+      <Tabs defaultValue="tab1" className="custom-class">
+        <TabsList>
+          <TabsTrigger value="tab1">Tab 1</TabsTrigger>
+        </TabsList>
+        <TabsContent value="tab1">Content 1</TabsContent>
+      </Tabs>
+    );
+
+    expect(container.querySelector('.custom-class')).toBeInTheDocument();
+  });
+
+  it('should throw error when using Tab components outside Tabs context', () => {
+    // Suppress console.error for this test
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(() => {
+      render(
+        <TabsList>
+          <TabsTrigger value="tab1">Tab 1</TabsTrigger>
+        </TabsList>
+      );
+    }).toThrow('Tab components must be used within a Tabs component');
+
+    consoleError.mockRestore();
+  });
+});

--- a/frontend/src/components/Webhooks/DeadLetterTab.tsx
+++ b/frontend/src/components/Webhooks/DeadLetterTab.tsx
@@ -1,0 +1,196 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import { webhookApi, DeadLetterEntry } from '../../services/webhookApi';
+import { Spinner } from '../UI/Spinner';
+import { Button } from '../UI/Button';
+import { ConfirmDialog } from '../UI/ConfirmDialog';
+import { CheckCircle } from 'lucide-react';
+
+interface DeadLetterTabProps {
+  subscriptionId: string;
+}
+
+export function DeadLetterTab({ subscriptionId }: DeadLetterTabProps) {
+  const [entries, setEntries] = useState<DeadLetterEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [confirmingId, setConfirmingId] = useState<string | null>(null);
+  const [confirmingAction, setConfirmingAction] = useState<'retry' | 'discard' | null>(null);
+  const [processingId, setProcessingId] = useState<string | null>(null);
+
+  const fetchEntries = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await webhookApi.getDeadLetters(subscriptionId);
+      setEntries(data);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load dead-letter entries');
+    } finally {
+      setLoading(false);
+    }
+  }, [subscriptionId]);
+
+  useEffect(() => {
+    fetchEntries();
+  }, [fetchEntries]);
+
+  const handleRetry = async () => {
+    if (!confirmingId) return;
+    setProcessingId(confirmingId);
+    try {
+      await webhookApi.retryDeadLetter(confirmingId);
+      setEntries(prev => prev.filter(e => e.id !== confirmingId));
+      setConfirmingId(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to retry dead-letter');
+    } finally {
+      setProcessingId(null);
+    }
+  };
+
+  const handleDiscard = async () => {
+    if (!confirmingId) return;
+    setProcessingId(confirmingId);
+    try {
+      await webhookApi.discardDeadLetter(confirmingId);
+      setEntries(prev => prev.filter(e => e.id !== confirmingId));
+      setConfirmingId(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to discard dead-letter');
+    } finally {
+      setProcessingId(null);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex justify-center py-12">
+        <Spinner size="lg" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="p-6 text-center text-red-600">
+        <p>{error}</p>
+        <button
+          onClick={fetchEntries}
+          className="mt-2 text-sm text-blue-600 hover:underline"
+        >
+          Try again
+        </button>
+      </div>
+    );
+  }
+
+  if (entries.length === 0) {
+    return (
+      <div className="p-12 text-center text-gray-500">
+        <CheckCircle className="w-12 h-12 text-green-300 mx-auto mb-4" />
+        <p>No dead-letter entries. All webhooks are being delivered successfully!</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full divide-y divide-gray-200">
+        <thead className="bg-gray-50">
+          <tr>
+            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              Event Type
+            </th>
+            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              Failure Reason
+            </th>
+            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              Attempts
+            </th>
+            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              Last Attempt
+            </th>
+            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              Actions
+            </th>
+          </tr>
+        </thead>
+        <tbody className="bg-white divide-y divide-gray-200">
+          {entries.map((entry) => (
+            <tr key={entry.id} className="hover:bg-gray-50">
+              <td className="px-6 py-4 whitespace-nowrap">
+                <span className="text-sm text-gray-900 font-mono">
+                  {entry.event}
+                </span>
+              </td>
+              <td className="px-6 py-4 text-sm text-gray-500 max-w-xs truncate">
+                {entry.lastError || 'Unknown error'}
+              </td>
+              <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 text-center">
+                {entry.attemptCount}
+              </td>
+              <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                {new Date(entry.updatedAt).toLocaleString()}
+              </td>
+              <td className="px-6 py-4 whitespace-nowrap">
+                <div className="flex gap-2">
+                    <Button
+                    size="sm"
+                    variant="primary"
+                    onClick={() => {
+                      setConfirmingId(entry.id);
+                      setConfirmingAction('retry');
+                    }}
+                    disabled={processingId === entry.id}
+                    className="text-xs"
+                  >
+                    Retry
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="secondary"
+                    onClick={() => {
+                      setConfirmingId(entry.id);
+                      setConfirmingAction('discard');
+                    }}
+                    disabled={processingId === entry.id}
+                    className="text-xs"
+                  >
+                    Discard
+                  </Button>
+                </div>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <ConfirmDialog
+        isOpen={confirmingAction === 'retry' && confirmingId !== null}
+        title="Retry Dead-Letter Delivery?"
+        message="This will attempt to deliver the webhook again with the original payload."
+        confirmText="Retry"
+        action="custom"
+        onConfirm={handleRetry}
+        onClose={() => {
+          setConfirmingId(null);
+          setConfirmingAction(null);
+        }}
+      />
+
+      <ConfirmDialog
+        isOpen={confirmingAction === 'discard' && confirmingId !== null}
+        title="Discard Dead-Letter Entry?"
+        message="This will mark the entry as skipped and remove it from the queue. This action cannot be undone."
+        confirmText="Discard"
+        confirmButtonVariant="danger"
+        action="custom"
+        onConfirm={handleDiscard}
+        onClose={() => {
+          setConfirmingId(null);
+          setConfirmingAction(null);
+        }}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/Webhooks/WebhookSubscriptionList.tsx
+++ b/frontend/src/components/Webhooks/WebhookSubscriptionList.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useCallback, useMemo } from 'react';
-import { webhookApi, WebhookSubscription, WebhookEventType } from '../../services/webhookApi';
+import { webhookApi, WebhookSubscription, WebhookEventType, DeadLetterEntry } from '../../services/webhookApi';
 import { useWallet } from '../../hooks/useWallet';
 import { Card } from '../UI/Card';
 import { Button } from '../UI/Button';
@@ -7,6 +7,8 @@ import { Spinner } from '../UI/Spinner';
 import { ConfirmDialog } from '../UI/ConfirmDialog';
 import { Modal } from '../UI/Modal';
 import { WebhookDeliveryLogs } from './WebhookDeliveryLogs';
+import { DeadLetterTab } from './DeadLetterTab';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '../UI/Tabs';
 import { Icons } from '../UI/Icons';
 
 export function WebhookSubscriptionList() {
@@ -19,6 +21,7 @@ export function WebhookSubscriptionList() {
     const [selectedSubId, setSelectedSubId] = useState<string | null>(null);
     const [isTestingId, setIsTestingId] = useState<string | null>(null);
     const [query, setQuery] = useState('');
+    const [deadLetterCounts, setDeadLetterCounts] = useState<Record<string, number>>({});
 
     const fetchSubscriptions = useCallback(async () => {
         if (!wallet?.address) return;
@@ -26,6 +29,20 @@ export function WebhookSubscriptionList() {
         try {
             const data = await webhookApi.listSubscriptions(wallet.address);
             setSubscriptions(data);
+            
+            // Fetch dead-letter counts for each subscription
+            const counts: Record<string, number> = {};
+            for (const sub of data) {
+                try {
+                    const deadLetters = await webhookApi.getDeadLetters(sub.id, 1);
+                    // Just get the count by making a small request
+                    const allDeadLetters = await webhookApi.getDeadLetters(sub.id, 999);
+                    counts[sub.id] = allDeadLetters.length;
+                } catch (err) {
+                    counts[sub.id] = 0;
+                }
+            }
+            setDeadLetterCounts(counts);
             setError(null);
         } catch (err) {
             setError(err instanceof Error ? err.message : 'Failed to load subscriptions');
@@ -242,7 +259,7 @@ export function WebhookSubscriptionList() {
                                     className="text-blue-600 border-blue-200 hover:bg-blue-50"
                                     onClick={() => setSelectedSubId(sub.id)}
                                 >
-                                    View Delivery Logs
+                                    View Details
                                 </Button>
                             </div>
                         </div>
@@ -265,10 +282,25 @@ export function WebhookSubscriptionList() {
             <Modal
                 isOpen={!!selectedSubId}
                 onClose={() => setSelectedSubId(null)}
-                title="Webhook Delivery Logs"
+                title="Webhook Details"
                 maxWidth="4xl"
             >
-                {selectedSubId && <WebhookDeliveryLogs subscriptionId={selectedSubId} />}
+                {selectedSubId && (
+                    <Tabs defaultValue="logs" className="w-full">
+                        <TabsList className="w-full">
+                            <TabsTrigger value="logs">Delivery Logs</TabsTrigger>
+                            <TabsTrigger value="dead-letters" badge={deadLetterCounts[selectedSubId] || 0}>
+                                Dead Letters
+                            </TabsTrigger>
+                        </TabsList>
+                        <TabsContent value="logs" className="mt-6">
+                            <WebhookDeliveryLogs subscriptionId={selectedSubId} />
+                        </TabsContent>
+                        <TabsContent value="dead-letters" className="mt-6">
+                            <DeadLetterTab subscriptionId={selectedSubId} />
+                        </TabsContent>
+                    </Tabs>
+                )}
             </Modal>
         </div>
     );

--- a/frontend/src/components/Webhooks/__tests__/DeadLetterTab.test.tsx
+++ b/frontend/src/components/Webhooks/__tests__/DeadLetterTab.test.tsx
@@ -1,0 +1,274 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { DeadLetterTab } from '../DeadLetterTab';
+import { webhookApi, WebhookEventType } from '../../../services/webhookApi';
+
+// Mock the API
+vi.mock('../../../services/webhookApi', () => ({
+  webhookApi: {
+    getDeadLetters: vi.fn(),
+    retryDeadLetter: vi.fn(),
+    discardDeadLetter: vi.fn(),
+  },
+  WebhookEventType: {
+    TOKEN_BURN_SELF: 'token.burn.self',
+    TOKEN_BURN_ADMIN: 'token.burn.admin',
+    TOKEN_CREATED: 'token.created',
+    TOKEN_METADATA_UPDATED: 'token.metadata.updated',
+  },
+}));
+
+const mockDeadLetters = [
+  {
+    id: 'dl-1',
+    subscriptionId: 'sub-1',
+    event: WebhookEventType.TOKEN_BURN_SELF,
+    payload: '{"data": "test"}',
+    statusCode: 500,
+    lastError: 'Connection refused',
+    attemptCount: 3,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    resolvedAt: null,
+    resolution: null,
+  },
+  {
+    id: 'dl-2',
+    subscriptionId: 'sub-1',
+    event: WebhookEventType.TOKEN_CREATED,
+    payload: '{"data": "test2"}',
+    statusCode: 503,
+    lastError: 'Service temporarily unavailable',
+    attemptCount: 2,
+    createdAt: new Date(Date.now() - 60000).toISOString(),
+    updatedAt: new Date(Date.now() - 60000).toISOString(),
+    resolvedAt: null,
+    resolution: null,
+  },
+];
+
+describe('DeadLetterTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render loading state initially', () => {
+    (webhookApi.getDeadLetters as any).mockImplementation(
+      () => new Promise(() => {}) // Never resolves
+    );
+
+    render(<DeadLetterTab subscriptionId="sub-1" />);
+    expect(screen.getByRole('img', { hidden: true })).toBeInTheDocument(); // Spinner
+  });
+
+  it('should display dead-letter entries', async () => {
+    (webhookApi.getDeadLetters as any).mockResolvedValueOnce(mockDeadLetters);
+
+    render(<DeadLetterTab subscriptionId="sub-1" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('token.burn.self')).toBeInTheDocument();
+      expect(screen.getByText('token.created')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Connection refused')).toBeInTheDocument();
+    expect(screen.getByText('Service temporarily unavailable')).toBeInTheDocument();
+  });
+
+  it('should display table headers correctly', async () => {
+    (webhookApi.getDeadLetters as any).mockResolvedValueOnce(mockDeadLetters);
+
+    render(<DeadLetterTab subscriptionId="sub-1" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Event Type')).toBeInTheDocument();
+      expect(screen.getByText('Failure Reason')).toBeInTheDocument();
+      expect(screen.getByText('Attempts')).toBeInTheDocument();
+      expect(screen.getByText('Last Attempt')).toBeInTheDocument();
+      expect(screen.getByText('Actions')).toBeInTheDocument();
+    });
+  });
+
+  it('should show empty state when no dead letters', async () => {
+    (webhookApi.getDeadLetters as any).mockResolvedValueOnce([]);
+
+    render(<DeadLetterTab subscriptionId="sub-1" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/No dead-letter entries/)).toBeInTheDocument();
+    });
+  });
+
+  it('should show error state on fetch failure', async () => {
+    const errorMessage = 'Failed to fetch dead letters';
+    (webhookApi.getDeadLetters as any).mockRejectedValueOnce(new Error(errorMessage));
+
+    render(<DeadLetterTab subscriptionId="sub-1" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(errorMessage)).toBeInTheDocument();
+    });
+  });
+
+  it('should retry dead-letter on confirm', async () => {
+    (webhookApi.getDeadLetters as any).mockResolvedValueOnce(mockDeadLetters);
+    (webhookApi.retryDeadLetter as any).mockResolvedValueOnce({
+      success: true,
+      message: 'Retried successfully',
+    });
+
+    const user = userEvent.setup();
+    render(<DeadLetterTab subscriptionId="sub-1" />);
+
+    await waitFor(() => {
+      expect(screen.getAllByText('Retry')).toHaveLength(2);
+    });
+
+    const retryButtons = screen.getAllByText('Retry');
+    await user.click(retryButtons[0]);
+
+    // Confirm dialog should appear
+    await waitFor(() => {
+      expect(screen.getByText('Retry Dead-Letter Delivery?')).toBeInTheDocument();
+    });
+
+    const confirmButton = screen.getByText('Retry');
+    await user.click(confirmButton);
+
+    await waitFor(() => {
+      expect(webhookApi.retryDeadLetter).toHaveBeenCalledWith('dl-1');
+    });
+
+    // Entry should be removed from table
+    await waitFor(() => {
+      expect(screen.queryByText('Connection refused')).not.toBeInTheDocument();
+    });
+  });
+
+  it('should discard dead-letter on confirm', async () => {
+    (webhookApi.getDeadLetters as any).mockResolvedValueOnce(mockDeadLetters);
+    (webhookApi.discardDeadLetter as any).mockResolvedValueOnce({
+      success: true,
+      message: 'Discarded successfully',
+    });
+
+    const user = userEvent.setup();
+    render(<DeadLetterTab subscriptionId="sub-1" />);
+
+    await waitFor(() => {
+      expect(screen.getAllByText('Discard')).toHaveLength(2);
+    });
+
+    const discardButtons = screen.getAllByText('Discard');
+    await user.click(discardButtons[0]);
+
+    // Confirm dialog should appear
+    await waitFor(() => {
+      expect(screen.getByText('Discard Dead-Letter Entry?')).toBeInTheDocument();
+    });
+
+    const confirmButton = screen.getByText('Discard');
+    await user.click(confirmButton);
+
+    await waitFor(() => {
+      expect(webhookApi.discardDeadLetter).toHaveBeenCalledWith('dl-1');
+    });
+
+    // Entry should be removed from table
+    await waitFor(() => {
+      expect(screen.queryByText('Connection refused')).not.toBeInTheDocument();
+    });
+  });
+
+  it('should cancel retry action', async () => {
+    (webhookApi.getDeadLetters as any).mockResolvedValueOnce(mockDeadLetters);
+
+    const user = userEvent.setup();
+    render(<DeadLetterTab subscriptionId="sub-1" />);
+
+    await waitFor(() => {
+      expect(screen.getAllByText('Retry')).toHaveLength(2);
+    });
+
+    const retryButtons = screen.getAllByText('Retry');
+    await user.click(retryButtons[0]);
+
+    // Confirm dialog should appear
+    await waitFor(() => {
+      expect(screen.getByText('Retry Dead-Letter Delivery?')).toBeInTheDocument();
+    });
+
+    // Click cancel (first button that says something other than Retry in the dialog)
+    const cancelButton = screen.getByText(/Retry Dead-Letter Delivery/);
+    const dialog = cancelButton.closest('[role="dialog"]');
+    const buttons = dialog?.querySelectorAll('button');
+    if (buttons && buttons.length > 0) {
+      await user.click(buttons[0]); // Cancel is usually first
+    }
+
+    expect(webhookApi.retryDeadLetter).not.toHaveBeenCalled();
+  });
+
+  it('should display attempt count', async () => {
+    (webhookApi.getDeadLetters as any).mockResolvedValueOnce(mockDeadLetters);
+
+    render(<DeadLetterTab subscriptionId="sub-1" />);
+
+    await waitFor(() => {
+      const cells = screen.getAllByText(/^[23]$/); // Attempt counts 3 and 2
+      expect(cells.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  it('should display formatted last attempt timestamp', async () => {
+    (webhookApi.getDeadLetters as any).mockResolvedValueOnce(mockDeadLetters);
+
+    render(<DeadLetterTab subscriptionId="sub-1" />);
+
+    await waitFor(() => {
+      const dateStrings = screen.getAllByText(/\d{1,2}\/\d{1,2}\/\d{4}/);
+      expect(dateStrings.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('should handle retry error gracefully', async () => {
+    (webhookApi.getDeadLetters as any).mockResolvedValueOnce(mockDeadLetters);
+    const errorMessage = 'Retry failed';
+    (webhookApi.retryDeadLetter as any).mockRejectedValueOnce(new Error(errorMessage));
+
+    const user = userEvent.setup();
+    render(<DeadLetterTab subscriptionId="sub-1" />);
+
+    await waitFor(() => {
+      expect(screen.getAllByText('Retry')).toHaveLength(2);
+    });
+
+    const retryButtons = screen.getAllByText('Retry');
+    await user.click(retryButtons[0]);
+
+    await waitFor(() => {
+      expect(screen.getByText('Retry Dead-Letter Delivery?')).toBeInTheDocument();
+    });
+
+    const confirmButton = screen.getByText('Retry');
+    await user.click(confirmButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(errorMessage)).toBeInTheDocument();
+    });
+  });
+
+  it('should display endpoint URL if available in payload', async () => {
+    (webhookApi.getDeadLetters as any).mockResolvedValueOnce(mockDeadLetters);
+
+    render(<DeadLetterTab subscriptionId="sub-1" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('token.burn.self')).toBeInTheDocument();
+    });
+
+    // Verify the table renders with all entries
+    expect(screen.getByText('token.created')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/services/webhookApi.ts
+++ b/frontend/src/services/webhookApi.ts
@@ -36,6 +36,20 @@ export interface WebhookDeliveryLog {
   createdAt: string;
 }
 
+export interface DeadLetterEntry {
+  id: string;
+  subscriptionId: string;
+  event: WebhookEventType;
+  payload: string;
+  statusCode: number | null;
+  lastError: string | null;
+  attemptCount: number;
+  createdAt: string;
+  updatedAt: string;
+  resolvedAt: string | null;
+  resolution: string | null;
+}
+
 export interface CreateWebhookInput {
   url: string;
   tokenAddress?: string | null;
@@ -115,6 +129,28 @@ export const webhookApi = {
    */
   testWebhook: (id: string) =>
     request<{ success: boolean; message: string }>(`/${id}/test`, {
+      method: "POST",
+    }),
+
+  /**
+   * Get dead-letter entries for a subscription
+   */
+  getDeadLetters: (id: string, limit = 50) =>
+    request<DeadLetterEntry[]>(`/${id}/dead-letters?limit=${limit}`),
+
+  /**
+   * Retry a dead-letter delivery
+   */
+  retryDeadLetter: (id: string) =>
+    request<{ success: boolean; message: string }>(`/dead-letters/${id}/retry`, {
+      method: "POST",
+    }),
+
+  /**
+   * Skip/discard a dead-letter delivery
+   */
+  discardDeadLetter: (id: string) =>
+    request<{ success: boolean; message: string }>(`/dead-letters/${id}/skip`, {
       method: "POST",
     }),
 };


### PR DESCRIPTION
Changes Summary

DeadLetterTab Component (DeadLetterTab.tsx)

Displays failed webhook deliveries in a table with event type, failure reason, attempt count, and last attempt timestamp
Implements Retry and Discard action buttons per entry
Shows empty state when no failures exist
Tabs UI Component (Tabs.tsx)

New reusable tab interface with context-based state management
Supports badge counts on tab triggers
Accessible with proper ARIA attributes
API Extensions (webhookApi.ts)

Added DeadLetterEntry interface
New methods: getDeadLetters(), retryDeadLetter(), discardDeadLetter()
WebhookSubscriptionList Integration (WebhookSubscriptionList.tsx)

Replaced single delivery logs modal with tabbed interface
Dead Letters tab shows with count badge
Fetches dead-letter counts on subscription load
Tests

DeadLetterTab.test.tsx: 11 tests covering render, actions, error states
Tabs.test.tsx: 9 tests for tab switching, badges, context validation
Result: Operators now see dead-letter entries directly in the webhook manager with actionable retry/discard controls.

Closes #1395


