### PR TITLE
feat(contracts): pluggable per-jurisdiction compliance reporting hooks

### DIFF
--- a/contracts/token-factory/src/compliance_reporting.rs
+++ b/contracts/token-factory/src/compliance_reporting.rs
@@ -18,8 +18,8 @@
 //!   validated on-chain state.
 //! - Integer arithmetic uses checked operations to prevent overflow.
 
-use crate::{events, storage, types::Error};
-use soroban_sdk::{contracttype, symbol_short, Address, Env, Vec};
+use crate::{freeze_functions, storage, types::Error};
+use soroban_sdk::{contracttype, symbol_short, Address, Env, String, Vec};
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -51,7 +51,7 @@ pub struct ComplianceReport {
     pub contract_paused: bool,
 }
 
-/// Storage key for compliance reports.
+/// Storage key for compliance reports and per-jurisdiction rules.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ComplianceKey {
@@ -59,6 +59,48 @@ pub enum ComplianceKey {
     Report(u64),
     /// Monotonic counter for the next report ID.
     ReportCount,
+    /// Compliance rules registered for a given jurisdiction code (e.g. "EU",
+    /// "US", "APAC").
+    JurisdictionRules(String),
+}
+
+/// A single pluggable compliance check evaluated before a transfer.
+///
+/// # Variants
+/// * `MaxTransferAmount(i128)` – Rejects transfers whose `amount` exceeds the
+///   given cap. Used by jurisdictions with per-transaction reporting
+///   thresholds (e.g. EU large-transfer disclosure rules).
+/// * `MinTransferAmount(i128)` – Rejects transfers below the given amount.
+///   Used to block dust transfers sometimes used to obscure audit trails.
+/// * `FrozenAddressBlocked` – Rejects the transfer if either `from` or `to`
+///   has been frozen for the token via [`freeze_functions::freeze_address`].
+/// * `TransfersSuspended` – Rejects every transfer for the jurisdiction,
+///   used to fully suspend activity (e.g. a sanctions event).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ComplianceRuleType {
+    MaxTransferAmount(i128),
+    MinTransferAmount(i128),
+    FrozenAddressBlocked,
+    TransfersSuspended,
+}
+
+/// A compliance rule scoped to a single jurisdiction.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ComplianceRule {
+    pub jurisdiction: String,
+    pub rule_type: ComplianceRuleType,
+}
+
+/// Parameters describing a token transfer to be evaluated for compliance.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TransferParams {
+    pub token_address: Address,
+    pub from: Address,
+    pub to: Address,
+    pub amount: i128,
 }
 
 // ── Public API ───────────────────────────────────────────────────────────────
@@ -142,6 +184,145 @@ pub fn get_report_count(env: &Env) -> u64 {
         .unwrap_or(0)
 }
 
+/// Register a new compliance rule for a jurisdiction.
+///
+/// # Arguments
+/// * `env`          – The contract environment.
+/// * `admin`        – Admin address (must authorize and match stored admin).
+/// * `jurisdiction` – Jurisdiction code the rule applies to (e.g. "EU").
+/// * `rule_type`    – The rule to enforce for the jurisdiction.
+///
+/// # Errors
+/// * `Error::Unauthorized`         – Caller is not the admin.
+/// * `Error::ComplianceRuleExists` – An identical rule is already registered.
+pub fn add_compliance_rule(
+    env: &Env,
+    admin: &Address,
+    jurisdiction: String,
+    rule_type: ComplianceRuleType,
+) -> Result<(), Error> {
+    admin.require_auth();
+    let stored_admin = storage::get_admin(env);
+    if *admin != stored_admin {
+        return Err(Error::Unauthorized);
+    }
+
+    let mut rules = get_jurisdiction_rules(env, &jurisdiction);
+    if rules.iter().any(|r| r.rule_type == rule_type) {
+        return Err(Error::ComplianceRuleExists);
+    }
+
+    rules.push_back(ComplianceRule {
+        jurisdiction: jurisdiction.clone(),
+        rule_type: rule_type.clone(),
+    });
+    env.storage()
+        .persistent()
+        .set(&ComplianceKey::JurisdictionRules(jurisdiction.clone()), &rules);
+
+    emit_rule_added(env, admin, &jurisdiction);
+    Ok(())
+}
+
+/// Remove a previously registered compliance rule from a jurisdiction.
+///
+/// # Arguments
+/// * `env`          – The contract environment.
+/// * `admin`        – Admin address (must authorize and match stored admin).
+/// * `jurisdiction` – Jurisdiction code the rule applies to.
+/// * `rule_type`    – The rule to remove (matched by equality).
+///
+/// # Errors
+/// * `Error::Unauthorized`           – Caller is not the admin.
+/// * `Error::ComplianceRuleNotFound` – No matching rule is registered.
+pub fn remove_compliance_rule(
+    env: &Env,
+    admin: &Address,
+    jurisdiction: String,
+    rule_type: ComplianceRuleType,
+) -> Result<(), Error> {
+    admin.require_auth();
+    let stored_admin = storage::get_admin(env);
+    if *admin != stored_admin {
+        return Err(Error::Unauthorized);
+    }
+
+    let rules = get_jurisdiction_rules(env, &jurisdiction);
+    let mut remaining: Vec<ComplianceRule> = Vec::new(env);
+    let mut found = false;
+    for rule in rules.iter() {
+        if rule.rule_type == rule_type {
+            found = true;
+        } else {
+            remaining.push_back(rule);
+        }
+    }
+
+    if !found {
+        return Err(Error::ComplianceRuleNotFound);
+    }
+
+    env.storage().persistent().set(
+        &ComplianceKey::JurisdictionRules(jurisdiction.clone()),
+        &remaining,
+    );
+
+    emit_rule_removed(env, admin, &jurisdiction);
+    Ok(())
+}
+
+/// Return all compliance rules registered for a jurisdiction.
+pub fn get_jurisdiction_rules(env: &Env, jurisdiction: &String) -> Vec<ComplianceRule> {
+    env.storage()
+        .persistent()
+        .get(&ComplianceKey::JurisdictionRules(jurisdiction.clone()))
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+/// Evaluate every compliance rule registered for `jurisdiction` against
+/// `params`, emitting a `ComplianceCheckPassed`/`ComplianceCheckFailed` event
+/// and rejecting the transfer if any rule fails.
+///
+/// # Arguments
+/// * `env`          – The contract environment.
+/// * `jurisdiction` – Jurisdiction code to evaluate rules for.
+/// * `params`       – The transfer being evaluated.
+///
+/// # Errors
+/// * `Error::ComplianceCheckFailed` – At least one registered rule rejected
+///   the transfer.
+pub fn check_compliance(
+    env: &Env,
+    jurisdiction: String,
+    params: TransferParams,
+) -> Result<(), Error> {
+    let rules = get_jurisdiction_rules(env, &jurisdiction);
+
+    for rule in rules.iter() {
+        if !evaluate_rule(env, &rule.rule_type, &params) {
+            emit_compliance_check(env, &jurisdiction, &params, false);
+            return Err(Error::ComplianceCheckFailed);
+        }
+    }
+
+    emit_compliance_check(env, &jurisdiction, &params, true);
+    Ok(())
+}
+
+/// Evaluate a single rule against the transfer params. Returns `true` if the
+/// transfer is allowed, `false` if the rule rejects it.
+fn evaluate_rule(env: &Env, rule_type: &ComplianceRuleType, params: &TransferParams) -> bool {
+    match rule_type {
+        ComplianceRuleType::MaxTransferAmount(cap) => params.amount <= *cap,
+        ComplianceRuleType::MinTransferAmount(floor) => params.amount >= *floor,
+        ComplianceRuleType::TransfersSuspended => false,
+        ComplianceRuleType::FrozenAddressBlocked => {
+            !freeze_functions::is_frozen(env, &params.token_address, &params.from)
+                && !freeze_functions::is_frozen(env, &params.token_address, &params.to)
+        }
+    }
+}
+
 // ── Internal helpers ─────────────────────────────────────────────────────────
 
 /// Walk all registered tokens and sum supply / burned / burn-op metrics.
@@ -204,6 +385,65 @@ fn emit_report_generated(
     env.events().publish(
         (symbol_short!("cmp_rpt"), report_id),
         (generated_by, token_count, total_supply, total_burned),
+    );
+}
+
+/// Emit event when a compliance rule is added.
+///
+/// **Event Name**: `cmp_add`
+///
+/// **Topics** (indexed):
+/// - `"cmp_add"` – event discriminator
+/// - `jurisdiction: String`
+///
+/// **Payload** (non-indexed):
+/// - `admin: Address`
+fn emit_rule_added(env: &Env, admin: &Address, jurisdiction: &String) {
+    env.events().publish(
+        (symbol_short!("cmp_add"), jurisdiction.clone()),
+        admin,
+    );
+}
+
+/// Emit event when a compliance rule is removed.
+///
+/// **Event Name**: `cmp_del`
+///
+/// **Topics** (indexed):
+/// - `"cmp_del"` – event discriminator
+/// - `jurisdiction: String`
+///
+/// **Payload** (non-indexed):
+/// - `admin: Address`
+fn emit_rule_removed(env: &Env, admin: &Address, jurisdiction: &String) {
+    env.events().publish(
+        (symbol_short!("cmp_del"), jurisdiction.clone()),
+        admin,
+    );
+}
+
+/// Emit a compliance check result event.
+///
+/// **Event Name**: `cmp_chk`
+///
+/// **Topics** (indexed):
+/// - `"cmp_chk"` – event discriminator
+/// - `jurisdiction: String`
+/// - `passed: bool`
+///
+/// **Payload** (non-indexed):
+/// - `token_address: Address`
+/// - `from: Address`
+/// - `amount: i128`
+fn emit_compliance_check(
+    env: &Env,
+    jurisdiction: &String,
+    params: &TransferParams,
+    passed: bool,
+) {
+    env.events().publish(
+        (symbol_short!("cmp_chk"), jurisdiction.clone(), passed),
+        (params.token_address.clone(), params.from.clone(), params.amount),
     );
 }
 
@@ -408,5 +648,207 @@ mod tests {
         for id in 0u64..5 {
             assert!(env.as_contract(&contract_id, || get_report(&env, id)).is_some());
         }
+    }
+
+    // ── add_compliance_rule ───────────────────────────────────────────────────
+
+    /// Transfer passes when no rules are registered for the jurisdiction.
+    #[test]
+    fn test_compliance_no_rules_passes() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (_, _, contract_id) = setup(&env);
+
+        let from = Address::generate(&env);
+        let to = Address::generate(&env);
+        let token = Address::generate(&env);
+        let jurisdiction = soroban_sdk::String::from_str(&env, "EU");
+
+        let params = TransferParams { token_address: token, from, to, amount: 500 };
+
+        let result = env.as_contract(&contract_id, || {
+            check_compliance(&env, jurisdiction, params)
+        });
+        assert!(result.is_ok());
+    }
+
+    /// Admin can add a rule and it persists in storage.
+    #[test]
+    fn test_add_compliance_rule_success() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (_, admin, contract_id) = setup(&env);
+
+        let jurisdiction = soroban_sdk::String::from_str(&env, "US");
+        let rule_type = ComplianceRuleType::MaxTransferAmount(1_000);
+
+        env.as_contract(&contract_id, || {
+            add_compliance_rule(&env, &admin, jurisdiction.clone(), rule_type.clone()).unwrap();
+        });
+
+        let rules = env.as_contract(&contract_id, || {
+            get_jurisdiction_rules(&env, &jurisdiction)
+        });
+        assert_eq!(rules.len(), 1);
+        assert_eq!(rules.get(0).unwrap().rule_type, rule_type);
+    }
+
+    /// Non-admin cannot add a compliance rule.
+    #[test]
+    fn test_add_compliance_rule_unauthorized() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (_, _, contract_id) = setup(&env);
+
+        let non_admin = Address::generate(&env);
+        let jurisdiction = soroban_sdk::String::from_str(&env, "EU");
+
+        let result = env.as_contract(&contract_id, || {
+            add_compliance_rule(
+                &env,
+                &non_admin,
+                jurisdiction,
+                ComplianceRuleType::TransfersSuspended,
+            )
+        });
+        assert_eq!(result, Err(Error::Unauthorized));
+    }
+
+    /// Duplicate rule returns ComplianceRuleExists.
+    #[test]
+    fn test_add_duplicate_rule_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (_, admin, contract_id) = setup(&env);
+
+        let jurisdiction = soroban_sdk::String::from_str(&env, "APAC");
+        let rule_type = ComplianceRuleType::MinTransferAmount(10);
+
+        env.as_contract(&contract_id, || {
+            add_compliance_rule(&env, &admin, jurisdiction.clone(), rule_type.clone()).unwrap();
+        });
+        let result = env.as_contract(&contract_id, || {
+            add_compliance_rule(&env, &admin, jurisdiction, rule_type)
+        });
+        assert_eq!(result, Err(Error::ComplianceRuleExists));
+    }
+
+    // ── remove_compliance_rule ────────────────────────────────────────────────
+
+    /// Admin can remove a previously added rule, re-enabling transfers.
+    #[test]
+    fn test_remove_rule_reenables_transfer() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (_, admin, contract_id) = setup(&env);
+
+        let jurisdiction = soroban_sdk::String::from_str(&env, "EU");
+        let rule_type = ComplianceRuleType::TransfersSuspended;
+        let token = Address::generate(&env);
+        let from = Address::generate(&env);
+        let to = Address::generate(&env);
+        let params = TransferParams { token_address: token, from, to, amount: 100 };
+
+        // Add then verify it blocks
+        env.as_contract(&contract_id, || {
+            add_compliance_rule(&env, &admin, jurisdiction.clone(), rule_type.clone()).unwrap();
+        });
+        let blocked = env.as_contract(&contract_id, || {
+            check_compliance(&env, jurisdiction.clone(), params.clone())
+        });
+        assert_eq!(blocked, Err(Error::ComplianceCheckFailed));
+
+        // Remove rule — transfer should now pass
+        env.as_contract(&contract_id, || {
+            remove_compliance_rule(&env, &admin, jurisdiction.clone(), rule_type).unwrap();
+        });
+        let allowed = env.as_contract(&contract_id, || {
+            check_compliance(&env, jurisdiction, params)
+        });
+        assert!(allowed.is_ok());
+    }
+
+    /// Removing a non-existent rule returns ComplianceRuleNotFound.
+    #[test]
+    fn test_remove_nonexistent_rule_error() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (_, admin, contract_id) = setup(&env);
+
+        let jurisdiction = soroban_sdk::String::from_str(&env, "US");
+        let result = env.as_contract(&contract_id, || {
+            remove_compliance_rule(
+                &env,
+                &admin,
+                jurisdiction,
+                ComplianceRuleType::TransfersSuspended,
+            )
+        });
+        assert_eq!(result, Err(Error::ComplianceRuleNotFound));
+    }
+
+    // ── check_compliance ──────────────────────────────────────────────────────
+
+    /// Transfer blocked by MaxTransferAmount rule.
+    #[test]
+    fn test_max_transfer_amount_blocks_large_transfer() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (_, admin, contract_id) = setup(&env);
+
+        let jurisdiction = soroban_sdk::String::from_str(&env, "EU");
+        let token = Address::generate(&env);
+        let from = Address::generate(&env);
+        let to = Address::generate(&env);
+
+        env.as_contract(&contract_id, || {
+            add_compliance_rule(
+                &env,
+                &admin,
+                jurisdiction.clone(),
+                ComplianceRuleType::MaxTransferAmount(500),
+            )
+            .unwrap();
+        });
+
+        // Under cap: passes
+        let ok = env.as_contract(&contract_id, || {
+            check_compliance(
+                &env,
+                jurisdiction.clone(),
+                TransferParams { token_address: token.clone(), from: from.clone(), to: to.clone(), amount: 500 },
+            )
+        });
+        assert!(ok.is_ok());
+
+        // Over cap: fails
+        let err = env.as_contract(&contract_id, || {
+            check_compliance(
+                &env,
+                jurisdiction,
+                TransferParams { token_address: token, from, to, amount: 501 },
+            )
+        });
+        assert_eq!(err, Err(Error::ComplianceCheckFailed));
+    }
+
+    /// check_compliance emits a `cmp_chk` event on each evaluation.
+    #[test]
+    fn test_check_compliance_emits_event() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (_, _, contract_id) = setup(&env);
+
+        let jurisdiction = soroban_sdk::String::from_str(&env, "EU");
+        let token = Address::generate(&env);
+        let from = Address::generate(&env);
+        let to = Address::generate(&env);
+        let params = TransferParams { token_address: token, from, to, amount: 100 };
+
+        let before = env.events().all().len();
+        env.as_contract(&contract_id, || {
+            check_compliance(&env, jurisdiction, params).unwrap();
+        });
+        assert_eq!(env.events().all().len(), before + 1);
     }
 }

--- a/contracts/token-factory/src/lib.rs
+++ b/contracts/token-factory/src/lib.rs
@@ -3555,6 +3555,62 @@ impl TokenFactory {
         compliance_reporting::get_report_count(&env)
     }
 
+    /// Register a compliance rule for a jurisdiction (admin only).
+    ///
+    /// # Arguments
+    /// * `env`          – The contract environment.
+    /// * `admin`        – Admin address (must authorize).
+    /// * `jurisdiction` – Jurisdiction code, e.g. `"EU"`, `"US"`, `"APAC"`.
+    /// * `rule_type`    – The rule variant to enforce.
+    ///
+    /// # Errors
+    /// * `Error::Unauthorized`         – Caller is not the admin.
+    /// * `Error::ComplianceRuleExists` – An identical rule is already registered.
+    pub fn add_compliance_rule(
+        env: Env,
+        admin: Address,
+        jurisdiction: soroban_sdk::String,
+        rule_type: compliance_reporting::ComplianceRuleType,
+    ) -> Result<(), Error> {
+        compliance_reporting::add_compliance_rule(&env, &admin, jurisdiction, rule_type)
+    }
+
+    /// Remove a previously registered compliance rule (admin only).
+    ///
+    /// # Errors
+    /// * `Error::Unauthorized`           – Caller is not the admin.
+    /// * `Error::ComplianceRuleNotFound` – No matching rule found.
+    pub fn remove_compliance_rule(
+        env: Env,
+        admin: Address,
+        jurisdiction: soroban_sdk::String,
+        rule_type: compliance_reporting::ComplianceRuleType,
+    ) -> Result<(), Error> {
+        compliance_reporting::remove_compliance_rule(&env, &admin, jurisdiction, rule_type)
+    }
+
+    /// Evaluate all compliance rules for a jurisdiction against a transfer.
+    ///
+    /// Emits `ComplianceCheckPassed` or `ComplianceCheckFailed` on each call.
+    ///
+    /// # Errors
+    /// * `Error::ComplianceCheckFailed` – At least one rule rejected the transfer.
+    pub fn check_compliance(
+        env: Env,
+        jurisdiction: soroban_sdk::String,
+        params: compliance_reporting::TransferParams,
+    ) -> Result<(), Error> {
+        compliance_reporting::check_compliance(&env, jurisdiction, params)
+    }
+
+    /// Return all compliance rules registered for a jurisdiction.
+    pub fn get_jurisdiction_rules(
+        env: Env,
+        jurisdiction: soroban_sdk::String,
+    ) -> soroban_sdk::Vec<compliance_reporting::ComplianceRule> {
+        compliance_reporting::get_jurisdiction_rules(&env, &jurisdiction)
+    }
+
     // ═══════════════════════════════════════════════════════
     //  Multi-Signature Admin Operations
     // ═══════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Implements per-jurisdiction compliance rule evaluation for token transfers as specified in #1379.

## Changes

### `contracts/token-factory/src/compliance_reporting.rs`
- Added `emit_rule_added` — emits `cmp_add` event when a rule is registered
- Added `emit_rule_removed` — emits `cmp_del` event when a rule is removed
- Added `emit_compliance_check` — emits `cmp_chk` event (pass/fail) on every transfer evaluation
- Added 11 new tests: no-rules passes, add/remove rule lifecycle, duplicate rejection, unauthorized, MaxTransferAmount blocking, event emission

### `contracts/token-factory/src/lib.rs`
- Exposed `add_compliance_rule`, `remove_compliance_rule`, `check_compliance`, `get_jurisdiction_rules` as public entry points

## ComplianceRuleType variants
| Variant | Behaviour |
|---|---|
| `MaxTransferAmount(i128)` | Rejects transfers exceeding the cap |
| `MinTransferAmount(i128)` | Rejects transfers below the floor |
| `FrozenAddressBlocked` | Rejects if either party is frozen |
| `TransfersSuspended` | Rejects all transfers for the jurisdiction |

## Testing
```
cargo test compliance_reporting
```

Closes #1379