### PR TITLE
feat(jobs): dead-letter inspection API with manual retry and discard for failed async jobs

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -62,6 +62,10 @@
     {
       "name": "Webhooks",
       "description": "Webhook subscriptions and delivery"
+    },
+    {
+      "name": "Admin Jobs",
+      "description": "Dead-letter job inspection with manual retry and discard (admin only)"
     }
   ],
   "paths": {
@@ -1347,10 +1351,194 @@
           }
         }
       }
+    },
+    "/api/admin/jobs/failed": {
+      "get": {
+        "tags": ["Admin Jobs"],
+        "summary": "List failed (dead-letter) jobs",
+        "description": "Returns all jobs that have exhausted their retry budget. Supports filtering by job type, error message substring, and creation date range.",
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          {
+            "name": "jobType",
+            "in": "query",
+            "schema": { "type": "string" },
+            "description": "Filter by exact job type name"
+          },
+          {
+            "name": "errorCode",
+            "in": "query",
+            "schema": { "type": "string" },
+            "description": "Substring match against the job error message"
+          },
+          {
+            "name": "startDate",
+            "in": "query",
+            "schema": { "type": "string", "format": "date-time" },
+            "description": "Return only jobs created on or after this ISO 8601 timestamp"
+          },
+          {
+            "name": "endDate",
+            "in": "query",
+            "schema": { "type": "string", "format": "date-time" },
+            "description": "Return only jobs created on or before this ISO 8601 timestamp"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": { "type": "integer", "minimum": 1, "default": 50 },
+            "description": "Maximum number of jobs to return"
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "schema": { "type": "integer", "minimum": 0, "default": 0 },
+            "description": "Number of jobs to skip for pagination"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated list of failed jobs",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": { "type": "boolean" },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "jobs": {
+                          "type": "array",
+                          "items": { "$ref": "#/components/schemas/DeadLetterJob" }
+                        },
+                        "pagination": {
+                          "type": "object",
+                          "properties": {
+                            "total": { "type": "integer" },
+                            "limit": { "type": "integer" },
+                            "offset": { "type": "integer" },
+                            "hasMore": { "type": "boolean" }
+                          }
+                        }
+                      }
+                    },
+                    "timestamp": { "type": "string", "format": "date-time" }
+                  }
+                }
+              }
+            }
+          },
+          "400": { "description": "Invalid query parameters" },
+          "401": { "description": "Authentication required" },
+          "403": { "description": "Admin access required" }
+        }
+      }
+    },
+    "/api/admin/jobs/{id}/retry": {
+      "post": {
+        "tags": ["Admin Jobs"],
+        "summary": "Retry a dead-letter job",
+        "description": "Removes the job from the dead-letter list, resets its retry counter, and re-enqueues it with elevated priority.",
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "Job ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Job re-enqueued successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": { "type": "boolean" },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "job": { "$ref": "#/components/schemas/DeadLetterJob" }
+                      }
+                    },
+                    "timestamp": { "type": "string", "format": "date-time" }
+                  }
+                }
+              }
+            }
+          },
+          "401": { "description": "Authentication required" },
+          "403": { "description": "Admin access required" },
+          "404": { "description": "Job not found in dead-letter list" }
+        }
+      }
+    },
+    "/api/admin/jobs/{id}": {
+      "delete": {
+        "tags": ["Admin Jobs"],
+        "summary": "Discard a dead-letter job",
+        "description": "Permanently removes the job from the dead-letter list. This action is irreversible.",
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "Job ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Job discarded successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": { "type": "boolean" },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "discarded": { "type": "boolean" },
+                        "id": { "type": "string" }
+                      }
+                    },
+                    "timestamp": { "type": "string", "format": "date-time" }
+                  }
+                }
+              }
+            }
+          },
+          "401": { "description": "Authentication required" },
+          "403": { "description": "Admin access required" },
+          "404": { "description": "Job not found in dead-letter list" }
+        }
+      }
     }
   },
   "components": {
     "schemas": {
+      "DeadLetterJob": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string", "example": "job_lz4k2_x9abc" },
+          "type": { "type": "string", "example": "email.send" },
+          "payload": { "type": "object" },
+          "priority": { "type": "integer", "example": 0 },
+          "attempts": { "type": "integer", "example": 3 },
+          "maxRetries": { "type": "integer", "example": 3 },
+          "status": { "type": "string", "enum": ["dead"], "example": "dead" },
+          "createdAt": { "type": "string", "format": "date-time" },
+          "runAt": { "type": "string", "format": "date-time" },
+          "startedAt": { "type": "string", "format": "date-time" },
+          "error": { "type": "string", "example": "SMTP connection refused" }
+        }
+      },
       "ErrorResponse": {
         "type": "object",
         "properties": {

--- a/backend/src/routes/admin/index.ts
+++ b/backend/src/routes/admin/index.ts
@@ -5,6 +5,7 @@ import usersRouter from "./users";
 import auditRouter from "./audit";
 import operationalRouter from "./operational";
 import backupRouter from "./backup";
+import jobsRouter from "./jobs";
 
 const router = Router();
 
@@ -14,5 +15,6 @@ router.use("/users", usersRouter);
 router.use("/audit", auditRouter);
 router.use("/operational", operationalRouter);
 router.use("/backup", backupRouter);
+router.use("/jobs", jobsRouter);
 
 export default router;

--- a/backend/src/routes/admin/jobs.ts
+++ b/backend/src/routes/admin/jobs.ts
@@ -1,0 +1,150 @@
+/**
+ * Admin REST endpoints for dead-letter job inspection and management.
+ *
+ * GET    /api/admin/jobs/failed        – list failed jobs (filterable)
+ * POST   /api/admin/jobs/:id/retry     – re-enqueue a dead-letter job with high priority
+ * DELETE /api/admin/jobs/:id           – permanently discard a dead-letter job
+ *
+ * All routes require admin authentication.
+ */
+
+import { Router } from "express";
+import { z } from "zod";
+import { authenticateAdmin } from "../../middleware/auth";
+import { successResponse, errorResponse } from "../../utils/response";
+import { jobQueue } from "../../services/jobQueue";
+
+const router = Router();
+
+// ---------------------------------------------------------------------------
+// Validation schemas
+// ---------------------------------------------------------------------------
+
+const failedJobsQuerySchema = z.object({
+  jobType: z.string().optional(),
+  errorCode: z.string().optional(),
+  startDate: z.string().datetime().optional(),
+  endDate: z.string().datetime().optional(),
+  limit: z.string().regex(/^\d+$/).optional(),
+  offset: z.string().regex(/^\d+$/).optional(),
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/admin/jobs/failed
+// ---------------------------------------------------------------------------
+
+router.get("/failed", authenticateAdmin, (req, res) => {
+  try {
+    const query = failedJobsQuerySchema.parse(req.query);
+
+    const filters: {
+      jobType?: string;
+      errorCode?: string;
+      startDate?: Date;
+      endDate?: Date;
+    } = {};
+
+    if (query.jobType) filters.jobType = query.jobType;
+    if (query.errorCode) filters.errorCode = query.errorCode;
+    if (query.startDate) filters.startDate = new Date(query.startDate);
+    if (query.endDate) filters.endDate = new Date(query.endDate);
+
+    let jobs = jobQueue.failedJobs(filters);
+
+    const limit = query.limit ? parseInt(query.limit, 10) : 50;
+    const offset = query.offset ? parseInt(query.offset, 10) : 0;
+    const total = jobs.length;
+    jobs = jobs.slice(offset, offset + limit);
+
+    res.json(
+      successResponse({
+        jobs,
+        pagination: {
+          total,
+          limit,
+          offset,
+          hasMore: offset + limit < total,
+        },
+      })
+    );
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return res.status(400).json(
+        errorResponse({
+          code: "VALIDATION_ERROR",
+          message: "Invalid query parameters",
+          details: error.errors,
+        })
+      );
+    }
+    console.error("Error fetching failed jobs:", error);
+    res.status(500).json(
+      errorResponse({
+        code: "INTERNAL_SERVER_ERROR",
+        message: "Failed to fetch failed jobs",
+      })
+    );
+  }
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/admin/jobs/:id/retry
+// ---------------------------------------------------------------------------
+
+router.post("/:id/retry", authenticateAdmin, (req, res) => {
+  try {
+    const { id } = req.params;
+    const job = jobQueue.retryJob(id);
+
+    if (!job) {
+      return res.status(404).json(
+        errorResponse({
+          code: "JOB_NOT_FOUND",
+          message: `No dead-letter job found with id "${id}"`,
+        })
+      );
+    }
+
+    res.json(successResponse({ job }));
+  } catch (error) {
+    console.error("Error retrying job:", error);
+    res.status(500).json(
+      errorResponse({
+        code: "INTERNAL_SERVER_ERROR",
+        message: "Failed to retry job",
+      })
+    );
+  }
+});
+
+// ---------------------------------------------------------------------------
+// DELETE /api/admin/jobs/:id
+// ---------------------------------------------------------------------------
+
+router.delete("/:id", authenticateAdmin, (req, res) => {
+  try {
+    const { id } = req.params;
+    const discarded = jobQueue.discardJob(id);
+
+    if (!discarded) {
+      return res.status(404).json(
+        errorResponse({
+          code: "JOB_NOT_FOUND",
+          message: `No dead-letter job found with id "${id}"`,
+        })
+      );
+    }
+
+    res.json(successResponse({ discarded: true, id }));
+  } catch (error) {
+    console.error("Error discarding job:", error);
+    res.status(500).json(
+      errorResponse({
+        code: "INTERNAL_SERVER_ERROR",
+        message: "Failed to discard job",
+      })
+    );
+  }
+});
+
+export default router;

--- a/backend/src/services/jobQueue.test.ts
+++ b/backend/src/services/jobQueue.test.ts
@@ -311,4 +311,191 @@ describe("JobQueue", () => {
       expect(() => q.enqueue("size.ok", payload)).not.toThrow();
     });
   });
+
+  // ── failedJobs ────────────────────────────────────────────────────────────
+
+  describe("failedJobs", () => {
+    async function seedDeadJob(type: string, errorMsg = "boom"): Promise<void> {
+      q.register(type, async () => { throw new Error(errorMsg); });
+      q.enqueue(type, {}, { maxRetries: 1 });
+      await flush(20);   // attempt 1
+      await flush(600);  // attempt 2 (back-off ~500ms)
+      await flush(20);   // settle
+    }
+
+    it("returns all dead-letter jobs when no filters given", async () => {
+      await seedDeadJob("fj.all");
+      const jobs = q.failedJobs();
+      expect(jobs.length).toBeGreaterThanOrEqual(1);
+      expect(jobs.every((j) => j.status === "dead")).toBe(true);
+    }, 5_000);
+
+    it("filters by jobType", async () => {
+      await seedDeadJob("fj.type.a");
+      await seedDeadJob("fj.type.b");
+
+      const jobs = q.failedJobs({ jobType: "fj.type.a" });
+      expect(jobs.length).toBeGreaterThanOrEqual(1);
+      expect(jobs.every((j) => j.type === "fj.type.a")).toBe(true);
+    }, 10_000);
+
+    it("filters by errorCode substring", async () => {
+      await seedDeadJob("fj.err.match", "unique-error-xyz");
+      await seedDeadJob("fj.err.nomatch", "something-else");
+
+      const jobs = q.failedJobs({ errorCode: "unique-error-xyz" });
+      expect(jobs.length).toBeGreaterThanOrEqual(1);
+      expect(jobs.every((j) => j.error?.includes("unique-error-xyz"))).toBe(true);
+    }, 10_000);
+
+    it("filters by startDate", async () => {
+      const before = new Date();
+      await seedDeadJob("fj.date.start");
+      const after = new Date();
+
+      const withStart = q.failedJobs({ startDate: before });
+      const withFuture = q.failedJobs({ startDate: after });
+
+      expect(withStart.some((j) => j.type === "fj.date.start")).toBe(true);
+      expect(withFuture.some((j) => j.type === "fj.date.start")).toBe(false);
+    }, 5_000);
+
+    it("filters by endDate", async () => {
+      await seedDeadJob("fj.date.end");
+      const now = new Date();
+      const past = new Date(Date.now() - 60_000);
+
+      const withinRange = q.failedJobs({ endDate: now });
+      const beforeRange = q.failedJobs({ endDate: past });
+
+      expect(withinRange.some((j) => j.type === "fj.date.end")).toBe(true);
+      expect(beforeRange.some((j) => j.type === "fj.date.end")).toBe(false);
+    }, 5_000);
+
+    it("returns empty array when no jobs match filters", async () => {
+      const jobs = q.failedJobs({ jobType: "nonexistent.type.xyz" });
+      expect(jobs).toEqual([]);
+    });
+  });
+
+  // ── retryJob ──────────────────────────────────────────────────────────────
+
+  describe("retryJob", () => {
+    it("returns null for unknown job id", () => {
+      expect(q.retryJob("nonexistent-id")).toBeNull();
+    });
+
+    it("removes the job from dead-letter and re-enqueues it", async () => {
+      let calls = 0;
+      q.register("retry.dl", async () => {
+        calls++;
+        if (calls === 1) throw new Error("fail first");
+        // succeed on retry
+      });
+
+      q.enqueue("retry.dl", {}, { maxRetries: 1 });
+      await flush(20);   // attempt 1 fails
+      await flush(600);  // attempt 2 fails → goes dead
+      await flush(20);
+
+      const dead = q.deadLetterJobs();
+      const deadJob = dead.find((j) => j.type === "retry.dl");
+      expect(deadJob).toBeDefined();
+
+      const requeued = q.retryJob(deadJob!.id);
+      expect(requeued).not.toBeNull();
+      expect(requeued!.status).toBe("pending");
+      expect(requeued!.attempts).toBe(0);
+
+      // No longer in dead-letter
+      expect(q.deadLetterJobs().find((j) => j.id === deadJob!.id)).toBeUndefined();
+    }, 5_000);
+
+    it("re-enqueued job eventually completes", async () => {
+      let calls = 0;
+      // Fail only on the first call; succeed on any subsequent call.
+      q.register("retry.complete", async () => {
+        calls++;
+        if (calls === 1) throw new Error("first call fails");
+        // calls >= 2: succeed
+      });
+
+      // maxRetries=1 means 1 attempt total before going dead (attempts >= maxRetries)
+      q.enqueue("retry.complete", {}, { maxRetries: 1 });
+      await flush(20);   // attempt 1 fails → dead (attempts === maxRetries)
+      await flush(20);   // settle
+
+      const deadJob = q.deadLetterJobs().find((j) => j.type === "retry.complete");
+      expect(deadJob).toBeDefined();
+
+      // Retry resets attempts to 0, so maxRetries=1 allows one fresh attempt
+      q.retryJob(deadJob!.id);
+      await flush(50);   // the re-queued job runs and succeeds
+
+      expect(calls).toBeGreaterThanOrEqual(2);
+      expect(q.deadLetterJobs().find((j) => j.id === deadJob!.id)).toBeUndefined();
+    }, 5_000);
+
+    it("elevates the job priority to at least 10", async () => {
+      q.register("retry.prio", async () => { throw new Error("fail"); });
+      q.enqueue("retry.prio", {}, { maxRetries: 1 });
+
+      await flush(20);
+      await flush(600);
+      await flush(20);
+
+      const deadJob = q.deadLetterJobs().find((j) => j.type === "retry.prio");
+      const requeued = q.retryJob(deadJob!.id);
+      expect(requeued!.priority).toBeGreaterThanOrEqual(10);
+    }, 5_000);
+  });
+
+  // ── discardJob ────────────────────────────────────────────────────────────
+
+  describe("discardJob", () => {
+    it("returns false for unknown job id", () => {
+      expect(q.discardJob("nonexistent-id")).toBe(false);
+    });
+
+    it("removes the job from dead-letter and returns true", async () => {
+      q.register("discard.dl", async () => { throw new Error("fail"); });
+      q.enqueue("discard.dl", {}, { maxRetries: 1 });
+
+      await flush(20);
+      await flush(600);
+      await flush(20);
+
+      const dead = q.deadLetterJobs();
+      const deadJob = dead.find((j) => j.type === "discard.dl");
+      expect(deadJob).toBeDefined();
+
+      const result = q.discardJob(deadJob!.id);
+      expect(result).toBe(true);
+      expect(q.deadLetterJobs().find((j) => j.id === deadJob!.id)).toBeUndefined();
+    }, 5_000);
+
+    it("does not affect other jobs in the dead-letter list", async () => {
+      q.register("discard.keep", async () => { throw new Error("fail"); });
+      q.register("discard.remove", async () => { throw new Error("fail"); });
+
+      q.enqueue("discard.keep", {}, { maxRetries: 1 });
+      q.enqueue("discard.remove", {}, { maxRetries: 1 });
+
+      await flush(20);
+      await flush(600);
+      await flush(20);
+
+      const before = q.deadLetterJobs();
+      const toRemove = before.find((j) => j.type === "discard.remove");
+      const toKeep = before.find((j) => j.type === "discard.keep");
+      expect(toRemove).toBeDefined();
+      expect(toKeep).toBeDefined();
+
+      q.discardJob(toRemove!.id);
+
+      const after = q.deadLetterJobs();
+      expect(after.find((j) => j.id === toRemove!.id)).toBeUndefined();
+      expect(after.find((j) => j.id === toKeep!.id)).toBeDefined();
+    }, 5_000);
+  });
 });

--- a/backend/src/services/jobQueue.ts
+++ b/backend/src/services/jobQueue.ts
@@ -204,6 +204,73 @@ export class JobQueue {
     return [...this.dead];
   }
 
+  /**
+   * Return failed (dead-letter) jobs with optional filters.
+   * Filters: jobType, errorCode (substring match on error message), startDate, endDate.
+   */
+  failedJobs(filters: {
+    jobType?: string;
+    errorCode?: string;
+    startDate?: Date;
+    endDate?: Date;
+  } = {}): Job[] {
+    let jobs = [...this.dead];
+
+    if (filters.jobType) {
+      jobs = jobs.filter((j) => j.type === filters.jobType);
+    }
+    if (filters.errorCode) {
+      const needle = filters.errorCode.toLowerCase();
+      jobs = jobs.filter((j) => j.error?.toLowerCase().includes(needle));
+    }
+    if (filters.startDate) {
+      jobs = jobs.filter((j) => j.createdAt >= filters.startDate!);
+    }
+    if (filters.endDate) {
+      jobs = jobs.filter((j) => j.createdAt <= filters.endDate!);
+    }
+
+    return jobs;
+  }
+
+  /**
+   * Re-enqueue a dead-letter job: reset its retry counter and enqueue with
+   * high priority so it runs as soon as a worker is free.
+   * Returns the job, or null if no dead-letter job with that id exists.
+   */
+  retryJob(id: string): Job | null {
+    const idx = this.dead.findIndex((j) => j.id === id);
+    if (idx === -1) return null;
+
+    const [job] = this.dead.splice(idx, 1);
+
+    // Reset state for fresh execution
+    job.attempts = 0;
+    job.status = "pending";
+    job.runAt = new Date();
+    job.error = undefined;
+    // Elevate priority so the retry runs before normal-priority work
+    job.priority = Math.max(job.priority, 10);
+
+    this.pending.push(job);
+    this.pending.sort((a, b) => b.priority - a.priority);
+
+    this.updateMetrics();
+    this.scheduleTick();
+    return job;
+  }
+
+  /**
+   * Permanently discard a job from the dead-letter list.
+   * Returns true if the job was found and removed, false otherwise.
+   */
+  discardJob(id: string): boolean {
+    const idx = this.dead.findIndex((j) => j.id === id);
+    if (idx === -1) return false;
+    this.dead.splice(idx, 1);
+    return true;
+  }
+
   /** Number of currently active workers. */
   get workerCount(): number {
     return this.activeWorkers;


### PR DESCRIPTION
## Summary
- Added failedJobs(), retryJob(id), discardJob(id) methods to jobQueue.ts
- New admin REST endpoints: GET /api/admin/jobs/failed (with filters), POST /api/admin/jobs/:id/retry, DELETE /api/admin/jobs/:id
- All endpoints require admin authentication
- Manual retry resets retry counter and re-enqueues with high priority
- Filter support: job type, error code, date range

## Test plan
- [ ] Integration tests cover list, retry, and discard operations
- [ ] Admin auth required — unauthorized requests rejected
- [ ] npx vitest run src/services/jobQueue.test.ts passes
- [ ] npm run lint passes

Closes #1356