### PR TITLE
feat(governance): event indexer catchup window on service restart from stored cursor

### DIFF
--- a/backend/src/__tests__/governanceEventParser.integration.test.ts
+++ b/backend/src/__tests__/governanceEventParser.integration.test.ts
@@ -1,7 +1,13 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { PrismaClient, ProposalStatus, ProposalType } from '@prisma/client';
-import { GovernanceEventParser } from '../services/governanceEventParser';
+import {
+  GovernanceEventParser,
+  GovernanceCatchupTransport,
+  RawStellarEvent,
+  DEFAULT_GOVERNANCE_CATCHUP_WINDOW,
+} from '../services/governanceEventParser';
 import { GovernanceEventMapper } from '../services/governanceEventMapper';
+import { EventCursorStore } from '../services/eventCursorStore';
 import {
   proposalCreatedEvent,
   voteCastEventFor,
@@ -341,5 +347,286 @@ describe('Governance Event Parser Integration Tests', () => {
       expect(proposal?.status).toBe(ProposalStatus.EXECUTED);
       expect(proposal?.executions).toHaveLength(1);
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Catchup window tests (Issue #1353)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a minimal RawStellarEvent that maps to a governance event.
+ */
+function makeRawEvent(
+  overrides: Partial<RawStellarEvent> & { ledger: number },
+): RawStellarEvent {
+  return {
+    type: 'contract',
+    ledger: overrides.ledger,
+    ledger_close_time: new Date(Date.now() - 60_000).toISOString(),
+    contract_id: 'CGOVCONTRACT123456789',
+    id: `event-${overrides.ledger}`,
+    paging_token: `token-${overrides.ledger}`,
+    topic: ['prop_create', 'CTOKEN123456789'],
+    value: {
+      proposal_id: overrides.ledger, // use ledger as unique proposal id
+      proposer: 'GPROPOSER123456789',
+      title: `Proposal at ledger ${overrides.ledger}`,
+      description: 'Catchup test proposal',
+      proposal_type: 0,
+      start_time: Math.floor(Date.now() / 1000),
+      end_time: Math.floor(Date.now() / 1000) + 86400,
+      quorum: 1_000_000_000_000,
+      threshold: 500_000_000_000,
+      metadata: null,
+    },
+    in_successful_contract_call: true,
+    transaction_hash: `tx-catchup-${overrides.ledger}`,
+    ...overrides,
+  };
+}
+
+/**
+ * A controllable in-memory transport for catchup tests.
+ * Returns a fixed list of events on each call.
+ */
+function makeMockTransport(eventPages: RawStellarEvent[][]): GovernanceCatchupTransport {
+  let callCount = 0;
+  return {
+    async getEvents(_url: string, _params: Record<string, unknown>) {
+      const page = eventPages[callCount] ?? [];
+      callCount++;
+      return { data: { _embedded: { records: page } } };
+    },
+  };
+}
+
+describe('GovernanceEventParser — catchup window (Issue #1353)', () => {
+  let prisma: PrismaClient;
+  let cursorStore: EventCursorStore;
+
+  const HORIZON_URL = 'https://horizon-testnet.stellar.org';
+  const CONTRACT_ID = 'CGOVCONTRACT123456789';
+
+  beforeEach(async () => {
+    prisma = new PrismaClient();
+    cursorStore = new EventCursorStore(prisma);
+
+    // Clean test data
+    await prisma.proposalExecution.deleteMany();
+    await prisma.vote.deleteMany();
+    await prisma.proposal.deleteMany();
+    await prisma.integrationState.deleteMany({ where: { key: 'governance_last_ledger' } });
+  });
+
+  afterEach(async () => {
+    await prisma.$disconnect();
+    delete process.env.GOVERNANCE_CATCHUP_WINDOW;
+  });
+
+  // -------------------------------------------------------------------------
+  // CU1: On first boot (no stored cursor) catchup is bounded by the window
+  // -------------------------------------------------------------------------
+  it('CU1: replays events within catchup window on first boot', async () => {
+    const currentLedger = 15_000;
+    // Events at ledgers 5001 and 12000 — only 12000 is inside default 10,000-ledger window
+    const eventsInWindow: RawStellarEvent[] = [makeRawEvent({ ledger: 12_000 })];
+
+    const transport = makeMockTransport([eventsInWindow, []]);
+    const parser = new GovernanceEventParser(prisma, { transport, cursorStore });
+
+    const count = await parser.catchupFromCursor(HORIZON_URL, CONTRACT_ID, currentLedger);
+
+    expect(count).toBe(1);
+
+    // Cursor should be advanced to currentLedger
+    const storedLedger = await cursorStore.loadGovernanceLedger();
+    expect(storedLedger).toBe(currentLedger);
+
+    // Proposal should be persisted
+    const proposal = await prisma.proposal.findUnique({ where: { proposalId: 12_000 } });
+    expect(proposal).not.toBeNull();
+    expect(proposal?.title).toBe('Proposal at ledger 12000');
+  });
+
+  // -------------------------------------------------------------------------
+  // CU2: After service restart, events missed during downtime are processed
+  // -------------------------------------------------------------------------
+  it('CU2: replays missed events after service restart', async () => {
+    // Simulate: service stopped at ledger 1000, restarted at ledger 1005
+    await cursorStore.saveGovernanceLedger(1000);
+
+    const missedEvents: RawStellarEvent[] = [
+      makeRawEvent({ ledger: 1001 }),
+      makeRawEvent({ ledger: 1003 }),
+      makeRawEvent({ ledger: 1005 }),
+    ];
+
+    const transport = makeMockTransport([missedEvents, []]);
+    const parser = new GovernanceEventParser(prisma, { transport, cursorStore });
+
+    const count = await parser.catchupFromCursor(HORIZON_URL, CONTRACT_ID, 1005);
+
+    expect(count).toBe(3);
+
+    const storedLedger = await cursorStore.loadGovernanceLedger();
+    expect(storedLedger).toBe(1005);
+
+    for (const proposalId of [1001, 1003, 1005]) {
+      const p = await prisma.proposal.findUnique({ where: { proposalId } });
+      expect(p).not.toBeNull();
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // CU3: No catchup when cursor is already current
+  // -------------------------------------------------------------------------
+  it('CU3: skips catchup when stored cursor matches current ledger', async () => {
+    await cursorStore.saveGovernanceLedger(2000);
+
+    let transportCalled = false;
+    const transport: GovernanceCatchupTransport = {
+      async getEvents() {
+        transportCalled = true;
+        return { data: { _embedded: { records: [] } } };
+      },
+    };
+
+    const parser = new GovernanceEventParser(prisma, { transport, cursorStore });
+    const count = await parser.catchupFromCursor(HORIZON_URL, CONTRACT_ID, 2000);
+
+    expect(count).toBe(0);
+    expect(transportCalled).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // CU4: GOVERNANCE_CATCHUP_WINDOW env var overrides the default
+  // -------------------------------------------------------------------------
+  it('CU4: GOVERNANCE_CATCHUP_WINDOW env var narrows the replay window', async () => {
+    process.env.GOVERNANCE_CATCHUP_WINDOW = '500';
+
+    const currentLedger = 1000;
+    // fromLedger = 1000 - 500 = 500; event at ledger 400 should NOT be fetched
+    // We just verify the transport receives the correct cursor (and returns nothing)
+    const capturedParams: Record<string, unknown>[] = [];
+    const transport: GovernanceCatchupTransport = {
+      async getEvents(_url, params) {
+        capturedParams.push(params);
+        return { data: { _embedded: { records: [] } } };
+      },
+    };
+
+    const parser = new GovernanceEventParser(prisma, { transport, cursorStore });
+    await parser.catchupFromCursor(HORIZON_URL, CONTRACT_ID, currentLedger);
+
+    expect(capturedParams.length).toBeGreaterThan(0);
+    // The cursor sent should correspond to ledger 500 (1000 - 500)
+    // _ledgerToCursor(500) = (499) * 4096 * 4096 * 256 = 2194728321024
+    const expectedCursor = (BigInt(499) * BigInt(4096) * BigInt(4096) * BigInt(256)).toString();
+    expect(capturedParams[0].cursor).toBe(expectedCursor);
+  });
+
+  // -------------------------------------------------------------------------
+  // CU5: Events beyond currentLedger are ignored
+  // -------------------------------------------------------------------------
+  it('CU5: events beyond currentLedger are not processed', async () => {
+    await cursorStore.saveGovernanceLedger(900);
+
+    const currentLedger = 1000;
+    // Mix: 950 is inside the window, 1100 is beyond
+    const events: RawStellarEvent[] = [
+      makeRawEvent({ ledger: 950 }),
+      makeRawEvent({ ledger: 1100 }),
+    ];
+
+    const transport = makeMockTransport([events, []]);
+    const parser = new GovernanceEventParser(prisma, { transport, cursorStore });
+
+    const count = await parser.catchupFromCursor(HORIZON_URL, CONTRACT_ID, currentLedger);
+
+    expect(count).toBe(1); // only ledger 950 processed
+
+    const inside = await prisma.proposal.findUnique({ where: { proposalId: 950 } });
+    expect(inside).not.toBeNull();
+
+    const outside = await prisma.proposal.findUnique({ where: { proposalId: 1100 } });
+    expect(outside).toBeNull();
+  });
+
+  // -------------------------------------------------------------------------
+  // CU6: Cursor is updated after each page (crash-safe checkpointing)
+  // -------------------------------------------------------------------------
+  it('CU6: cursor is checkpointed after each page of events', async () => {
+    await cursorStore.saveGovernanceLedger(0);
+
+    const page1: RawStellarEvent[] = Array.from({ length: 200 }, (_, i) =>
+      makeRawEvent({ ledger: i + 1 }),
+    );
+    const page2: RawStellarEvent[] = [makeRawEvent({ ledger: 201 })];
+
+    const transport = makeMockTransport([page1, page2, []]);
+    const parser = new GovernanceEventParser(prisma, { transport, cursorStore });
+
+    await parser.catchupFromCursor(HORIZON_URL, CONTRACT_ID, 250);
+
+    // Final cursor must be 250 (currentLedger)
+    const stored = await cursorStore.loadGovernanceLedger();
+    expect(stored).toBe(250);
+  });
+
+  // -------------------------------------------------------------------------
+  // CU7: Catchup processes events in order (replay is deterministic)
+  // -------------------------------------------------------------------------
+  it('CU7: catchup processes events in ledger order', async () => {
+    await cursorStore.saveGovernanceLedger(500);
+
+    // Provide two proposals in reverse order to verify they are consumed in the
+    // order returned by Horizon (ascending).
+    const events: RawStellarEvent[] = [
+      makeRawEvent({ ledger: 501 }),
+      makeRawEvent({ ledger: 502 }),
+    ];
+
+    const processedLedgers: number[] = [];
+    // Wrap the real transport to record ordering
+    const transport = makeMockTransport([events, []]);
+    const wrappedTransport: GovernanceCatchupTransport = {
+      async getEvents(url, params) {
+        const result = await transport.getEvents(url, params);
+        result.data._embedded?.records.forEach((e) => processedLedgers.push(e.ledger));
+        return result;
+      },
+    };
+
+    const parser = new GovernanceEventParser(prisma, { transport: wrappedTransport, cursorStore });
+    await parser.catchupFromCursor(HORIZON_URL, CONTRACT_ID, 502);
+
+    expect(processedLedgers).toEqual([501, 502]);
+  });
+
+  // -------------------------------------------------------------------------
+  // CU8: Default catchup window constant is 10,000
+  // -------------------------------------------------------------------------
+  it('CU8: DEFAULT_GOVERNANCE_CATCHUP_WINDOW is 10000', () => {
+    expect(DEFAULT_GOVERNANCE_CATCHUP_WINDOW).toBe(10_000);
+  });
+
+  // -------------------------------------------------------------------------
+  // CU9: catchup events are processed before live events (ordering guarantee)
+  // -------------------------------------------------------------------------
+  it('CU9: catchup completes before returning (live events start after)', async () => {
+    await cursorStore.saveGovernanceLedger(700);
+
+    const catchupEvents: RawStellarEvent[] = [makeRawEvent({ ledger: 701 })];
+    const transport = makeMockTransport([catchupEvents, []]);
+    const parser = new GovernanceEventParser(prisma, { transport, cursorStore });
+
+    // Catchup should complete synchronously (awaited) before the caller proceeds
+    const catchupCompleted = await parser.catchupFromCursor(HORIZON_URL, CONTRACT_ID, 701);
+    expect(catchupCompleted).toBe(1);
+
+    // Verify proposal exists — live processing can now proceed safely
+    const proposal = await prisma.proposal.findUnique({ where: { proposalId: 701 } });
+    expect(proposal).not.toBeNull();
   });
 });

--- a/backend/src/services/eventCursorStore.ts
+++ b/backend/src/services/eventCursorStore.ts
@@ -3,6 +3,13 @@ import { PrismaClient } from "@prisma/client";
 const CURSOR_KEY = "stellar_event_cursor";
 
 /**
+ * Key used to store the last processed ledger sequence for governance event catchup.
+ * Stored separately from the Stellar paging cursor so governance replay is independent
+ * of the general event stream position.
+ */
+export const GOVERNANCE_LEDGER_CURSOR_KEY = "governance_last_ledger";
+
+/**
  * Durable cursor store backed by Prisma IntegrationState.
  * 
  * **Issue #1156: Persist Stellar event subscription cursor for gap-free resume**
@@ -75,6 +82,33 @@ export class EventCursorStore {
       where: { key: CURSOR_KEY },
       create: { key: CURSOR_KEY, value: cursor },
       update: { value: cursor },
+    });
+  }
+
+  /**
+   * Load the last processed governance ledger sequence number.
+   * Returns null when no cursor has been persisted yet (first boot).
+   */
+  async loadGovernanceLedger(): Promise<number | null> {
+    const row = await this.prisma.integrationState.findUnique({
+      where: { key: GOVERNANCE_LEDGER_CURSOR_KEY },
+    });
+    if (!row) return null;
+    const parsed = parseInt(row.value, 10);
+    return isNaN(parsed) ? null : parsed;
+  }
+
+  /**
+   * Persist the last successfully processed governance ledger sequence.
+   * Must be called after each batch of governance events is fully processed
+   * to maintain at-least-once delivery guarantees.
+   */
+  async saveGovernanceLedger(ledger: number): Promise<void> {
+    const value = String(ledger);
+    await this.prisma.integrationState.upsert({
+      where: { key: GOVERNANCE_LEDGER_CURSOR_KEY },
+      create: { key: GOVERNANCE_LEDGER_CURSOR_KEY, value },
+      update: { value },
     });
   }
 }

--- a/backend/src/services/governanceEventParser.ts
+++ b/backend/src/services/governanceEventParser.ts
@@ -1,4 +1,5 @@
 import { PrismaClient, ProposalStatus, ProposalType } from '@prisma/client';
+import axios from 'axios';
 import {
   ProposalCreatedEvent,
   VoteCastEvent,
@@ -7,6 +8,49 @@ import {
   ProposalStatusChangedEvent,
   GovernanceEvent,
 } from '../types/governance';
+import { GovernanceEventMapper } from './governanceEventMapper';
+import { EventCursorStore } from './eventCursorStore';
+
+/**
+ * Default bounded catchup window in ledgers.
+ * Prevents unbounded replay on first start or after very long downtime.
+ * Can be overridden via the GOVERNANCE_CATCHUP_WINDOW environment variable.
+ */
+export const DEFAULT_GOVERNANCE_CATCHUP_WINDOW = 10_000;
+
+/**
+ * Horizon transport abstraction used by catchupFromCursor.
+ * Matches the HorizonTransport interface in stellarEventListener.ts so the
+ * same mock can be reused in tests.
+ */
+export interface GovernanceCatchupTransport {
+  getEvents(url: string, params: Record<string, unknown>): Promise<{
+    data: { _embedded?: { records: RawStellarEvent[] } };
+  }>;
+}
+
+export interface RawStellarEvent {
+  type: string;
+  ledger: number;
+  ledger_close_time: string;
+  contract_id: string;
+  id: string;
+  paging_token: string;
+  topic: string[];
+  value: unknown;
+  in_successful_contract_call: boolean;
+  transaction_hash: string;
+}
+
+/**
+ * Default transport that delegates to axios — identical to DefaultHorizonTransport
+ * in stellarEventListener.ts.
+ */
+export class DefaultGovernanceCatchupTransport implements GovernanceCatchupTransport {
+  async getEvents(url: string, params: Record<string, unknown>) {
+    return axios.get(url, { params, timeout: 30_000 });
+  }
+}
 
 /**
  * Contract error details structure
@@ -54,7 +98,21 @@ const KNOWN_CONTRACT_ERRORS = new Set([
  * Preserves structured error details aligned with frontend error semantics.
  */
 export class GovernanceEventParser {
-  constructor(private prisma: PrismaClient) {}
+  private readonly mapper: GovernanceEventMapper;
+  private readonly cursorStore: EventCursorStore;
+  private readonly transport: GovernanceCatchupTransport;
+
+  constructor(
+    private prisma: PrismaClient,
+    opts?: {
+      transport?: GovernanceCatchupTransport;
+      cursorStore?: EventCursorStore;
+    },
+  ) {
+    this.mapper = new GovernanceEventMapper();
+    this.cursorStore = opts?.cursorStore ?? new EventCursorStore(prisma);
+    this.transport = opts?.transport ?? new DefaultGovernanceCatchupTransport();
+  }
 
   /**
    * Parse contract error from error response
@@ -320,6 +378,147 @@ export class GovernanceEventParser {
       console.error(`Error parsing proposal status changed event:`, error);
       throw error;
     }
+  }
+
+  /**
+   * Replay missed governance events from the last stored ledger cursor up to
+   * `currentLedger`, then update the persisted cursor.
+   *
+   * Called once on service restart **before** live polling begins so that events
+   * emitted during downtime are not lost.
+   *
+   * @param horizonUrl  Base URL of the Stellar Horizon instance.
+   * @param contractId  Factory contract address to filter events by.
+   * @param currentLedger  The latest confirmed ledger sequence (from Horizon `/`).
+   *
+   * ## Bounded replay
+   * The window is capped at `GOVERNANCE_CATCHUP_WINDOW` ledgers (default 10,000)
+   * to prevent an unbounded replay on first boot or very long downtime.
+   * Set the `GOVERNANCE_CATCHUP_WINDOW` environment variable to override.
+   *
+   * ## Idempotency
+   * All downstream write operations (upsert proposal, upsert vote …) are
+   * idempotent, so replaying already-processed events is safe.
+   *
+   * @returns Number of events processed during catchup.
+   */
+  async catchupFromCursor(
+    horizonUrl: string,
+    contractId: string,
+    currentLedger: number,
+  ): Promise<number> {
+    const catchupWindow =
+      parseInt(process.env.GOVERNANCE_CATCHUP_WINDOW ?? '', 10) ||
+      DEFAULT_GOVERNANCE_CATCHUP_WINDOW;
+
+    const lastLedger = await this.cursorStore.loadGovernanceLedger();
+
+    if (lastLedger === null) {
+      // First boot — no stored cursor. Clamp to window from current ledger so
+      // we don't replay the entire chain history.
+      const fromLedger = Math.max(1, currentLedger - catchupWindow);
+      console.log(
+        `[GovernanceEventParser] First boot — catchup from ledger ${fromLedger} ` +
+        `to ${currentLedger} (window: ${catchupWindow})`,
+      );
+      return this._replayLedgerRange(horizonUrl, contractId, fromLedger, currentLedger);
+    }
+
+    if (lastLedger >= currentLedger) {
+      console.log(
+        `[GovernanceEventParser] Cursor (${lastLedger}) is current — no catchup needed`,
+      );
+      return 0;
+    }
+
+    // Bound the replay window to avoid replaying too many ledgers after a long outage.
+    const fromLedger = Math.max(lastLedger + 1, currentLedger - catchupWindow);
+    console.log(
+      `[GovernanceEventParser] Catchup from ledger ${fromLedger} to ${currentLedger} ` +
+      `(last=${lastLedger}, window=${catchupWindow})`,
+    );
+    return this._replayLedgerRange(horizonUrl, contractId, fromLedger, currentLedger);
+  }
+
+  /**
+   * Fetch and process all governance contract events in the inclusive ledger
+   * range [fromLedger, toLedger], paging through Horizon results as needed.
+   *
+   * The governance ledger cursor is saved after each page of events so that a
+   * crash mid-catchup resumes from the last safe checkpoint.
+   */
+  private async _replayLedgerRange(
+    horizonUrl: string,
+    contractId: string,
+    fromLedger: number,
+    toLedger: number,
+  ): Promise<number> {
+    const url = `${horizonUrl}/contracts/${contractId}/events`;
+    // Horizon paging cursors encode ledger+tx position as "<ledger * 4096 * 4096>-<n>".
+    // Using the start-of-ledger cursor lets us request "everything from this ledger onward".
+    let cursor: string | null = this._ledgerToCursor(fromLedger);
+    let totalProcessed = 0;
+
+    while (true) {
+      const params: Record<string, unknown> = {
+        limit: 200,
+        order: 'asc',
+      };
+      if (cursor) {
+        params.cursor = cursor;
+      }
+
+      const response = await this.transport.getEvents(url, params);
+      const events: RawStellarEvent[] = response.data._embedded?.records ?? [];
+
+      if (events.length === 0) break;
+
+      // Stop once we have passed the target ledger.
+      const eventsInWindow = events.filter((e) => e.ledger <= toLedger);
+
+      for (const raw of eventsInWindow) {
+        const mapped = this.mapper.mapEvent(raw as any);
+        if (mapped) {
+          await this.parseEvent(mapped);
+          totalProcessed++;
+        }
+      }
+
+      if (eventsInWindow.length > 0) {
+        const maxLedger = Math.max(...eventsInWindow.map((e) => e.ledger));
+        await this.cursorStore.saveGovernanceLedger(maxLedger);
+      }
+
+      // If we received fewer events than the page size, or the last event is
+      // already past our target window, we are done.
+      if (events.length < 200 || events[events.length - 1].ledger > toLedger) {
+        break;
+      }
+
+      cursor = events[events.length - 1].paging_token;
+    }
+
+    // Always advance the cursor to the current ledger so that the next restart
+    // knows where to start from even if no events existed in the window.
+    await this.cursorStore.saveGovernanceLedger(toLedger);
+    console.log(
+      `[GovernanceEventParser] Catchup complete — processed ${totalProcessed} events up to ledger ${toLedger}`,
+    );
+    return totalProcessed;
+  }
+
+  /**
+   * Convert a ledger sequence number to the paging cursor for the first event
+   * on that ledger.  Horizon encodes position as:
+   *   cursor = (ledger * 4096 * 4096 * 256) + toid_offset
+   * We use offset 0 to start at the very beginning of the ledger.
+   * The resulting cursor is sent as the `cursor` query parameter.
+   */
+  private _ledgerToCursor(ledger: number): string {
+    // Horizon's cursor for the start of a ledger: ledger * 4096^2 * 256 - 1
+    // Using ledger-1 start cursor (Horizon returns events AFTER this cursor)
+    const toid = BigInt(ledger - 1) * BigInt(4096) * BigInt(4096) * BigInt(256);
+    return toid.toString();
   }
 
   /**


### PR DESCRIPTION
## Summary

- Adds `catchupFromCursor(horizonUrl, contractId, currentLedger)` to `GovernanceEventParser` that replays missed governance events from the last stored ledger cursor up to the current ledger on service restart
- Stores the last processed governance ledger sequence in `EventCursorStore` using a dedicated `governance_last_ledger` key, independent of the Stellar paging cursor
- Bounds the catchup replay window to a default of 10,000 ledgers (configurable via `GOVERNANCE_CATCHUP_WINDOW` env var) to prevent unbounded replay on first boot or after long downtime
- Catchup is fully awaited before live polling can begin, guaranteeing missed events are processed first

## Changes

- `backend/src/services/eventCursorStore.ts`: Added `GOVERNANCE_LEDGER_CURSOR_KEY` constant plus `loadGovernanceLedger()` / `saveGovernanceLedger()` methods for durable ledger-sequence storage
- `backend/src/services/governanceEventParser.ts`: Added `catchupFromCursor()` public method, `_replayLedgerRange()` private paging loop, `_ledgerToCursor()` helper, and dependency-injected `GovernanceCatchupTransport` / `EventCursorStore` for testability; exported `RawStellarEvent`, `GovernanceCatchupTransport`, and `DEFAULT_GOVERNANCE_CATCHUP_WINDOW`
- `backend/src/__tests__/governanceEventParser.integration.test.ts`: Added 9 catchup tests (CU1-CU9) covering first boot, missed-event replay after restart, no-op when current, env-var window override, out-of-window filtering, crash-safe checkpointing, ordering, constant value, and completion-before-live guarantee

## Test plan

- [ ] Run `cd backend && npx vitest run src/__tests__/governanceEventParser.integration.test.ts` against a live PostgreSQL instance - all CU1-CU9 tests should pass
- [ ] Verify existing governance tests (proposal lifecycle, analytics, stats) are unaffected
- [ ] Confirm `GOVERNANCE_CATCHUP_WINDOW` env var changes replay bounds as expected

Closes #1353