### PR TITLE
feat(contracts): per-epoch vault withdrawal circuit breaker with configurable limit

### DIFF
--- a/contracts/token-factory/src/lib.rs
+++ b/contracts/token-factory/src/lib.rs
@@ -51,6 +51,7 @@ mod timelock;
 mod token_creation;
 mod treasury;
 mod types;
+mod vault;
 mod vesting;
 mod validation;
 
@@ -153,6 +154,9 @@ mod batch_atomicity_test;
 
 #[cfg(test)]
 mod vault_deposit_withdraw_test;
+
+#[cfg(test)]
+mod vault_circuit_breaker_test;
 
 use soroban_sdk::{contract, contractimpl, symbol_short, Address, Bytes, BytesN, Env, String, Symbol, Vec};
 use types::{
@@ -2832,6 +2836,10 @@ impl TokenFactory {
             return Err(Error::InvalidParameters);
         }
 
+        // Per-epoch circuit breaker: reject if a previous trigger paused
+        // withdrawals (#1362).
+        vault::ensure_withdrawals_enabled(env)?;
+
         let claimable = vault
             .total_amount
             .checked_sub(vault.claimed_amount)
@@ -2839,6 +2847,10 @@ impl TokenFactory {
         if claimable <= 0 {
             return Err(Error::NothingToClaim);
         }
+
+        // Record the withdrawal against the per-epoch limit and trip the
+        // breaker if the cumulative volume reaches the cap (#1362).
+        vault::record_withdrawal(env, claimable)?;
 
         // State update before external call (CEI pattern)
         vault.claimed_amount = vault.total_amount;
@@ -2893,6 +2905,52 @@ impl TokenFactory {
         events::emit_vault_cancelled(&env, vault_id, &actor, remaining_amount);
 
         Ok(())
+    }
+
+    /// Configure the per-epoch vault withdrawal circuit breaker limit (admin only, #1362).
+    ///
+    /// The limit caps the cumulative volume of vault withdrawals allowed within
+    /// a single epoch. When the cumulative epoch volume reaches `limit`,
+    /// withdrawals are paused and a `VaultCircuitBreakerTriggered` event is
+    /// emitted. Pass `limit = 0` to disable the breaker entirely.
+    ///
+    /// # Arguments
+    /// * `env` - The contract environment
+    /// * `admin` - Admin address (must authorize and match stored admin)
+    /// * `limit` - Per-epoch withdrawal cap (`0` disables the limit)
+    ///
+    /// # Errors
+    /// * `Error::Unauthorized` - Caller is not the admin
+    /// * `Error::InvalidParameters` - `limit` is negative
+    pub fn set_vault_withdraw_limit(env: Env, admin: Address, limit: i128) -> Result<(), Error> {
+        vault::set_vault_withdraw_limit(&env, &admin, limit)
+    }
+
+    /// Read the configured per-epoch vault withdrawal limit (`0` = disabled, #1362).
+    pub fn get_vault_withdraw_limit(env: Env) -> i128 {
+        storage::get_vault_withdraw_limit(&env)
+    }
+
+    /// Whether vault withdrawals are currently paused by the circuit breaker (#1362).
+    pub fn is_vault_circuit_breaker_paused(env: Env) -> bool {
+        storage::get_vault_circuit_breaker_paused(&env)
+    }
+
+    /// Manually resume vault withdrawals after a circuit breaker trigger (admin only, #1362).
+    ///
+    /// Intended to be called after governance/admin has reviewed the situation
+    /// that tripped the breaker. Clears the paused flag so vault withdrawals can
+    /// proceed again; the per-epoch volume counter is unchanged and continues to
+    /// reset at the next epoch boundary.
+    ///
+    /// # Arguments
+    /// * `env` - The contract environment
+    /// * `admin` - Admin address (must authorize and match stored admin)
+    ///
+    /// # Errors
+    /// * `Error::Unauthorized` - Caller is not the admin
+    pub fn resume_vault(env: Env, admin: Address) -> Result<(), Error> {
+        vault::resume_vault(&env, &admin)
     }
 
     /// Mark a vault's milestone as verified (#1133).

--- a/contracts/token-factory/src/storage.rs
+++ b/contracts/token-factory/src/storage.rs
@@ -1117,6 +1117,58 @@ pub fn get_creator_vault_count(env: &Env, creator: &Address) -> u32 {
         .unwrap_or(0)
 }
 
+// ── Vault circuit breaker storage ─────────────────────────────────────────
+
+/// Default epoch length in ledgers (~1 day at 5s/ledger)
+pub const DEFAULT_EPOCH_LEDGERS: u32 = 17_280;
+
+/// Current epoch number derived from ledger sequence.
+pub fn current_epoch(env: &Env) -> u32 {
+    env.ledger().sequence() / DEFAULT_EPOCH_LEDGERS
+}
+
+/// Cumulative withdrawal volume for the given epoch.
+pub fn get_epoch_withdraw_volume(env: &Env, epoch: u32) -> i128 {
+    env.storage()
+        .temporary()
+        .get(&DataKey::EpochWithdrawVolume(epoch))
+        .unwrap_or(0_i128)
+}
+
+pub fn set_epoch_withdraw_volume(env: &Env, epoch: u32, volume: i128) {
+    env.storage()
+        .temporary()
+        .set(&DataKey::EpochWithdrawVolume(epoch), &volume);
+}
+
+/// Per-epoch withdrawal limit (0 = unlimited / not set).
+pub fn get_vault_withdraw_limit(env: &Env) -> i128 {
+    env.storage()
+        .instance()
+        .get(&DataKey::VaultWithdrawLimit)
+        .unwrap_or(0_i128)
+}
+
+pub fn set_vault_withdraw_limit(env: &Env, limit: i128) {
+    env.storage()
+        .instance()
+        .set(&DataKey::VaultWithdrawLimit, &limit);
+}
+
+/// Whether vault withdrawals are paused by the circuit breaker.
+pub fn get_vault_circuit_breaker_paused(env: &Env) -> bool {
+    env.storage()
+        .instance()
+        .get(&DataKey::VaultCircuitBreakerPaused)
+        .unwrap_or(false)
+}
+
+pub fn set_vault_circuit_breaker_paused(env: &Env, paused: bool) {
+    env.storage()
+        .instance()
+        .set(&DataKey::VaultCircuitBreakerPaused, &paused);
+}
+
 /// Get a page of vaults in ascending vault_id order
 ///
 /// # Parameters

--- a/contracts/token-factory/src/types.rs
+++ b/contracts/token-factory/src/types.rs
@@ -625,6 +625,12 @@ pub enum DataKey {
     OwnerVaultCount(Address),
     VaultByCreator(Address, u32),
     CreatorVaultCount(Address),
+    /// Cumulative withdrawal volume for the current epoch (keyed by epoch number)
+    EpochWithdrawVolume(u32),
+    /// Admin-configured per-epoch withdrawal limit
+    VaultWithdrawLimit,
+    /// Whether vault withdrawals are paused by the circuit breaker
+    VaultCircuitBreakerPaused,
     PendingAdmin,
     BuybackCampaign(u64),
     BuybackCampaignCount,
@@ -991,6 +997,8 @@ impl Error {
     pub const DistributionAlreadyClaimed: Self = Self(103);
     pub const DistributionAlreadyReclaimed: Self = Self(104);
     pub const DistributionZeroSupply: Self = Self(105);
+    // Per-epoch vault withdrawal circuit breaker (#1362)
+    pub const VaultCircuitBreakerActive: Self = Self(106);
 }
 
 impl From<Error> for soroban_sdk::Error {

--- a/contracts/token-factory/src/vault.rs
+++ b/contracts/token-factory/src/vault.rs
@@ -8,6 +8,76 @@ use crate::{
 };
 use soroban_sdk::{symbol_short, Address, Env};
 
+// ── Circuit breaker public API ────────────────────────────────────────────────
+
+/// Set the per-epoch withdrawal limit (admin only).
+/// Pass `0` to disable the limit.
+pub fn set_vault_withdraw_limit(env: &Env, admin: &Address, limit: i128) -> Result<(), Error> {
+    admin.require_auth();
+    let current_admin = storage::get_admin(env);
+    if *admin != current_admin {
+        return Err(Error::Unauthorized);
+    }
+    if limit < 0 {
+        return Err(Error::InvalidParameters);
+    }
+    storage::set_vault_withdraw_limit(env, limit);
+    Ok(())
+}
+
+/// Manually resume vault withdrawals after a circuit breaker trigger (admin only).
+pub fn resume_vault(env: &Env, admin: &Address) -> Result<(), Error> {
+    admin.require_auth();
+    let current_admin = storage::get_admin(env);
+    if *admin != current_admin {
+        return Err(Error::Unauthorized);
+    }
+    storage::set_vault_circuit_breaker_paused(env, false);
+    env.events().publish(
+        (symbol_short!("vlt_rsm"), symbol_short!("v1")),
+        admin.clone(),
+    );
+    Ok(())
+}
+
+/// Reject the call if the per-epoch circuit breaker has paused withdrawals.
+///
+/// Shared by both the module-level `claim_vault` and the contract's
+/// `claim_vault` entry point so the protection is enforced on every
+/// withdrawal path.
+pub fn ensure_withdrawals_enabled(env: &Env) -> Result<(), Error> {
+    if storage::get_vault_circuit_breaker_paused(env) {
+        return Err(Error::VaultCircuitBreakerActive);
+    }
+    Ok(())
+}
+
+/// Record a withdrawal of `amount` against the current epoch's cumulative
+/// volume and trip the circuit breaker if the configured per-epoch limit is
+/// reached.
+///
+/// When the limit is set to `0` the breaker is disabled and withdrawals are
+/// never capped. The epoch counter is keyed by epoch number, so volume resets
+/// automatically at each epoch boundary.
+pub fn record_withdrawal(env: &Env, amount: i128) -> Result<(), Error> {
+    let limit = storage::get_vault_withdraw_limit(env);
+    if limit > 0 {
+        let epoch = storage::current_epoch(env);
+        let new_volume = storage::get_epoch_withdraw_volume(env, epoch)
+            .checked_add(amount)
+            .ok_or(Error::ArithmeticError)?;
+        storage::set_epoch_withdraw_volume(env, epoch, new_volume);
+        if new_volume >= limit {
+            storage::set_vault_circuit_breaker_paused(env, true);
+            env.events().publish(
+                (symbol_short!("vlt_cb"), symbol_short!("v1")),
+                (epoch, new_volume, limit),
+            );
+        }
+    }
+    Ok(())
+}
+
 /// Fund a vault with tokens.
 ///
 /// Safety checks:
@@ -107,6 +177,10 @@ pub fn claim_vault(
         return Err(Error::MilestoneUnauthorized);
     }
 
+    // ── Circuit breaker ───────────────────────────────────────────────────────
+    // Reject if withdrawals are paused by a previous circuit breaker trigger.
+    ensure_withdrawals_enabled(env)?;
+
     // Calculate claimable amount
     let claimable = vault.total_amount
         .checked_sub(vault.claimed_amount)
@@ -116,6 +190,10 @@ pub fn claim_vault(
     if claimable <= 0 {
         return Err(Error::NothingToClaim);
     }
+
+    // Track this withdrawal against the per-epoch limit and trip the breaker
+    // if the cumulative volume reaches the configured cap.
+    record_withdrawal(env, claimable)?;
 
     // Update claimed amount with checked arithmetic
     vault.claimed_amount = vault.claimed_amount
@@ -278,7 +356,6 @@ mod tests {
         assert_eq!(event_funder, funder);
         assert_eq!(event_amount, amount);
     }
-}
 
     // ============================================================================
     // Claim Vault Tests

--- a/contracts/token-factory/src/vault_circuit_breaker_test.rs
+++ b/contracts/token-factory/src/vault_circuit_breaker_test.rs
@@ -1,0 +1,231 @@
+//! Per-epoch vault withdrawal circuit breaker tests (issue #1362).
+
+#![cfg(test)]
+
+use super::*;
+use crate::storage;
+use crate::types::{Error, Vault, VaultStatus};
+use crate::vault;
+use soroban_sdk::{
+    testutils::{Address as _, Events, Ledger},
+    Address, BytesN, Env, Symbol, TryFromVal,
+};
+
+fn seed_vault(env: &Env, vault_id: u64, owner: &Address, amount: i128) {
+    let v = Vault {
+        id: vault_id,
+        token: Address::generate(env),
+        owner: owner.clone(),
+        creator: Address::generate(env),
+        total_amount: amount,
+        claimed_amount: 0,
+        unlock_time: 0,
+        milestone_hash: BytesN::from_array(env, &[0u8; 32]),
+        status: VaultStatus::Active,
+        created_at: 0,
+        verifier: None,
+        milestone_verified: false,
+    };
+    storage::set_vault(env, &v).unwrap();
+}
+
+fn setup() -> (Env, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    storage::set_admin(&env, &admin);
+    (env, admin)
+}
+
+// ── Normal operation under limit ──────────────────────────────────────────────
+
+#[test]
+fn test_claim_below_limit_succeeds() {
+    let (env, admin) = setup();
+    let owner = Address::generate(&env);
+    seed_vault(&env, 1, &owner, 500);
+
+    vault::set_vault_withdraw_limit(&env, &admin, 1_000).unwrap();
+
+    let claimed = vault::claim_vault(&env, 1, &owner).unwrap();
+    assert_eq!(claimed, 500);
+    assert!(!storage::get_vault_circuit_breaker_paused(&env));
+}
+
+#[test]
+fn test_claim_with_no_limit_set_succeeds() {
+    let (env, _admin) = setup();
+    let owner = Address::generate(&env);
+    seed_vault(&env, 1, &owner, 1_000_000);
+
+    let claimed = vault::claim_vault(&env, 1, &owner).unwrap();
+    assert_eq!(claimed, 1_000_000);
+    assert!(!storage::get_vault_circuit_breaker_paused(&env));
+}
+
+// ── Circuit breaker triggers at limit ────────────────────────────────────────
+
+#[test]
+fn test_circuit_breaker_triggers_at_limit() {
+    let (env, admin) = setup();
+    let owner = Address::generate(&env);
+    seed_vault(&env, 1, &owner, 1_000);
+
+    vault::set_vault_withdraw_limit(&env, &admin, 1_000).unwrap();
+
+    vault::claim_vault(&env, 1, &owner).unwrap();
+
+    // Circuit breaker should now be paused
+    assert!(storage::get_vault_circuit_breaker_paused(&env));
+}
+
+#[test]
+fn test_circuit_breaker_emits_event() {
+    let (env, admin) = setup();
+    let owner = Address::generate(&env);
+    seed_vault(&env, 1, &owner, 1_000);
+
+    vault::set_vault_withdraw_limit(&env, &admin, 1_000).unwrap();
+    vault::claim_vault(&env, 1, &owner).unwrap();
+
+    let events = env.events().all();
+    let has_cb_event = events.iter().any(|(_, topics, _)| {
+        topics
+            .get(0)
+            .and_then(|v| Symbol::try_from_val(&env, &v).ok())
+            .map(|s| s == Symbol::new(&env, "vlt_cb"))
+            .unwrap_or(false)
+    });
+    assert!(has_cb_event, "VaultCircuitBreakerTriggered event not emitted");
+}
+
+#[test]
+fn test_withdrawal_blocked_after_circuit_breaker() {
+    let (env, admin) = setup();
+
+    // First vault triggers circuit breaker
+    let owner1 = Address::generate(&env);
+    seed_vault(&env, 1, &owner1, 1_000);
+    vault::set_vault_withdraw_limit(&env, &admin, 1_000).unwrap();
+    vault::claim_vault(&env, 1, &owner1).unwrap();
+    assert!(storage::get_vault_circuit_breaker_paused(&env));
+
+    // Second vault is blocked
+    let owner2 = Address::generate(&env);
+    seed_vault(&env, 2, &owner2, 100);
+    let result = vault::claim_vault(&env, 2, &owner2);
+    assert_eq!(result, Err(Error::VaultCircuitBreakerActive));
+}
+
+// ── Multiple claims accumulate volume ────────────────────────────────────────
+
+#[test]
+fn test_cumulative_volume_tracked_across_claims() {
+    let (env, admin) = setup();
+    vault::set_vault_withdraw_limit(&env, &admin, 1_000).unwrap();
+
+    let epoch = storage::current_epoch(&env);
+
+    // Three claims of 300 each; limit is 1000
+    for id in 1u64..=3 {
+        let owner = Address::generate(&env);
+        seed_vault(&env, id, &owner, 300);
+        vault::claim_vault(&env, id, &owner).unwrap();
+    }
+
+    let volume = storage::get_epoch_withdraw_volume(&env, epoch);
+    assert_eq!(volume, 900);
+    assert!(!storage::get_vault_circuit_breaker_paused(&env));
+
+    // One more claim of 100 hits exactly 1000 → triggers
+    let owner = Address::generate(&env);
+    seed_vault(&env, 4, &owner, 100);
+    vault::claim_vault(&env, 4, &owner).unwrap();
+    assert!(storage::get_vault_circuit_breaker_paused(&env));
+}
+
+// ── Resume after manual review ────────────────────────────────────────────────
+
+#[test]
+fn test_admin_can_resume_after_circuit_breaker() {
+    let (env, admin) = setup();
+    let owner = Address::generate(&env);
+    seed_vault(&env, 1, &owner, 1_000);
+
+    vault::set_vault_withdraw_limit(&env, &admin, 1_000).unwrap();
+    vault::claim_vault(&env, 1, &owner).unwrap();
+    assert!(storage::get_vault_circuit_breaker_paused(&env));
+
+    vault::resume_vault(&env, &admin).unwrap();
+    assert!(!storage::get_vault_circuit_breaker_paused(&env));
+}
+
+#[test]
+fn test_claims_allowed_after_resume() {
+    let (env, admin) = setup();
+
+    let owner1 = Address::generate(&env);
+    seed_vault(&env, 1, &owner1, 1_000);
+    vault::set_vault_withdraw_limit(&env, &admin, 1_000).unwrap();
+    vault::claim_vault(&env, 1, &owner1).unwrap();
+
+    vault::resume_vault(&env, &admin).unwrap();
+
+    // New epoch so volume resets; but circuit breaker is unpaused so claim works
+    // Advance to next epoch to reset volume
+    let next_epoch_seq = (storage::current_epoch(&env) + 1) * storage::DEFAULT_EPOCH_LEDGERS;
+    env.ledger().with_mut(|li| li.sequence = next_epoch_seq);
+
+    let owner2 = Address::generate(&env);
+    seed_vault(&env, 2, &owner2, 500);
+    let result = vault::claim_vault(&env, 2, &owner2);
+    assert!(result.is_ok(), "claim should succeed after resume in new epoch");
+}
+
+#[test]
+fn test_non_admin_cannot_resume() {
+    let (env, admin) = setup();
+    let owner = Address::generate(&env);
+    seed_vault(&env, 1, &owner, 1_000);
+
+    vault::set_vault_withdraw_limit(&env, &admin, 1_000).unwrap();
+    vault::claim_vault(&env, 1, &owner).unwrap();
+
+    let attacker = Address::generate(&env);
+    let result = vault::resume_vault(&env, &attacker);
+    assert_eq!(result, Err(Error::Unauthorized));
+}
+
+#[test]
+fn test_non_admin_cannot_set_limit() {
+    let (env, _admin) = setup();
+    let attacker = Address::generate(&env);
+    let result = vault::set_vault_withdraw_limit(&env, &attacker, 500);
+    assert_eq!(result, Err(Error::Unauthorized));
+}
+
+// ── Epoch boundary resets volume ─────────────────────────────────────────────
+
+#[test]
+fn test_new_epoch_starts_fresh_volume() {
+    let (env, admin) = setup();
+    vault::set_vault_withdraw_limit(&env, &admin, 1_000).unwrap();
+
+    let owner1 = Address::generate(&env);
+    seed_vault(&env, 1, &owner1, 1_000);
+    vault::claim_vault(&env, 1, &owner1).unwrap();
+    assert!(storage::get_vault_circuit_breaker_paused(&env));
+
+    // Admin resumes and we advance to the next epoch
+    vault::resume_vault(&env, &admin).unwrap();
+    let next_epoch_seq = (storage::current_epoch(&env) + 1) * storage::DEFAULT_EPOCH_LEDGERS;
+    env.ledger().with_mut(|li| li.sequence = next_epoch_seq);
+
+    let new_epoch = storage::current_epoch(&env);
+    assert_eq!(storage::get_epoch_withdraw_volume(&env, new_epoch), 0);
+
+    // Fresh claim in new epoch should succeed (volume = 0 < limit 1000)
+    let owner2 = Address::generate(&env);
+    seed_vault(&env, 2, &owner2, 500);
+    assert!(vault::claim_vault(&env, 2, &owner2).is_ok());
+}


### PR DESCRIPTION
## Summary

Adds a per-epoch circuit breaker to the token-factory vault so large coordinated withdrawals can be capped and halted before governance can respond. The vault previously allowed unlimited deposits/withdrawals within a single epoch.

## What changed

- **Epoch volume tracking** — cumulative withdrawal volume is stored in temporary storage keyed by epoch number (`EpochWithdrawVolume(epoch)`), so it resets automatically at each epoch boundary. Epoch = `ledger_sequence / DEFAULT_EPOCH_LEDGERS` (~1 day at 5s/ledger).
- **Configurable limit** — admin-settable `VaultWithdrawLimit` instance key (`0` = unlimited / breaker disabled).
- **Trip behaviour** — when cumulative epoch volume reaches the limit, withdrawals are paused (`VaultCircuitBreakerPaused`) and a `vlt_cb` circuit-breaker-triggered event is emitted with `(epoch, volume, limit)`.
- **Manual resume** — `resume_vault(env, admin)` clears the paused flag after admin review and emits a resume event. The volume counter is untouched and still resets at the next epoch boundary.
- **Enforced on every withdrawal path** — shared helpers `vault::ensure_withdrawals_enabled` and `vault::record_withdrawal` are used by both the `vault` module's `claim_vault` and the contract-level `claim_vault` entry point (`claim_vault_inner`).
- **New contract entry points**: `set_vault_withdraw_limit`, `get_vault_withdraw_limit`, `is_vault_circuit_breaker_paused`, `resume_vault`.
- Added a dedicated `Error::VaultCircuitBreakerActive` (code 106).
- Wired the previously-orphaned `vault` module into the crate (`mod vault;`).

## Tests

`vault_circuit_breaker_test.rs` covers:
- normal operation below the limit, and with no limit set
- cumulative volume tracking across multiple claims
- circuit break exactly at the limit (+ event emission)
- withdrawals blocked while tripped
- admin resume + claims allowed after resume
- epoch-boundary volume reset
- authorization (non-admin cannot set limit or resume)

## Note on build state

The `token-factory` crate currently does **not** compile on `main` — there are ~75 pre-existing, unrelated errors across other modules (e.g. `freeze_functions`, `snapshot`, multisig events, `fractionalization`), plus a pre-existing parse error in `campaign.rs`. None of these originate from this change; I verified that no error span points at the files touched here. As a consequence `cargo test vault_circuit_breaker` cannot currently be executed end-to-end in the workspace. The new code is brace-balanced and self-consistent; wiring in the `vault` module required removing one stray brace in that module's pre-existing (never-compiled) inline test block.

Closes #1362