### PR TITLE
feat(frontend): configurable time-range selector and granularity toggle for token analytics

### DIFF
--- a/frontend/src/components/TokenAnalytics/GranularityToggle.tsx
+++ b/frontend/src/components/TokenAnalytics/GranularityToggle.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Button } from '../UI/Button';
+
+export type Granularity = 'hourly' | 'daily' | 'weekly';
+
+interface GranularityToggleProps {
+  value: Granularity;
+  onChange: (granularity: Granularity) => void;
+  className?: string;
+}
+
+const OPTIONS: Array<{ label: string; value: Granularity }> = [
+  { label: 'Hourly', value: 'hourly' },
+  { label: 'Daily', value: 'daily' },
+  { label: 'Weekly', value: 'weekly' },
+];
+
+export function GranularityToggle({ value, onChange, className = '' }: GranularityToggleProps) {
+  return (
+    <div className={`p-4 bg-gray-50 rounded-lg border border-gray-200 ${className}`}>
+      <p className="text-sm font-medium text-gray-700 mb-2">Granularity</p>
+      <div className="flex gap-2">
+        {OPTIONS.map((option) => (
+          <Button
+            key={option.value}
+            size="sm"
+            variant={value === option.value ? 'primary' : 'outline'}
+            onClick={() => onChange(option.value)}
+            className="text-xs"
+          >
+            {option.label}
+          </Button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/TokenAnalytics/TimeRangeSelector.tsx
+++ b/frontend/src/components/TokenAnalytics/TimeRangeSelector.tsx
@@ -1,0 +1,157 @@
+import React, { useEffect, useState } from 'react';
+import { Input } from '../UI/Input';
+import { Button } from '../UI/Button';
+
+export type TimeRangePreset = '24h' | '7d' | '30d' | '90d' | 'all-time' | 'custom';
+
+export interface TimeRange {
+  preset: TimeRangePreset;
+  startDate?: string; // ISO date YYYY-MM-DD
+  endDate?: string;   // ISO date YYYY-MM-DD
+}
+
+interface TimeRangeSelectorProps {
+  value: TimeRange;
+  onChange: (range: TimeRange) => void;
+  className?: string;
+}
+
+const PRESETS: Array<{ label: string; value: TimeRangePreset }> = [
+  { label: 'Last 24h', value: '24h' },
+  { label: 'Last 7d', value: '7d' },
+  { label: 'Last 30d', value: '30d' },
+  { label: 'Last 90d', value: '90d' },
+  { label: 'All Time', value: 'all-time' },
+];
+
+function getDateRangeFromPreset(preset: TimeRangePreset): { start?: Date; end?: Date } {
+  const today = new Date();
+  today.setUTCHours(0, 0, 0, 0);
+  const end = new Date(today);
+
+  switch (preset) {
+    case '24h': {
+      const start = new Date(end);
+      start.setDate(start.getDate() - 1);
+      return { start, end };
+    }
+    case '7d': {
+      const start = new Date(end);
+      start.setDate(start.getDate() - 7);
+      return { start, end };
+    }
+    case '30d': {
+      const start = new Date(end);
+      start.setDate(start.getDate() - 30);
+      return { start, end };
+    }
+    case '90d': {
+      const start = new Date(end);
+      start.setDate(start.getDate() - 90);
+      return { start, end };
+    }
+    case 'all-time':
+      return { end };
+    case 'custom':
+      return {};
+  }
+}
+
+function dateToString(date: Date): string {
+  return date.toISOString().split('T')[0];
+}
+
+export function TimeRangeSelector({ value, onChange, className = '' }: TimeRangeSelectorProps) {
+  const [showCustom, setShowCustom] = useState(value.preset === 'custom');
+  const [customStart, setCustomStart] = useState(value.startDate || dateToString(new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)));
+  const [customEnd, setCustomEnd] = useState(value.endDate || dateToString(new Date()));
+
+  const handlePresetClick = (preset: TimeRangePreset) => {
+    setShowCustom(false);
+    onChange({ preset });
+  };
+
+  const handleCustomApply = () => {
+    if (customStart && customEnd) {
+      if (new Date(customStart) > new Date(customEnd)) {
+        alert('Start date must be before end date');
+        return;
+      }
+      onChange({
+        preset: 'custom',
+        startDate: customStart,
+        endDate: customEnd,
+      });
+      setShowCustom(false);
+    }
+  };
+
+  const isPresetActive = (preset: TimeRangePreset) => value.preset === preset;
+
+  return (
+    <div className={`space-y-4 p-4 bg-gray-50 rounded-lg border border-gray-200 ${className}`}>
+      <div>
+        <p className="text-sm font-medium text-gray-700 mb-2">Time Range</p>
+        <div className="flex flex-wrap gap-2">
+          {PRESETS.map((preset) => (
+            <Button
+              key={preset.value}
+              size="sm"
+              variant={isPresetActive(preset.value) ? 'primary' : 'outline'}
+              onClick={() => handlePresetClick(preset.value)}
+              className="text-xs"
+            >
+              {preset.label}
+            </Button>
+          ))}
+          <Button
+            size="sm"
+            variant={value.preset === 'custom' ? 'primary' : 'outline'}
+            onClick={() => setShowCustom(!showCustom)}
+            className="text-xs"
+          >
+            Custom
+          </Button>
+        </div>
+      </div>
+
+      {showCustom && (
+        <div className="pt-2 border-t border-gray-200 space-y-3">
+          <div className="grid grid-cols-2 gap-2">
+            <Input
+              type="date"
+              label="Start Date"
+              value={customStart}
+              onChange={(e) => setCustomStart(e.target.value)}
+              max={customEnd}
+            />
+            <Input
+              type="date"
+              label="End Date"
+              value={customEnd}
+              onChange={(e) => setCustomEnd(e.target.value)}
+              min={customStart}
+              max={dateToString(new Date())}
+            />
+          </div>
+          <div className="flex gap-2">
+            <Button size="sm" variant="primary" onClick={handleCustomApply}>
+              Apply
+            </Button>
+            <Button size="sm" variant="outline" onClick={() => setShowCustom(false)}>
+              Cancel
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {value.preset !== 'custom' && (
+        <p className="text-xs text-gray-500">
+          {value.preset === 'all-time'
+            ? 'Showing all available data'
+            : `Preset: ${PRESETS.find((p) => p.value === value.preset)?.label}`}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/TokenAnalytics/__tests__/GranularityToggle.test.tsx
+++ b/frontend/src/components/TokenAnalytics/__tests__/GranularityToggle.test.tsx
@@ -1,0 +1,139 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import { GranularityToggle } from '../GranularityToggle';
+
+describe('GranularityToggle', () => {
+  it('should render all granularity options', () => {
+    const handleChange = vi.fn();
+    render(
+      <GranularityToggle
+        value="daily"
+        onChange={handleChange}
+      />
+    );
+
+    expect(screen.getByText('Hourly')).toBeInTheDocument();
+    expect(screen.getByText('Daily')).toBeInTheDocument();
+    expect(screen.getByText('Weekly')).toBeInTheDocument();
+  });
+
+  it('should highlight active granularity', () => {
+    const handleChange = vi.fn();
+    render(
+      <GranularityToggle
+        value="daily"
+        onChange={handleChange}
+      />
+    );
+
+    const dailyButton = screen.getByText('Daily').closest('button');
+    expect(dailyButton).toHaveClass('bg-blue-600');
+  });
+
+  it('should call onChange when granularity is clicked', async () => {
+    const handleChange = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <GranularityToggle
+        value="daily"
+        onChange={handleChange}
+      />
+    );
+
+    await user.click(screen.getByText('Weekly'));
+    expect(handleChange).toHaveBeenCalledWith('weekly');
+  });
+
+  it('should switch between hourly and daily', async () => {
+    const handleChange = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <GranularityToggle
+        value="hourly"
+        onChange={handleChange}
+      />
+    );
+
+    const hourlyButton = screen.getByText('Hourly').closest('button');
+    expect(hourlyButton).toHaveClass('bg-blue-600');
+
+    await user.click(screen.getByText('Daily'));
+    expect(handleChange).toHaveBeenCalledWith('daily');
+  });
+
+  it('should switch between daily and weekly', async () => {
+    const handleChange = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <GranularityToggle
+        value="daily"
+        onChange={handleChange}
+      />
+    );
+
+    const dailyButton = screen.getByText('Daily').closest('button');
+    expect(dailyButton).toHaveClass('bg-blue-600');
+
+    await user.click(screen.getByText('Weekly'));
+    expect(handleChange).toHaveBeenCalledWith('weekly');
+  });
+
+  it('should switch between weekly and hourly', async () => {
+    const handleChange = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <GranularityToggle
+        value="weekly"
+        onChange={handleChange}
+      />
+    );
+
+    const weeklyButton = screen.getByText('Weekly').closest('button');
+    expect(weeklyButton).toHaveClass('bg-blue-600');
+
+    await user.click(screen.getByText('Hourly'));
+    expect(handleChange).toHaveBeenCalledWith('hourly');
+  });
+
+  it('should apply custom className', () => {
+    const handleChange = vi.fn();
+    const { container } = render(
+      <GranularityToggle
+        value="daily"
+        onChange={handleChange}
+        className="custom-class"
+      />
+    );
+
+    const wrapper = container.querySelector('.custom-class');
+    expect(wrapper).toBeInTheDocument();
+  });
+
+  it('should maintain selection across re-renders', () => {
+    const handleChange = vi.fn();
+    const { rerender } = render(
+      <GranularityToggle
+        value="hourly"
+        onChange={handleChange}
+      />
+    );
+
+    let hourlyButton = screen.getByText('Hourly').closest('button');
+    expect(hourlyButton).toHaveClass('bg-blue-600');
+
+    rerender(
+      <GranularityToggle
+        value="hourly"
+        onChange={handleChange}
+      />
+    );
+
+    hourlyButton = screen.getByText('Hourly').closest('button');
+    expect(hourlyButton).toHaveClass('bg-blue-600');
+  });
+});

--- a/frontend/src/components/TokenAnalytics/__tests__/TimeRangeSelector.test.tsx
+++ b/frontend/src/components/TokenAnalytics/__tests__/TimeRangeSelector.test.tsx
@@ -1,0 +1,194 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import { TimeRangeSelector, type TimeRange } from '../TimeRangeSelector';
+
+describe('TimeRangeSelector', () => {
+  it('should render preset buttons', () => {
+    const handleChange = vi.fn();
+    render(
+      <TimeRangeSelector
+        value={{ preset: '7d' }}
+        onChange={handleChange}
+      />
+    );
+
+    expect(screen.getByText('Last 24h')).toBeInTheDocument();
+    expect(screen.getByText('Last 7d')).toBeInTheDocument();
+    expect(screen.getByText('Last 30d')).toBeInTheDocument();
+    expect(screen.getByText('Last 90d')).toBeInTheDocument();
+    expect(screen.getByText('All Time')).toBeInTheDocument();
+    expect(screen.getByText('Custom')).toBeInTheDocument();
+  });
+
+  it('should highlight active preset', () => {
+    const handleChange = vi.fn();
+    render(
+      <TimeRangeSelector
+        value={{ preset: '30d' }}
+        onChange={handleChange}
+      />
+    );
+
+    const button30d = screen.getByText('Last 30d').closest('button');
+    expect(button30d).toHaveClass('bg-blue-600');
+  });
+
+  it('should call onChange when preset is clicked', async () => {
+    const handleChange = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <TimeRangeSelector
+        value={{ preset: '7d' }}
+        onChange={handleChange}
+      />
+    );
+
+    await user.click(screen.getByText('Last 90d'));
+    expect(handleChange).toHaveBeenCalledWith({ preset: '90d' });
+  });
+
+  it('should show custom date inputs when Custom is clicked', async () => {
+    const handleChange = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <TimeRangeSelector
+        value={{ preset: '7d' }}
+        onChange={handleChange}
+      />
+    );
+
+    await user.click(screen.getByText('Custom'));
+    await waitFor(() => {
+      expect(screen.getByLabelText('Start Date')).toBeInTheDocument();
+      expect(screen.getByLabelText('End Date')).toBeInTheDocument();
+    });
+  });
+
+  it('should allow custom date selection', async () => {
+    const handleChange = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <TimeRangeSelector
+        value={{ preset: '7d' }}
+        onChange={handleChange}
+      />
+    );
+
+    await user.click(screen.getByText('Custom'));
+
+    const startInput = screen.getByLabelText('Start Date') as HTMLInputElement;
+    const endInput = screen.getByLabelText('End Date') as HTMLInputElement;
+
+    await user.clear(startInput);
+    await user.type(startInput, '2024-01-01');
+
+    await user.clear(endInput);
+    await user.type(endInput, '2024-01-31');
+
+    await user.click(screen.getByText('Apply'));
+
+    expect(handleChange).toHaveBeenCalledWith({
+      preset: 'custom',
+      startDate: '2024-01-01',
+      endDate: '2024-01-31',
+    });
+  });
+
+  it('should validate that start date is before end date', async () => {
+    const handleChange = vi.fn();
+    const user = userEvent.setup();
+    const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
+
+    render(
+      <TimeRangeSelector
+        value={{ preset: '7d' }}
+        onChange={handleChange}
+      />
+    );
+
+    await user.click(screen.getByText('Custom'));
+
+    const startInput = screen.getByLabelText('Start Date') as HTMLInputElement;
+    const endInput = screen.getByLabelText('End Date') as HTMLInputElement;
+
+    await user.clear(startInput);
+    await user.type(startInput, '2024-01-31');
+
+    await user.clear(endInput);
+    await user.type(endInput, '2024-01-01');
+
+    await user.click(screen.getByText('Apply'));
+
+    expect(alertSpy).toHaveBeenCalledWith('Start date must be before end date');
+    expect(handleChange).not.toHaveBeenCalled();
+
+    alertSpy.mockRestore();
+  });
+
+  it('should cancel custom date selection', async () => {
+    const handleChange = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <TimeRangeSelector
+        value={{ preset: '7d' }}
+        onChange={handleChange}
+      />
+    );
+
+    await user.click(screen.getByText('Custom'));
+    await user.click(screen.getByText('Cancel'));
+
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+
+  it('should display preset label when not in custom mode', () => {
+    const handleChange = vi.fn();
+
+    render(
+      <TimeRangeSelector
+        value={{ preset: '30d' }}
+        onChange={handleChange}
+      />
+    );
+
+    expect(screen.getByText('Preset: Last 30d')).toBeInTheDocument();
+  });
+
+  it('should handle all-time preset', async () => {
+    const handleChange = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <TimeRangeSelector
+        value={{ preset: '7d' }}
+        onChange={handleChange}
+      />
+    );
+
+    await user.click(screen.getByText('All Time'));
+
+    expect(handleChange).toHaveBeenCalledWith({ preset: 'all-time' });
+  });
+
+  it('should restore custom values when switching back to custom', async () => {
+    const handleChange = vi.fn();
+    const user = userEvent.setup();
+
+    const { rerender } = render(
+      <TimeRangeSelector
+        value={{ preset: 'custom', startDate: '2024-01-01', endDate: '2024-01-31' }}
+        onChange={handleChange}
+      />
+    );
+
+    await user.click(screen.getByText('Custom'));
+
+    const startInput = screen.getByLabelText('Start Date') as HTMLInputElement;
+    expect(startInput.value).toBe('2024-01-01');
+  });
+});

--- a/frontend/src/hooks/__tests__/useTokenAnalytics.test.ts
+++ b/frontend/src/hooks/__tests__/useTokenAnalytics.test.ts
@@ -1,0 +1,213 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useTokenAnalytics } from '../useTokenAnalytics';
+import * as tokenAnalyticsApi from '../../services/tokenAnalyticsApi';
+import type { Granularity } from '../../components/TokenAnalytics/GranularityToggle';
+import type { TimeRange } from '../../components/TokenAnalytics/TimeRangeSelector';
+
+// Mock the API
+vi.mock('../../services/tokenAnalyticsApi');
+
+const mockStats = {
+  address: '0x123',
+  name: 'Test Token',
+  symbol: 'TEST',
+  decimals: 7,
+  totalSupply: '1000000000000000',
+  supplyHistory: [
+    { timestamp: 1000000, supply: '1000000000000000' },
+  ],
+  burnCount: 10,
+  totalBurned: '1000000000',
+  burnerCount: 5,
+  dailyBurnVolume: '100000000',
+  weeklyBurnVolume: '700000000',
+  monthlyBurnVolume: '3000000000',
+  burnTrend: 5,
+};
+
+const mockBurnRecords = [
+  {
+    id: '1',
+    timestamp: 1000000,
+    from: '0xabc',
+    amount: '1000000',
+    isAdminBurn: false,
+    txHash: '0xtx1',
+  },
+];
+
+describe('useTokenAnalytics', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (tokenAnalyticsApi.fetchTokenStats as any).mockResolvedValue(mockStats);
+    (tokenAnalyticsApi.fetchBurnRecords as any).mockResolvedValue(mockBurnRecords);
+  });
+
+  it('should fetch data on mount', async () => {
+    const { result } = renderHook(() => useTokenAnalytics('0x123'));
+
+    expect(result.current.loading).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.stats).toEqual(mockStats);
+    expect(result.current.burnRecords).toEqual(mockBurnRecords);
+  });
+
+  it('should pass time range to fetchBurnRecords when custom', async () => {
+    const timeRange: TimeRange = {
+      preset: 'custom',
+      startDate: '2024-01-01',
+      endDate: '2024-01-31',
+    };
+
+    renderHook(() => useTokenAnalytics('0x123', timeRange));
+
+    await waitFor(() => {
+      expect(tokenAnalyticsApi.fetchBurnRecords).toHaveBeenCalledWith(
+        '0x123',
+        expect.objectContaining({
+          startDate: '2024-01-01',
+          endDate: '2024-01-31',
+        })
+      );
+    });
+  });
+
+  it('should pass granularity to fetchBurnRecords', async () => {
+    const granularity: Granularity = 'hourly';
+
+    renderHook(() => useTokenAnalytics('0x123', undefined, granularity));
+
+    await waitFor(() => {
+      expect(tokenAnalyticsApi.fetchBurnRecords).toHaveBeenCalledWith(
+        '0x123',
+        expect.objectContaining({
+          granularity: 'hourly',
+        })
+      );
+    });
+  });
+
+  it('should pass both time range and granularity', async () => {
+    const timeRange: TimeRange = {
+      preset: 'custom',
+      startDate: '2024-01-01',
+      endDate: '2024-01-31',
+    };
+    const granularity: Granularity = 'weekly';
+
+    renderHook(() => useTokenAnalytics('0x123', timeRange, granularity));
+
+    await waitFor(() => {
+      expect(tokenAnalyticsApi.fetchBurnRecords).toHaveBeenCalledWith(
+        '0x123',
+        expect.objectContaining({
+          startDate: '2024-01-01',
+          endDate: '2024-01-31',
+          granularity: 'weekly',
+        })
+      );
+    });
+  });
+
+  it('should not pass dates for preset ranges', async () => {
+    const timeRange: TimeRange = { preset: '7d' };
+
+    renderHook(() => useTokenAnalytics('0x123', timeRange));
+
+    await waitFor(() => {
+      expect(tokenAnalyticsApi.fetchBurnRecords).toHaveBeenCalledWith(
+        '0x123',
+        expect.not.objectContaining({
+          startDate: expect.anything(),
+          endDate: expect.anything(),
+        })
+      );
+    });
+  });
+
+  it('should update when time range changes', async () => {
+    const { rerender } = renderHook(
+      ({ timeRange }: { timeRange: TimeRange }) =>
+        useTokenAnalytics('0x123', timeRange),
+      {
+        initialProps: { timeRange: { preset: '7d' } },
+      }
+    );
+
+    await waitFor(() => {
+      expect(tokenAnalyticsApi.fetchBurnRecords).toHaveBeenCalled();
+    });
+
+    const callCount = (tokenAnalyticsApi.fetchBurnRecords as any).mock.calls.length;
+
+    rerender({
+      timeRange: {
+        preset: 'custom',
+        startDate: '2024-01-01',
+        endDate: '2024-01-31',
+      },
+    });
+
+    await waitFor(() => {
+      expect((tokenAnalyticsApi.fetchBurnRecords as any).mock.calls.length).toBeGreaterThan(callCount);
+    });
+  });
+
+  it('should update when granularity changes', async () => {
+    const { rerender } = renderHook(
+      ({ granularity }: { granularity: Granularity }) =>
+        useTokenAnalytics('0x123', undefined, granularity),
+      {
+        initialProps: { granularity: 'daily' as Granularity },
+      }
+    );
+
+    await waitFor(() => {
+      expect(tokenAnalyticsApi.fetchBurnRecords).toHaveBeenCalled();
+    });
+
+    const callCount = (tokenAnalyticsApi.fetchBurnRecords as any).mock.calls.length;
+
+    rerender({ granularity: 'hourly' as Granularity });
+
+    await waitFor(() => {
+      expect((tokenAnalyticsApi.fetchBurnRecords as any).mock.calls.length).toBeGreaterThan(callCount);
+    });
+  });
+
+  it('should handle fetch error', async () => {
+    const error = new Error('Fetch failed');
+    (tokenAnalyticsApi.fetchTokenStats as any).mockRejectedValue(error);
+
+    const { result } = renderHook(() => useTokenAnalytics('0x123'));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.error).toBe('Fetch failed');
+  });
+
+  it('should provide refresh function', async () => {
+    const { result } = renderHook(() => useTokenAnalytics('0x123'));
+
+    await waitFor(() => {
+      expect(result.current.stats).not.toBeNull();
+    });
+
+    const initialCallCount = (tokenAnalyticsApi.fetchTokenStats as any).mock.calls.length;
+
+    result.current.refresh();
+
+    await waitFor(() => {
+      expect((tokenAnalyticsApi.fetchTokenStats as any).mock.calls.length).toBeGreaterThan(
+        initialCallCount
+      );
+    });
+  });
+});

--- a/frontend/src/hooks/useTokenAnalytics.ts
+++ b/frontend/src/hooks/useTokenAnalytics.ts
@@ -3,6 +3,8 @@ import { fetchTokenStats, fetchBurnRecords } from '../services/tokenAnalyticsApi
 import { groupBurnsByDay, normaliseSupplyHistory } from '../utils/analyticsTransforms';
 import type { TokenStats, BurnRecord } from '../services/tokenAnalyticsApi';
 import type { DailyBurnPoint, SupplyPoint } from '../utils/analyticsTransforms';
+import type { Granularity } from '../components/TokenAnalytics/GranularityToggle';
+import type { TimeRange } from '../components/TokenAnalytics/TimeRangeSelector';
 
 export interface TokenAnalyticsData {
   stats: TokenStats | null;
@@ -18,7 +20,11 @@ export interface TokenAnalyticsData {
  * Fetch token stats (REST) and burn records (GraphQL) in parallel and return
  * a unified, chart-ready data shape.
  */
-export function useTokenAnalytics(address: string): TokenAnalyticsData {
+export function useTokenAnalytics(
+  address: string,
+  timeRange?: TimeRange,
+  granularity?: Granularity
+): TokenAnalyticsData {
   const [stats, setStats] = useState<TokenStats | null>(null);
   const [burnRecords, setBurnRecords] = useState<BurnRecord[]>([]);
   const [loading, setLoading] = useState(true);
@@ -32,24 +38,39 @@ export function useTokenAnalytics(address: string): TokenAnalyticsData {
     setLoading(true);
     setError(null);
 
-    Promise.all([fetchTokenStats(address), fetchBurnRecords(address)])
-      .then(([s, records]) => {
+    const fetchRecords = async () => {
+      try {
+        const options: { startDate?: string; endDate?: string; granularity?: Granularity } = {};
+        if (timeRange?.preset === 'custom') {
+          options.startDate = timeRange.startDate;
+          options.endDate = timeRange.endDate;
+        }
+        if (granularity) {
+          options.granularity = granularity;
+        }
+
+        const [s, records] = await Promise.all([
+          fetchTokenStats(address),
+          fetchBurnRecords(address, options),
+        ]);
+
         if (cancelled) return;
         setStats(s);
         setBurnRecords(records);
-      })
-      .catch((err: unknown) => {
+      } catch (err: unknown) {
         if (cancelled) return;
         setError(err instanceof Error ? err.message : 'Failed to load analytics');
-      })
-      .finally(() => {
+      } finally {
         if (!cancelled) setLoading(false);
-      });
+      }
+    };
+
+    fetchRecords();
 
     return () => {
       cancelled = true;
     };
-  }, [address, tick]);
+  }, [address, timeRange, granularity, tick]);
 
   const decimals = stats?.decimals ?? 7;
   const dailyBurns = groupBurnsByDay(burnRecords, decimals);

--- a/frontend/src/pages/TokenAnalyticsPage.tsx
+++ b/frontend/src/pages/TokenAnalyticsPage.tsx
@@ -1,4 +1,7 @@
+import { useState, useMemo } from 'react';
 import { useTokenAnalytics } from '../hooks/useTokenAnalytics';
+import { TimeRangeSelector, type TimeRange, type TimeRangePreset } from '../components/TokenAnalytics/TimeRangeSelector';
+import { GranularityToggle, type Granularity } from '../components/TokenAnalytics/GranularityToggle';
 import { SupplyChart, BurnRateChart, ActivityFeed } from '../components/TokenAnalytics';
 import { Spinner } from '../components/UI/Spinner';
 import { Button } from '../components/UI/Button';
@@ -20,9 +23,55 @@ function KpiCard({ label, value, sub }: { label: string; value: string; sub?: st
   );
 }
 
+function getQueryParams() {
+  const params = new URL(window.location).searchParams;
+  return {
+    timeRangePreset: (params.get('timeRange') as TimeRangePreset) || '7d',
+    timeRangeStart: params.get('startDate'),
+    timeRangeEnd: params.get('endDate'),
+    granularity: (params.get('granularity') as Granularity) || 'daily',
+  };
+}
+
+function updateQueryParams(timeRange: TimeRange, granularity: Granularity) {
+  const url = new URL(window.location);
+  
+  if (timeRange.preset === 'custom') {
+    url.searchParams.set('timeRange', 'custom');
+    if (timeRange.startDate) url.searchParams.set('startDate', timeRange.startDate);
+    if (timeRange.endDate) url.searchParams.set('endDate', timeRange.endDate);
+  } else {
+    url.searchParams.set('timeRange', timeRange.preset);
+    url.searchParams.delete('startDate');
+    url.searchParams.delete('endDate');
+  }
+  
+  url.searchParams.set('granularity', granularity);
+  window.history.replaceState(null, '', url.toString());
+}
+
 export default function TokenAnalyticsPage({ address }: Props) {
+  const query = useMemo(getQueryParams, []);
+  
+  const [timeRange, setTimeRange] = useState<TimeRange>({
+    preset: query.timeRangePreset,
+    startDate: query.timeRangeStart || undefined,
+    endDate: query.timeRangeEnd || undefined,
+  });
+  const [granularity, setGranularity] = useState<Granularity>(query.granularity);
+
   const { stats, burnRecords, dailyBurns, supplyHistory, loading, error, refresh } =
-    useTokenAnalytics(address);
+    useTokenAnalytics(address, timeRange, granularity);
+
+  const handleTimeRangeChange = (newTimeRange: TimeRange) => {
+    setTimeRange(newTimeRange);
+    updateQueryParams(newTimeRange, granularity);
+  };
+
+  const handleGranularityChange = (newGranularity: Granularity) => {
+    setGranularity(newGranularity);
+    updateQueryParams(timeRange, newGranularity);
+  };
 
   if (loading && !stats) {
     return (
@@ -52,7 +101,7 @@ export default function TokenAnalyticsPage({ address }: Props) {
   const symbol = stats?.symbol ?? '—';
 
   return (
-    <main className="max-w-5xl mx-auto px-4 sm:px-6 py-8 space-y-8">
+    <main className="max-w-7xl mx-auto px-4 sm:px-6 py-8 space-y-8">
       {/* Header */}
       <header className="flex flex-wrap items-start justify-between gap-4">
         <div>
@@ -67,6 +116,12 @@ export default function TokenAnalyticsPage({ address }: Props) {
           Refresh
         </Button>
       </header>
+
+      {/* Controls */}
+      <section aria-label="Analytics controls" className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <TimeRangeSelector value={timeRange} onChange={handleTimeRangeChange} />
+        <GranularityToggle value={granularity} onChange={handleGranularityChange} />
+      </section>
 
       {/* KPI cards */}
       <section

--- a/frontend/src/services/tokenAnalyticsApi.ts
+++ b/frontend/src/services/tokenAnalyticsApi.ts
@@ -6,6 +6,8 @@
  */
 
 import { apiClient } from './apiClient';
+import type { Granularity } from '../components/TokenAnalytics/GranularityToggle';
+import type { TimeRange } from '../components/TokenAnalytics/TimeRangeSelector';
 
 export interface TokenStats {
   address: string;
@@ -37,8 +39,8 @@ const GQL_ENDPOINT =
   (import.meta as any)?.env?.VITE_GRAPHQL_URL ?? '/api/graphql';
 
 const BURN_RECORDS_QUERY = `
-  query BurnRecords($address: String!) {
-    burnRecords(tokenAddress: $address) {
+  query BurnRecords($address: String!, $startTime: Int, $endTime: Int, $granularity: String) {
+    burnRecords(tokenAddress: $address, startTime: $startTime, endTime: $endTime, granularity: $granularity) {
       id
       timestamp
       from
@@ -53,10 +55,31 @@ export async function fetchTokenStats(address: string): Promise<TokenStats> {
   return apiClient.get<TokenStats>(`/api/tokens/${address}/stats`);
 }
 
-export async function fetchBurnRecords(address: string): Promise<BurnRecord[]> {
+interface BurnRecordsOptions {
+  startDate?: string; // ISO date YYYY-MM-DD
+  endDate?: string;
+  granularity?: Granularity;
+}
+
+export async function fetchBurnRecords(
+  address: string,
+  options?: BurnRecordsOptions
+): Promise<BurnRecord[]> {
+  const variables: Record<string, unknown> = { address };
+
+  if (options?.startDate) {
+    variables.startTime = Math.floor(new Date(options.startDate).getTime() / 1000);
+  }
+  if (options?.endDate) {
+    variables.endTime = Math.floor(new Date(options.endDate).getTime() / 1000);
+  }
+  if (options?.granularity) {
+    variables.granularity = options.granularity;
+  }
+
   const res = await apiClient.post<{ data: { burnRecords: BurnRecord[] } }>(
     GQL_ENDPOINT,
-    { query: BURN_RECORDS_QUERY, variables: { address } }
+    { query: BURN_RECORDS_QUERY, variables }
   );
   return res.data.burnRecords;
 }


### PR DESCRIPTION
- Add TimeRangeSelector component with presets (24h, 7d, 30d, 90d, all-time) and custom date range
- Add GranularityToggle component for hourly/daily/weekly selection
- Update useTokenAnalytics hook to accept timeRange and granularity parameters
- Extend fetchBurnRecords API to accept startDate, endDate, and granularity options
- Integrate selectors into TokenAnalyticsPage with URL query param persistence
- Selections are saved to URL (timeRange, startDate, endDate, granularity) for sharing
- Add comprehensive tests for TimeRangeSelector, GranularityToggle, and useTokenAnalytics

Closes #1396

