### PR TITLE
feat(campaigns): distributed lock idempotency for campaign execution step concurrency

### DIFF
--- a/backend/src/__tests__/campaignStepLock.concurrency.test.ts
+++ b/backend/src/__tests__/campaignStepLock.concurrency.test.ts
@@ -1,0 +1,314 @@
+/**
+ * Concurrency tests: Distributed lock idempotency for campaign execution steps.
+ *
+ * Scenarios:
+ *   L1  Second concurrent request returns 202 PROCESSING while first holds the lock
+ *   L2  First request completes successfully (200) when it holds the lock
+ *   L3  Lock is released after successful execution (third request can proceed)
+ *   L4  Lock is released after a failed execution (error path) — no lock leakage
+ *   L5  Redis unavailable → fail open, request proceeds without lock
+ *   L6  Multiple campaigns do not interfere with each other's locks
+ *
+ * The test mocks both Prisma and the lock module so no live Redis or DB is needed.
+ */
+
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+// ---------------------------------------------------------------------------
+// Hoist mock factories so they are available before module imports
+// ---------------------------------------------------------------------------
+const {
+  mockFindUnique,
+  mockStepUpdate,
+  mockCampaignUpdate,
+  mockAcquireStepLock,
+  mockReleaseStepLock,
+} = vi.hoisted(() => ({
+  mockFindUnique: vi.fn(),
+  mockStepUpdate: vi.fn(),
+  mockCampaignUpdate: vi.fn(),
+  mockAcquireStepLock: vi.fn(),
+  mockReleaseStepLock: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock PrismaClient
+// ---------------------------------------------------------------------------
+vi.mock('@prisma/client', () => ({
+  PrismaClient: vi.fn(() => ({
+    buybackCampaign: {
+      create: vi.fn(),
+      findMany: vi.fn().mockResolvedValue([]),
+      findUnique: mockFindUnique,
+      update: mockCampaignUpdate,
+      count: vi.fn().mockResolvedValue(0),
+    },
+    buybackStep: {
+      update: mockStepUpdate,
+    },
+  })),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock the lock module
+// ---------------------------------------------------------------------------
+vi.mock('../lib/lock', () => ({
+  acquireStepLock: (...args: unknown[]) => mockAcquireStepLock(...args),
+  releaseStepLock: (...args: unknown[]) => mockReleaseStepLock(...args),
+  STEP_LOCK_TTL_MS: 30_000,
+  stepLockKey: (campaignId: unknown, stepNumber: unknown) =>
+    `campaign_step_lock:${campaignId}:${stepNumber}`,
+}));
+
+// Mock the rateLimiter's createRedisClient so no real Redis connection is made
+vi.mock('../middleware/rateLimiter', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../middleware/rateLimiter')>();
+  return {
+    ...original,
+    createRedisClient: vi.fn(() => ({ /* mock redis client */ })),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// App setup (import AFTER mocks are registered)
+// ---------------------------------------------------------------------------
+import buybackRoutes from '../routes/buyback';
+
+const app = express();
+app.use(express.json());
+app.use('/api/buyback', buybackRoutes);
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeActiveCampaign(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    tokenAddress: 'CTOKEN123',
+    totalAmount: '10000',
+    executedAmount: '0',
+    currentStep: 0,
+    totalSteps: 3,
+    status: 'ACTIVE',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    steps: [
+      { id: 1, stepNumber: 0, amount: '2000', status: 'PENDING', executedAt: null, txHash: null },
+      { id: 2, stepNumber: 1, amount: '3000', status: 'PENDING', executedAt: null, txHash: null },
+      { id: 3, stepNumber: 2, amount: '5000', status: 'PENDING', executedAt: null, txHash: null },
+    ],
+    ...overrides,
+  };
+}
+
+function makeUpdatedStep(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    stepNumber: 0,
+    amount: '2000',
+    status: 'COMPLETED',
+    executedAt: new Date(),
+    txHash: 'tx-abc',
+    ...overrides,
+  };
+}
+
+function makeUpdatedCampaign(overrides: Record<string, unknown> = {}) {
+  return {
+    ...makeActiveCampaign(),
+    executedAmount: '2000',
+    currentStep: 1,
+    steps: [
+      { id: 1, stepNumber: 0, amount: '2000', status: 'COMPLETED', executedAt: new Date(), txHash: 'tx-abc' },
+      { id: 2, stepNumber: 1, amount: '3000', status: 'PENDING', executedAt: null, txHash: null },
+      { id: 3, stepNumber: 2, amount: '5000', status: 'PENDING', executedAt: null, txHash: null },
+    ],
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Campaign Step Distributed Lock — Concurrency', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockReleaseStepLock.mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ── L1: Concurrent second request returns 202 PROCESSING ─────────────────
+
+  it('L1: second concurrent request returns 202 with PROCESSING status while lock is held', async () => {
+    mockFindUnique.mockResolvedValue(makeActiveCampaign());
+
+    // First caller holds the lock
+    mockAcquireStepLock.mockResolvedValue({
+      acquired: false,
+      holderRequestId: 'req-holder-abc',
+    });
+
+    const res = await request(app)
+      .post('/api/buyback/campaigns/1/execute-step')
+      .send({ txHash: 'tx-attempt' })
+      .expect(202);
+
+    expect(res.body.status).toBe('PROCESSING');
+    expect(res.body.holderRequestId).toBe('req-holder-abc');
+
+    // DB writes must NOT have been called
+    expect(mockStepUpdate).not.toHaveBeenCalled();
+    expect(mockCampaignUpdate).not.toHaveBeenCalled();
+  });
+
+  // ── L2: First request succeeds (200) when lock is acquired ───────────────
+
+  it('L2: first request acquires the lock and executes the step successfully', async () => {
+    mockFindUnique.mockResolvedValue(makeActiveCampaign());
+    mockAcquireStepLock.mockResolvedValue({
+      acquired: true,
+      holderRequestId: 'req-owner-xyz',
+    });
+    mockStepUpdate.mockResolvedValue(makeUpdatedStep());
+    mockCampaignUpdate.mockResolvedValue(makeUpdatedCampaign());
+
+    const res = await request(app)
+      .post('/api/buyback/campaigns/1/execute-step')
+      .send({ txHash: 'tx-abc' })
+      .expect(200);
+
+    expect(res.body.campaign.currentStep).toBe(1);
+    expect(res.body.executedStep.status).toBe('COMPLETED');
+
+    // Lock must have been acquired and then released
+    expect(mockAcquireStepLock).toHaveBeenCalledTimes(1);
+    expect(mockReleaseStepLock).toHaveBeenCalledTimes(1);
+  });
+
+  // ── L3: Lock is released after successful execution ───────────────────────
+
+  it('L3: lock is released in finally block after successful execution', async () => {
+    const releaseOrder: string[] = [];
+
+    mockFindUnique.mockResolvedValue(makeActiveCampaign());
+    mockAcquireStepLock.mockResolvedValue({ acquired: true, holderRequestId: 'req-1' });
+    mockStepUpdate.mockImplementation(async () => {
+      releaseOrder.push('step-updated');
+      return makeUpdatedStep();
+    });
+    mockCampaignUpdate.mockImplementation(async () => {
+      releaseOrder.push('campaign-updated');
+      return makeUpdatedCampaign();
+    });
+    mockReleaseStepLock.mockImplementation(async () => {
+      releaseOrder.push('lock-released');
+      return true;
+    });
+
+    await request(app)
+      .post('/api/buyback/campaigns/1/execute-step')
+      .send({ txHash: 'tx-abc' })
+      .expect(200);
+
+    expect(releaseOrder).toEqual(['step-updated', 'campaign-updated', 'lock-released']);
+    expect(mockReleaseStepLock).toHaveBeenCalledWith(
+      expect.anything(),
+      1,          // campaignId
+      0,          // stepNumber (currentStep)
+      expect.any(String), // requestId (UUID generated per request)
+    );
+  });
+
+  // ── L4: Lock is released even when execution fails ────────────────────────
+
+  it('L4: lock is released in finally block even when DB update throws', async () => {
+    mockFindUnique.mockResolvedValue(makeActiveCampaign());
+    mockAcquireStepLock.mockResolvedValue({ acquired: true, holderRequestId: 'req-err' });
+    mockStepUpdate.mockRejectedValue(new Error('DB connection lost'));
+
+    const res = await request(app)
+      .post('/api/buyback/campaigns/1/execute-step')
+      .send({ txHash: 'tx-err' })
+      .expect(500);
+
+    expect(res.body.error).toBe('Failed to execute step');
+
+    // Lock must still be released despite the error
+    expect(mockReleaseStepLock).toHaveBeenCalledTimes(1);
+  });
+
+  // ── L5: Redis unavailable → fail open ────────────────────────────────────
+
+  it('L5: when Redis is unavailable the step executes without a lock (fail open)', async () => {
+    mockFindUnique.mockResolvedValue(makeActiveCampaign());
+
+    // Simulate Redis error on lock acquisition
+    mockAcquireStepLock.mockRejectedValue(new Error('Redis connection refused'));
+    mockStepUpdate.mockResolvedValue(makeUpdatedStep());
+    mockCampaignUpdate.mockResolvedValue(makeUpdatedCampaign());
+
+    const res = await request(app)
+      .post('/api/buyback/campaigns/1/execute-step')
+      .send({ txHash: 'tx-failopen' })
+      .expect(200);
+
+    expect(res.body.campaign.currentStep).toBe(1);
+    // No lock to release (lockAcquired = false)
+    expect(mockReleaseStepLock).not.toHaveBeenCalled();
+  });
+
+  // ── L6: Different campaigns do not share locks ────────────────────────────
+
+  it('L6: concurrent executions on different campaigns are independent', async () => {
+    const campaign1 = makeActiveCampaign({ id: 1 });
+    const campaign2 = makeActiveCampaign({ id: 2 });
+
+    // Campaign 1 step is locked; campaign 2 step is free
+    mockFindUnique
+      .mockResolvedValueOnce(campaign1)  // first call (campaign 1)
+      .mockResolvedValueOnce(campaign2); // second call (campaign 2)
+
+    mockAcquireStepLock
+      .mockResolvedValueOnce({ acquired: false, holderRequestId: 'holder-1' }) // campaign 1 — locked
+      .mockResolvedValueOnce({ acquired: true, holderRequestId: 'req-2' });    // campaign 2 — free
+
+    mockStepUpdate.mockResolvedValue(makeUpdatedStep());
+    mockCampaignUpdate.mockResolvedValue(makeUpdatedCampaign({ id: 2 }));
+
+    const [res1, res2] = await Promise.all([
+      request(app).post('/api/buyback/campaigns/1/execute-step').send({ txHash: 'tx-1' }),
+      request(app).post('/api/buyback/campaigns/2/execute-step').send({ txHash: 'tx-2' }),
+    ]);
+
+    expect(res1.status).toBe(202);
+    expect(res1.body.status).toBe('PROCESSING');
+
+    expect(res2.status).toBe(200);
+    expect(res2.body.campaign).toBeDefined();
+
+    // Only campaign 2 should have triggered a DB write
+    expect(mockStepUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  // ── Edge: campaign not found before lock acquisition ─────────────────────
+
+  it('returns 404 and never acquires the lock when campaign does not exist', async () => {
+    mockFindUnique.mockResolvedValue(null);
+
+    const res = await request(app)
+      .post('/api/buyback/campaigns/999/execute-step')
+      .send({ txHash: 'tx-ghost' })
+      .expect(404);
+
+    expect(res.body.error).toBe('Campaign not found');
+    expect(mockAcquireStepLock).not.toHaveBeenCalled();
+    expect(mockReleaseStepLock).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/lib/lock.test.ts
+++ b/backend/src/lib/lock.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Unit tests for the distributed lock helpers in lib/lock.ts.
+ *
+ * Tests run entirely in-memory using a mock Redis client — no live Redis needed.
+ *
+ * Scenarios:
+ *   U1  acquireStepLock returns acquired:true when key does not exist
+ *   U2  acquireStepLock returns acquired:false when key already exists
+ *   U3  acquireStepLock returns the existing holder's requestId on failure
+ *   U4  releaseStepLock deletes the key and returns true when the caller is the holder
+ *   U5  releaseStepLock returns false when a different requestId holds the lock
+ *   U6  releaseStepLock returns false when the key has already expired/been deleted
+ *   U7  stepLockKey produces the expected key format
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  acquireStepLock,
+  releaseStepLock,
+  stepLockKey,
+  STEP_LOCK_TTL_MS,
+} from './lock';
+
+// ---------------------------------------------------------------------------
+// Minimal in-memory Redis mock
+// ---------------------------------------------------------------------------
+
+function makeRedisMock() {
+  const store = new Map<string, string>();
+
+  const mock = {
+    store,
+    set: vi.fn(async (
+      key: string,
+      value: string,
+      ...args: unknown[]
+    ): Promise<'OK' | null> => {
+      // Detect NX option (SET key val PX ttl NX)
+      const isNX = args.includes('NX');
+      if (isNX && store.has(key)) return null;
+      store.set(key, value);
+      return 'OK';
+    }),
+    get: vi.fn(async (key: string): Promise<string | null> => {
+      return store.get(key) ?? null;
+    }),
+    eval: vi.fn(async (
+      _script: string,
+      _numKeys: number,
+      key: string,
+      argv: string,
+    ): Promise<number> => {
+      // Implements: if GET(key) == argv then DEL(key) return 1 else return 0
+      if (store.get(key) === argv) {
+        store.delete(key);
+        return 1;
+      }
+      return 0;
+    }),
+  };
+
+  return mock;
+}
+
+type RedisMock = ReturnType<typeof makeRedisMock>;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('lib/lock — distributed lock helpers', () => {
+  let redis: RedisMock;
+
+  beforeEach(() => {
+    redis = makeRedisMock();
+  });
+
+  // ── U7: Key format ────────────────────────────────────────────────────────
+
+  it('U7: stepLockKey produces the expected key format', () => {
+    expect(stepLockKey(42, 3)).toBe('campaign_step_lock:42:3');
+    expect(stepLockKey('abc', 0)).toBe('campaign_step_lock:abc:0');
+  });
+
+  // ── U1: Acquire free lock ─────────────────────────────────────────────────
+
+  it('U1: acquireStepLock returns acquired:true when the key does not exist', async () => {
+    const result = await acquireStepLock(redis as any, 1, 0, 'req-A');
+
+    expect(result.acquired).toBe(true);
+    expect(result.holderRequestId).toBe('req-A');
+    expect(redis.set).toHaveBeenCalledWith(
+      stepLockKey(1, 0),
+      'req-A',
+      'PX',
+      STEP_LOCK_TTL_MS,
+      'NX',
+    );
+  });
+
+  // ── U2: Acquire already-held lock ─────────────────────────────────────────
+
+  it('U2: acquireStepLock returns acquired:false when the key already exists', async () => {
+    // Pre-seed the lock as held by another request
+    redis.store.set(stepLockKey(1, 0), 'req-holder');
+
+    const result = await acquireStepLock(redis as any, 1, 0, 'req-B');
+
+    expect(result.acquired).toBe(false);
+  });
+
+  // ── U3: Holder's requestId is returned on failure ─────────────────────────
+
+  it('U3: acquireStepLock returns the existing holder requestId when lock is taken', async () => {
+    redis.store.set(stepLockKey(5, 2), 'req-original-holder');
+
+    const result = await acquireStepLock(redis as any, 5, 2, 'req-newcomer');
+
+    expect(result.acquired).toBe(false);
+    expect(result.holderRequestId).toBe('req-original-holder');
+  });
+
+  // ── U4: Release lock as holder ────────────────────────────────────────────
+
+  it('U4: releaseStepLock deletes the key and returns true when called by the holder', async () => {
+    redis.store.set(stepLockKey(1, 0), 'req-holder');
+
+    const released = await releaseStepLock(redis as any, 1, 0, 'req-holder');
+
+    expect(released).toBe(true);
+    expect(redis.store.has(stepLockKey(1, 0))).toBe(false);
+  });
+
+  // ── U5: Release by non-holder is a no-op ─────────────────────────────────
+
+  it('U5: releaseStepLock returns false when a different requestId tries to release', async () => {
+    redis.store.set(stepLockKey(1, 0), 'req-real-holder');
+
+    const released = await releaseStepLock(redis as any, 1, 0, 'req-imposter');
+
+    expect(released).toBe(false);
+    // Key must still be present
+    expect(redis.store.get(stepLockKey(1, 0))).toBe('req-real-holder');
+  });
+
+  // ── U6: Release of expired/deleted key ───────────────────────────────────
+
+  it('U6: releaseStepLock returns false when the key does not exist (already expired)', async () => {
+    // Key never set
+    const released = await releaseStepLock(redis as any, 1, 0, 'req-any');
+
+    expect(released).toBe(false);
+  });
+
+  // ── Integration: acquire → release cycle ─────────────────────────────────
+
+  it('full cycle: acquire → lock held → release → can acquire again', async () => {
+    const campaignId = 10;
+    const stepNumber = 1;
+
+    // First request acquires
+    const r1 = await acquireStepLock(redis as any, campaignId, stepNumber, 'req-first');
+    expect(r1.acquired).toBe(true);
+
+    // Second request is blocked
+    const r2 = await acquireStepLock(redis as any, campaignId, stepNumber, 'req-second');
+    expect(r2.acquired).toBe(false);
+    expect(r2.holderRequestId).toBe('req-first');
+
+    // First request releases
+    const released = await releaseStepLock(redis as any, campaignId, stepNumber, 'req-first');
+    expect(released).toBe(true);
+
+    // Third request can now acquire
+    const r3 = await acquireStepLock(redis as any, campaignId, stepNumber, 'req-third');
+    expect(r3.acquired).toBe(true);
+    expect(r3.holderRequestId).toBe('req-third');
+  });
+
+  // ── Custom TTL is forwarded ───────────────────────────────────────────────
+
+  it('acquireStepLock uses the provided custom TTL', async () => {
+    await acquireStepLock(redis as any, 1, 0, 'req-ttl', 5_000);
+
+    expect(redis.set).toHaveBeenCalledWith(
+      expect.any(String),
+      'req-ttl',
+      'PX',
+      5_000,
+      'NX',
+    );
+  });
+});

--- a/backend/src/lib/lock.ts
+++ b/backend/src/lib/lock.ts
@@ -1,0 +1,120 @@
+/**
+ * Distributed lock helpers for Nova Launch backend.
+ *
+ * Uses Redis SET NX PX (set-if-not-exists with millisecond TTL) to implement
+ * a simple, single-instance distributed lock. This is suitable for preventing
+ * duplicate on-chain submissions when a client retries a slow request.
+ *
+ * Lock key format:  campaign_step_lock:<campaignId>:<stepNumber>
+ * Lock value:       a caller-supplied request ID (used to identify the holder)
+ *
+ * Security / correctness notes:
+ *   - Only the lock holder may release the lock (checked via Lua script).
+ *   - The TTL (default 30 s) exceeds the maximum expected on-chain submission
+ *     time, ensuring the lock expires automatically if the holder crashes.
+ *   - On Redis unavailability the acquire call throws; callers must decide
+ *     whether to fail open or closed. The execute-step handler fails open
+ *     (proceeds without the lock) to avoid blocking legitimate requests during
+ *     a Redis outage.
+ *
+ * References:
+ *   https://redis.io/docs/manual/patterns/distributed-locks/
+ */
+
+import Redis from "ioredis";
+
+/** Default lock TTL in milliseconds (30 seconds). */
+export const STEP_LOCK_TTL_MS = 30_000;
+
+/** Key prefix for campaign step locks. */
+const LOCK_PREFIX = "campaign_step_lock";
+
+/**
+ * Builds the Redis key for a campaign step lock.
+ *
+ * @param campaignId  Numeric campaign identifier
+ * @param stepNumber  Zero-based step index within the campaign
+ */
+export function stepLockKey(campaignId: number | string, stepNumber: number | string): string {
+  return `${LOCK_PREFIX}:${campaignId}:${stepNumber}`;
+}
+
+/**
+ * Result returned by `acquireStepLock`.
+ *
+ * - `acquired: true`  → the caller now holds the lock; call `releaseStepLock` when done.
+ * - `acquired: false` → another request is already processing this step.
+ *   `holderRequestId` identifies the current lock holder.
+ */
+export type AcquireLockResult =
+  | { acquired: true; holderRequestId: string }
+  | { acquired: false; holderRequestId: string };
+
+/**
+ * Attempts to acquire a distributed lock for a campaign execution step.
+ *
+ * Internally executes:
+ *   SET <key> <requestId> NX PX <ttlMs>
+ *
+ * @param redis       ioredis client (must be connected)
+ * @param campaignId  Campaign identifier
+ * @param stepNumber  Step number within the campaign
+ * @param requestId   Unique identifier for this request (e.g. UUID or correlation ID)
+ * @param ttlMs       Lock TTL in milliseconds (default: STEP_LOCK_TTL_MS)
+ *
+ * @returns AcquireLockResult — contains `acquired` flag and `holderRequestId`
+ */
+export async function acquireStepLock(
+  redis: Redis,
+  campaignId: number | string,
+  stepNumber: number | string,
+  requestId: string,
+  ttlMs: number = STEP_LOCK_TTL_MS,
+): Promise<AcquireLockResult> {
+  const key = stepLockKey(campaignId, stepNumber);
+
+  // SET NX PX is atomic: returns "OK" on success, null if key already exists.
+  const result = await redis.set(key, requestId, "PX", ttlMs, "NX");
+
+  if (result === "OK") {
+    return { acquired: true, holderRequestId: requestId };
+  }
+
+  // Lock already held — return the current holder's request ID.
+  const holderRequestId = (await redis.get(key)) ?? "unknown";
+  return { acquired: false, holderRequestId };
+}
+
+/**
+ * Releases a campaign step lock, but only if the caller still holds it.
+ *
+ * Uses a Lua script to make the check-and-delete atomic, preventing a lock
+ * holder from accidentally deleting a lock that was re-acquired after expiry.
+ *
+ * @param redis       ioredis client
+ * @param campaignId  Campaign identifier
+ * @param stepNumber  Step number within the campaign
+ * @param requestId   The same requestId used when the lock was acquired
+ *
+ * @returns `true` if the lock was released, `false` if it was already gone or held by another
+ */
+export async function releaseStepLock(
+  redis: Redis,
+  campaignId: number | string,
+  stepNumber: number | string,
+  requestId: string,
+): Promise<boolean> {
+  const key = stepLockKey(campaignId, stepNumber);
+
+  // Atomic compare-and-delete via Lua
+  const luaScript = `
+    if redis.call("GET", KEYS[1]) == ARGV[1] then
+      return redis.call("DEL", KEYS[1])
+    else
+      return 0
+    end
+  `;
+
+  const deleted = await redis.eval(luaScript, 1, key, requestId) as number;
+  return deleted === 1;
+}

--- a/backend/src/routes/buyback.ts
+++ b/backend/src/routes/buyback.ts
@@ -3,9 +3,19 @@ import { PrismaClient } from '@prisma/client';
 import { param, body, query } from 'express-validator';
 import { validate } from '../middleware/validation';
 import { campaignProjectionService } from '../services/campaignProjectionService';
+import { createRedisClient } from '../middleware/rateLimiter';
+import { acquireStepLock, releaseStepLock } from '../lib/lock';
+import { randomUUID } from 'crypto';
 
 const router = Router();
 const prisma = new PrismaClient();
+
+/** Lazily-initialised shared Redis client for distributed locks. */
+let _lockRedis: ReturnType<typeof createRedisClient> | null = null;
+function getLockRedis(): ReturnType<typeof createRedisClient> {
+  if (!_lockRedis) _lockRedis = createRedisClient();
+  return _lockRedis;
+}
 
 router.post(
   '/campaigns',
@@ -158,12 +168,23 @@ router.post(
     validate,
   ],
   async (req: Request, res: Response) => {
-    try {
-      const { id } = req.params;
-      const { txHash } = req.body;
+    const campaignId = Number(req.params.id);
+    const { txHash } = req.body;
 
+    // ── Distributed lock ────────────────────────────────────────────────────
+    // Derive the step number from the current campaign state before acquiring
+    // the lock. We need a quick read first to know which step we're locking.
+    // The lock is keyed by campaign_id:step_number and has a 30-second TTL,
+    // which is longer than the maximum expected on-chain submission time.
+
+    const requestId = randomUUID();
+    let lockAcquired = false;
+    let lockedStepNumber: number | null = null;
+
+    try {
+      // First, fetch the campaign to determine the current step number.
       const campaign = await prisma.buybackCampaign.findUnique({
-        where: { id: Number(id) },
+        where: { id: campaignId },
         include: { steps: true },
       });
 
@@ -178,6 +199,37 @@ router.post(
       if (campaign.currentStep >= campaign.totalSteps) {
         return res.status(400).json({ error: 'All steps completed' });
       }
+
+      lockedStepNumber = campaign.currentStep;
+
+      // Attempt to acquire the distributed lock for this campaign step.
+      let lockResult: Awaited<ReturnType<typeof acquireStepLock>> | null = null;
+      try {
+        lockResult = await acquireStepLock(
+          getLockRedis(),
+          campaignId,
+          lockedStepNumber,
+          requestId,
+        );
+      } catch (redisErr) {
+        // Redis unavailable — fail open: log and proceed without the lock.
+        console.error(
+          '[StepLock] Redis unavailable, proceeding without lock:',
+          (redisErr as Error).message,
+        );
+      }
+
+      if (lockResult && !lockResult.acquired) {
+        // Another request is already processing this step.
+        return res.status(202).json({
+          status: 'PROCESSING',
+          holderRequestId: lockResult.holderRequestId,
+        });
+      }
+
+      lockAcquired = lockResult?.acquired ?? false;
+
+      // ── Business logic (unchanged) ────────────────────────────────────────
 
       const currentStep = campaign.steps.find(
         (s) => s.stepNumber === campaign.currentStep
@@ -205,7 +257,7 @@ router.post(
       ).toString();
 
       const updatedCampaign = await prisma.buybackCampaign.update({
-        where: { id: Number(id) },
+        where: { id: campaignId },
         data: {
           executedAmount: newExecutedAmount,
           currentStep: campaign.currentStep + 1,
@@ -228,6 +280,15 @@ router.post(
     } catch (error) {
       console.error('Error executing step:', error);
       res.status(500).json({ error: 'Failed to execute step' });
+    } finally {
+      // Always release the lock (success or failure) to prevent lock leakage.
+      if (lockAcquired && lockedStepNumber !== null) {
+        try {
+          await releaseStepLock(getLockRedis(), campaignId, lockedStepNumber, requestId);
+        } catch (releaseErr) {
+          console.error('[StepLock] Failed to release lock:', (releaseErr as Error).message);
+        }
+      }
     }
   }
 );


### PR DESCRIPTION
## Summary

- Implements `acquireStepLock` / `releaseStepLock` in `backend/src/lib/lock.ts` using Redis `SET NX PX` with a 30-second TTL
- Integrates the lock into the `POST /api/buyback/campaigns/:id/execute-step` handler: concurrent requests for the same `campaign_id:step_number` receive `202 { status: 'PROCESSING', holderRequestId }` instead of submitting duplicate on-chain transactions
- Releases the lock in a `finally` block to prevent lock leakage on both success and failure paths
- Fails open when Redis is unavailable so a cache outage doesn't block legitimate step executions

## Test plan

- [ ] `backend/src/lib/lock.test.ts` — 9 unit tests for `acquireStepLock`, `releaseStepLock`, and `stepLockKey` using an in-memory Redis mock
- [ ] `backend/src/__tests__/campaignStepLock.concurrency.test.ts` — 7 concurrency/integration tests covering: concurrent 202 response, successful 200 with lock, lock release after success, lock release after failure, Redis fail-open, cross-campaign isolation, and campaign-not-found guard
- [ ] Run `vitest run src/lib/lock.test.ts src/__tests__/campaignStepLock.concurrency.test.ts` — all 16 tests pass

Closes #1354