### PR TITLE
test(eventBus): add concurrency and high-throughput burst tests (#1318)

### DIFF
--- a/backend/src/services/eventBus.test.ts
+++ b/backend/src/services/eventBus.test.ts
@@ -472,3 +472,71 @@ describe("Issue #1064: Event bus pub/sub delivery guarantees", () => {
     expect(history).toHaveLength(2);
   });
 });
+
+// ---------------------------------------------------------------------------
+// High-throughput burst
+// ---------------------------------------------------------------------------
+
+describe("high-throughput burst", () => {
+  it("delivers all 1000 events to each of 5 concurrent subscribers (zero dropped)", async () => {
+    const bus = makeBus();
+    const EVENT_COUNT = 1000;
+    const SUBSCRIBER_COUNT = 5;
+    const counts = Array.from({ length: SUBSCRIBER_COUNT }, () => 0);
+
+    for (let i = 0; i < SUBSCRIBER_COUNT; i++) {
+      bus.subscribe("burst.event", () => {
+        counts[i]++;
+      });
+    }
+
+    const publishes: Promise<unknown>[] = [];
+    for (let i = 0; i < EVENT_COUNT; i++) {
+      publishes.push(bus.publish("burst.event", { seq: i }));
+    }
+    await Promise.all(publishes);
+
+    const totalReceived = counts.reduce((sum, c) => sum + c, 0);
+    expect(totalReceived).toBe(EVENT_COUNT * SUBSCRIBER_COUNT);
+    for (const count of counts) {
+      expect(count).toBe(EVENT_COUNT);
+    }
+  });
+
+  it("error in subscriber 3 does not prevent other 4 subscribers from receiving all events", async () => {
+    const bus = makeBus();
+    const EVENT_COUNT = 100;
+    const SUBSCRIBER_COUNT = 5;
+    const counts = Array.from({ length: SUBSCRIBER_COUNT }, () => 0);
+
+    for (let i = 0; i < SUBSCRIBER_COUNT; i++) {
+      const idx = i;
+      bus.subscribe("burst.isolated", () => {
+        counts[idx]++;
+        // Subscriber 3 (index 2) throws on every 5th event it receives
+        if (idx === 2 && counts[idx] % 5 === 0) {
+          throw new Error(`subscriber 3 error on event ${counts[idx]}`);
+        }
+      });
+    }
+
+    const publishes: Promise<unknown>[] = [];
+    for (let i = 0; i < EVENT_COUNT; i++) {
+      publishes.push(bus.publish("burst.isolated", { seq: i }));
+    }
+    await Promise.all(publishes);
+
+    // Subscribers 0, 1, 3, 4 receive all events unaffected
+    for (let i = 0; i < SUBSCRIBER_COUNT; i++) {
+      expect(counts[i]).toBe(EVENT_COUNT);
+    }
+
+    // Errors from subscriber 3 are captured in the DLQ, not propagated
+    const dlq = bus.getDeadLetterQueue();
+    expect(dlq.length).toBeGreaterThan(0);
+    for (const entry of dlq) {
+      expect(entry.event.type).toBe("burst.isolated");
+      expect(entry.error).toMatch(/subscriber 3 error/);
+    }
+  });
+});


### PR DESCRIPTION
Overview
This pull request addresses issue #1318 by implementing comprehensive concurrency and high-throughput burst testing for the EventBus service. While the existing test suite verified single-subscriber scenarios, it lacked coverage for edge cases such as backpressure, message dropping, and error propagation under intense concurrent loads.

Changes
Extended Test Suite: Added a new describe('high-throughput burst') block to backend/src/services/eventBus.test.ts.

Burst Load Testing: Implemented a test scenario simulating 5 concurrent subscribers processing 1,000 events published in rapid succession to ensure no messages are dropped.

Error Isolation Testing: Added a test scenario verifying that an unhandled exception in one subscriber (specifically targeting every 5th event in a chosen subscriber) does not disrupt processing or corrupt the event loop for other healthy subscribers.

Verification Results
Executed linting checks via npm run lint with zero errors.

Validated the test suite using npx vitest run src/services/eventBus.test.ts. All concurrency tests pass consistently without flakiness.

Closes #1318 