### PR TITLE
feat(webhook): glob pattern event-type filtering for webhook subscriptions

### DIFF
--- a/backend/src/services/webhookService.ts
+++ b/backend/src/services/webhookService.ts
@@ -9,19 +9,31 @@ import {
   WebhookDeliveryLog,
 } from "../types/webhook";
 import { generateWebhookSecret, generateWebhookSignature } from "../utils/crypto";
+import { globMatch, isValidGlobPattern } from "../utils/globMatch";
 
 export class WebhookService {
   /**
-   * Create a new webhook subscription
+   * Create a new webhook subscription.
+   *
+   * Each entry in `input.events` may be either a concrete WebhookEventType value
+   * or a glob pattern (e.g. `token.*`, `governance.proposal.**`).  Glob patterns
+   * are validated at creation time — an invalid pattern causes the method to throw.
    */
   async createSubscription(
     input: CreateWebhookInput
   ): Promise<WebhookSubscription> {
+    // Validate any glob patterns supplied in the events array.
+    for (const event of input.events) {
+      if (event.includes("*") && !isValidGlobPattern(event)) {
+        throw new Error(`Invalid glob pattern in events: "${event}"`);
+      }
+    }
+
     const id = uuidv4();
     const secret = generateWebhookSecret();
 
     const query = `
-      INSERT INTO webhook_subscriptions 
+      INSERT INTO webhook_subscriptions
         (id, url, token_address, events, secret, created_by)
       VALUES ($1, $2, $3, $4, $5, $6)
       RETURNING *
@@ -107,21 +119,41 @@ export class WebhookService {
   }
 
   /**
-   * Find subscriptions matching an event
+   * Find subscriptions matching an event.
+   *
+   * A subscription matches when:
+   *  1. It is active.
+   *  2. Its token_address is NULL (wildcard) or equals the supplied tokenAddress.
+   *  3. At least one of its events entries either:
+   *       a. Exactly equals the incoming event type, OR
+   *       b. Is a glob pattern that matches the incoming event type string.
    */
   async findMatchingSubscriptions(
     event: WebhookEventType,
-    tokenAddress?: string
+    tokenAddress?: string | null
   ): Promise<WebhookSubscription[]> {
+    // Fetch all active subscriptions filtered by token address at the DB level.
+    // Event matching (including glob patterns) is done in-process so we can use
+    // the hand-rolled glob engine without relying on a Postgres extension.
     const query = `
-      SELECT * FROM webhook_subscriptions 
-      WHERE active = true 
-        AND $1 = ANY(events)
-        AND (token_address IS NULL OR token_address = $2)
+      SELECT * FROM webhook_subscriptions
+      WHERE active = true
+        AND (token_address IS NULL OR token_address = $1)
     `;
 
-    const result = await db.query(query, [event, tokenAddress || null]);
-    return result.rows.map(this.mapRowToSubscription);
+    const result = await db.query(query, [tokenAddress ?? null]);
+    const subscriptions: WebhookSubscription[] = result.rows.map(
+      this.mapRowToSubscription
+    );
+
+    // Filter by event type — supports exact matches and glob patterns.
+    return subscriptions.filter((sub) =>
+      sub.events.some((pattern) => {
+        if (pattern === event) return true;
+        if (pattern.includes("*")) return globMatch(pattern, event);
+        return false;
+      })
+    );
   }
 
   /**

--- a/backend/src/utils/globMatch.ts
+++ b/backend/src/utils/globMatch.ts
@@ -1,0 +1,54 @@
+/**
+ * Minimal glob matcher supporting:
+ *   - `*`  — matches any sequence of characters within a single dot-separated segment
+ *   - `**` — matches any number of dot-separated segments (including zero)
+ *
+ * Valid pattern characters: alphanumeric, dot (.), underscore (_), hyphen (-), asterisk (*).
+ * Consecutive asterisks other than exactly `**` are invalid.
+ */
+
+const VALID_PATTERN_RE = /^[a-zA-Z0-9._\-*]+$/;
+
+/**
+ * Returns true if the pattern string is a valid glob pattern.
+ *
+ * Rules:
+ *  - Only alphanumeric chars, dots, underscores, hyphens, and asterisks are allowed.
+ *  - Consecutive asterisks are only permitted as exactly `**` (three or more in a row are invalid).
+ */
+export function isValidGlobPattern(pattern: string): boolean {
+  if (!VALID_PATTERN_RE.test(pattern)) return false;
+  // Reject runs of 3+ asterisks
+  if (/\*{3,}/.test(pattern)) return false;
+  return true;
+}
+
+/**
+ * Returns true when `str` matches `pattern` using the glob rules described above.
+ *
+ * Matching is performed by converting the pattern into a regular expression:
+ *  - `**` → matches zero-or-more dot-separated segments: `[^]* ` (anything)
+ *  - `*`  → matches any sequence of non-dot characters within one segment
+ *  - `.`  → literal dot
+ *  - other chars → literal
+ */
+export function globMatch(pattern: string, str: string): boolean {
+  // Build regex from pattern
+  // Split on '**' first so we can handle it specially, then handle '*' within segments.
+  const parts = pattern.split('**');
+  const regexParts = parts.map((part) => {
+    // Escape regex special chars except '*' and '.'
+    return part
+      .split('*')
+      .map((segment) => segment.replace(/[.+^${}()|[\]\\]/g, '\\$&'))
+      .join('[^.]*');
+  });
+
+  // Join the '**' parts with a pattern that matches any segment(s), including zero.
+  // Between two '**' anchors we need to match: (nothing) OR (.<segment>)* style
+  // Simplest approach: '**' matches any sequence of characters (including dots).
+  const regexStr = '^' + regexParts.join('.*') + '$';
+
+  const regex = new RegExp(regexStr);
+  return regex.test(str);
+}


### PR DESCRIPTION
## Summary

- Adds glob pattern matching support for webhook subscription event types (e.g. `token.*`, `governance.proposal.*`, `stream.claim`)
- Validates glob patterns at subscription creation time, rejecting malformed patterns
- Filters events at delivery time using glob matching before queuing
- Existing exact-type subscriptions continue to work unchanged without any migration

## Test plan

- [ ] Run `npx vitest run src/__tests__/webhook-subscription-filtering.integration.test.ts` — all pass
- [ ] Glob match: `token.*` matches `token.burned` and `token.minted`
- [ ] Non-match: `token.*` does not match `governance.proposal`
- [ ] Invalid pattern rejected at subscription creation time with 400 error

Closes #1348