### PR TITLE
feat(contracts): circulating supply snapshot for dynamic governance quorum

### DIFF
--- a/contracts/token-factory/src/governance_dynamic_quorum_test.rs
+++ b/contracts/token-factory/src/governance_dynamic_quorum_test.rs
@@ -372,3 +372,178 @@ fn test_higher_participation_never_lowers_quorum_below_lower_participation() {
         assert!(q_high >= q_low, "higher participation must not lower quorum");
     });
 }
+
+// ── circulating supply snapshot tests ─────────────────────────────────────────
+
+#[cfg(test)]
+mod supply_snapshot_quorum_tests {
+    use crate::{
+        storage,
+        timelock::{create_proposal, finalize_proposal},
+        governance::initialize_governance,
+        types::{ActionType, Error, TokenInfo},
+        TokenFactory,
+    };
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger},
+        Address, Bytes, Env, String,
+    };
+
+    fn make_token_info(env: &Env, creator: &Address, supply: i128) -> TokenInfo {
+        TokenInfo {
+            address: Address::generate(env),
+            creator: creator.clone(),
+            name: String::from_str(env, "T"),
+            symbol: String::from_str(env, "T"),
+            decimals: 7,
+            total_supply: supply,
+            initial_supply: supply,
+            max_supply: None,
+            total_burned: 0,
+            burn_count: 0,
+            metadata_uri: None,
+            metadata_version: 0,
+            created_at: 0,
+            is_paused: false,
+            clawback_enabled: false,
+            freeze_enabled: false,
+        }
+    }
+
+    fn setup(env: &Env) -> (Address, Address) {
+        let contract_id = env.register_contract(None, TokenFactory);
+        let admin = Address::generate(env);
+        env.as_contract(&contract_id, || {
+            storage::set_admin(env, &admin);
+            storage::set_treasury(env, &Address::generate(env));
+            storage::set_base_fee(env, 1_000_000);
+            storage::set_metadata_fee(env, 500_000);
+            crate::timelock::initialize_timelock(env, Some(3600)).unwrap();
+            initialize_governance(env, Some(30), Some(51)).unwrap();
+        });
+        (admin, contract_id)
+    }
+
+    fn fee_payload(env: &Env) -> Bytes {
+        let mut b = Bytes::new(env);
+        // 32-byte payload: base_fee (i128 LE, 16B) || metadata_fee (i128 LE, 16B)
+        for byte in 1_000_000i128.to_le_bytes() { b.push_back(byte); }
+        for byte in 500_000i128.to_le_bytes()   { b.push_back(byte); }
+        b
+    }
+
+    /// Supply changes AFTER proposal creation must not affect the quorum threshold.
+    #[test]
+    fn test_supply_change_after_proposal_does_not_affect_quorum() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (admin, contract_id) = setup(&env);
+
+        env.as_contract(&contract_id, || {
+            // Seed a token with supply=1000 before creating the proposal
+            let creator = Address::generate(&env);
+            let mut info = make_token_info(&env, &creator, 1000);
+            // store at index 0
+            let idx = storage::increment_token_count(&env).unwrap() - 1;
+            storage::set_token_info(&env, idx, &info);
+
+            let t = env.ledger().timestamp();
+            let proposal_id = create_proposal(
+                &env, &admin, ActionType::FeeChange,
+                fee_payload(&env), t + 10, t + 86410, t + 90010,
+            ).unwrap();
+
+            // Snapshot should be 1000 (the supply at creation time)
+            let proposal = storage::get_proposal(&env, proposal_id).unwrap();
+            assert_eq!(proposal.circulating_supply_snapshot, 1000);
+
+            // Now inflate supply dramatically (simulates minting after snapshot)
+            info.total_supply = 1_000_000;
+            storage::set_token_info(&env, idx, &info);
+
+            // Quorum uses the snapshot (1000), not the current supply (1_000_000)
+            // 30% of 1000 = 300 votes needed.  Cast 350 For votes.
+            env.ledger().with_mut(|l| l.timestamp = t + 20);
+            let mut p = storage::get_proposal(&env, proposal_id).unwrap();
+            p.state = crate::types::ProposalState::Active;
+            p.votes_for = 350;
+            storage::set_proposal(&env, proposal_id, &p);
+
+            env.ledger().with_mut(|l| l.timestamp = t + 86411);
+            // Should succeed: 350/1000 = 35% ≥ 30% quorum, 100% approval ≥ 51%
+            finalize_proposal(&env, proposal_id).unwrap();
+            let finalized = storage::get_proposal(&env, proposal_id).unwrap();
+            assert_eq!(finalized.state, crate::types::ProposalState::Succeeded);
+        });
+    }
+
+    /// When supply is zero at proposal creation, quorum falls back gracefully.
+    #[test]
+    fn test_snapshot_zero_supply_fallback() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (admin, contract_id) = setup(&env);
+
+        env.as_contract(&contract_id, || {
+            // No tokens deployed — snapshot should be 0
+            let t = env.ledger().timestamp();
+            let proposal_id = create_proposal(
+                &env, &admin, ActionType::FeeChange,
+                fee_payload(&env), t + 10, t + 86410, t + 90010,
+            ).unwrap();
+
+            let proposal = storage::get_proposal(&env, proposal_id).unwrap();
+            assert_eq!(proposal.circulating_supply_snapshot, 0);
+
+            // With snapshot=0, eligible falls back to total_votes.max(1)
+            // Cast 1 For vote → 100% approval, quorum met via fallback
+            env.ledger().with_mut(|l| l.timestamp = t + 20);
+            let mut p = storage::get_proposal(&env, proposal_id).unwrap();
+            p.state = crate::types::ProposalState::Active;
+            p.votes_for = 1;
+            storage::set_proposal(&env, proposal_id, &p);
+
+            env.ledger().with_mut(|l| l.timestamp = t + 86411);
+            finalize_proposal(&env, proposal_id).unwrap();
+            let finalized = storage::get_proposal(&env, proposal_id).unwrap();
+            assert_eq!(finalized.state, crate::types::ProposalState::Succeeded);
+        });
+    }
+
+    /// Old proposals keep their snapshot; a new proposal sees the updated supply.
+    #[test]
+    fn test_old_proposal_keeps_its_snapshot() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (admin, contract_id) = setup(&env);
+
+        env.as_contract(&contract_id, || {
+            let creator = Address::generate(&env);
+            let mut info = make_token_info(&env, &creator, 500);
+            let idx = storage::increment_token_count(&env).unwrap() - 1;
+            storage::set_token_info(&env, idx, &info);
+
+            let t = env.ledger().timestamp();
+            let old_id = create_proposal(
+                &env, &admin, ActionType::FeeChange,
+                fee_payload(&env), t + 10, t + 86410, t + 90010,
+            ).unwrap();
+
+            // Double supply after first proposal
+            info.total_supply = 1000;
+            storage::set_token_info(&env, idx, &info);
+
+            env.ledger().with_mut(|l| l.timestamp = t + 1);
+            let new_id = create_proposal(
+                &env, &admin, ActionType::FeeChange,
+                fee_payload(&env), t + 20, t + 86420, t + 90020,
+            ).unwrap();
+
+            let old_proposal = storage::get_proposal(&env, old_id).unwrap();
+            let new_proposal = storage::get_proposal(&env, new_id).unwrap();
+
+            assert_eq!(old_proposal.circulating_supply_snapshot, 500);
+            assert_eq!(new_proposal.circulating_supply_snapshot, 1000);
+        });
+    }
+}

--- a/contracts/token-factory/src/timelock.rs
+++ b/contracts/token-factory/src/timelock.rs
@@ -534,6 +534,19 @@ pub fn create_proposal(
     let proposal_id = storage::get_next_proposal_id(env);
     storage::increment_proposal_count(env);
 
+    // Snapshot circulating supply (sum of total_supply across all deployed tokens)
+    // at proposal creation time so quorum is not affected by future supply changes.
+    let circulating_supply_snapshot: i128 = {
+        let token_count = storage::get_token_count(env);
+        let mut supply_sum: i128 = 0;
+        for i in 0..token_count {
+            if let Some(info) = storage::get_token_info(env, i) {
+                supply_sum = supply_sum.saturating_add(info.total_supply);
+            }
+        }
+        supply_sum
+    };
+
     // Create proposal
     let proposal = Proposal {
         id: proposal_id,
@@ -551,6 +564,7 @@ pub fn create_proposal(
         state: crate::types::ProposalState::Created,
         executed_at: None,
         cancelled_at: None,
+        circulating_supply_snapshot,
     };
 
     // Persist proposal
@@ -1154,17 +1168,12 @@ pub fn finalize_proposal(env: &Env, proposal_id: u64) -> Result<(), Error> {
     let config = storage::get_governance_config(env);
     let total_votes = proposal.votes_for + proposal.votes_against + proposal.votes_abstain;
 
-    // Token-weighted quorum: eligible weight = sum of all token total supplies.
-    // Falls back to vote count if no tokens have been deployed yet.
-    let total_eligible: i128 = {
-        let token_count = storage::get_token_count(env);
-        let mut supply_sum: i128 = 0;
-        for i in 0..token_count {
-            if let Some(info) = storage::get_token_info(env, i) {
-                supply_sum = supply_sum.saturating_add(info.total_supply);
-            }
-        }
-        if supply_sum > 0 { supply_sum } else { total_votes.max(1) }
+    // Use the circulating supply snapshotted at proposal creation as the quorum
+    // denominator. Fall back to vote count if no tokens existed at creation time.
+    let total_eligible: i128 = if proposal.circulating_supply_snapshot > 0 {
+        proposal.circulating_supply_snapshot
+    } else {
+        total_votes.max(1)
     };
 
     let quorum_met = crate::governance::is_quorum_met(

--- a/contracts/token-factory/src/types.rs
+++ b/contracts/token-factory/src/types.rs
@@ -1101,6 +1101,10 @@ pub struct Proposal {
     pub state: ProposalState,
     pub executed_at: Option<u64>,
     pub cancelled_at: Option<u64>,
+    /// Circulating supply (sum of all token `total_supply`) snapshotted at proposal
+    /// creation time. Used as the denominator for quorum calculations so that
+    /// supply changes after creation do not affect the quorum requirement.
+    pub circulating_supply_snapshot: i128,
 }
 
 /// Pagination cursor for token queries


### PR DESCRIPTION
## Summary

Fixes the issue where governance quorum was calculated against live total supply, allowing post-proposal mints/burns to change the quorum threshold for an already-created proposal.

## Changes

**`contracts/token-factory/src/types.rs`**
- Added `circulating_supply_snapshot: i128` field to `Proposal` struct — stores the sum of all token `total_supply` values at the moment the proposal is created

**`contracts/token-factory/src/timelock.rs`** — `create_proposal`
- Sums `total_supply` across all deployed tokens at proposal creation time and stores it as `circulating_supply_snapshot`

**`contracts/token-factory/src/timelock.rs`** — `finalize_proposal`
- Replaced the live supply re-computation loop with `proposal.circulating_supply_snapshot`
- Falls back to `total_votes.max(1)` when snapshot is zero (no tokens deployed at creation time)

**`contracts/token-factory/src/governance_dynamic_quorum_test.rs`**
- `test_supply_change_after_proposal_does_not_affect_quorum` — inflating supply after creation still uses the snapshot for quorum
- `test_snapshot_zero_supply_fallback` — zero snapshot falls back gracefully and proposal can still pass
- `test_old_proposal_keeps_its_snapshot` — two proposals created at different supply levels each keep their own snapshot

## Quorum formula

```
eligible = proposal.circulating_supply_snapshot   (or total_votes if snapshot == 0)
quorum_met = (total_votes / eligible) * 100 >= config.quorum_percent
```

## Testing

```bash
cargo test governance_dynamic_quorum -- --nocapture
```

Closes #1364