### PR TITLE
feat(contracts): FIFO execution queue with dependency resolution for governance proposals

### DIFF
--- a/backend/src/graphql/resolvers.ts
+++ b/backend/src/graphql/resolvers.ts
@@ -119,6 +119,25 @@ export const resolvers = {
       return bigintToString(rows);
     },
 
+    /**
+     * Current FIFO execution queue: queued proposals ordered by queue time.
+     *
+     * Proposals of the same `proposalType` execute in the order they were
+     * queued (FIFO); different types are independent. The returned list is
+     * ordered by `createdAt` ascending so the array index is the execution
+     * position within each type. Optionally narrowed to one `proposalType`.
+     */
+    async governanceQueue(_: unknown, args: { proposalType?: string }) {
+      const where: Record<string, unknown> = { status: "QUEUED" };
+      if (args.proposalType) where.proposalType = args.proposalType;
+
+      const rows = await prisma.proposal.findMany({
+        where,
+        orderBy: { createdAt: "asc" },
+      });
+      return bigintToString(rows);
+    },
+
     // ── Campaign ─────────────────────────────────────────────────────────────
 
     /** Fetch a single campaign by its on-chain campaignId. */
@@ -177,6 +196,28 @@ export const resolvers = {
         ...paginate(args),
       });
       return bigintToString(rows);
+    },
+
+    /**
+     * 0-based position of this proposal in the FIFO execution queue for its
+     * type. Computed as the number of QUEUED proposals of the same
+     * `proposalType` queued before it. Returns null unless the proposal is
+     * itself QUEUED.
+     */
+    async queuePosition(parent: {
+      status: string;
+      proposalType: string;
+      createdAt: Date | string;
+    }) {
+      if (parent.status !== "QUEUED") return null;
+      const ahead = await prisma.proposal.count({
+        where: {
+          status: "QUEUED",
+          proposalType: parent.proposalType as any,
+          createdAt: { lt: new Date(parent.createdAt) },
+        },
+      });
+      return ahead;
     },
   },
 };

--- a/backend/src/graphql/schema.ts
+++ b/backend/src/graphql/schema.ts
@@ -105,6 +105,11 @@ export const typeDefs = /* GraphQL */ `
     updatedAt: DateTime!
     executedAt: DateTime
     votes(limit: Int, offset: Int): [Vote!]!
+    """
+    0-based position of this proposal in the FIFO execution queue for its
+    proposalType. Only meaningful while status is QUEUED; null otherwise.
+    """
+    queuePosition: Int
   }
 
   type Vote {
@@ -183,6 +188,10 @@ export const typeDefs = /* GraphQL */ `
       limit: Int
       offset: Int
     ): [Proposal!]!
+
+    # Current FIFO execution queue (status = QUEUED), ordered by queue time.
+    # Optionally narrowed to a single proposalType.
+    governanceQueue(proposalType: ProposalType): [Proposal!]!
 
     # Campaign queries
     campaign(campaignId: Int!): Campaign

--- a/backend/src/routes/governance.ts
+++ b/backend/src/routes/governance.ts
@@ -418,6 +418,84 @@ router.get(
 
 /**
  * @openapi
+ * /api/governance/queue:
+ *   get:
+ *     summary: Get the current proposal execution queue
+ *     description: >
+ *       Returns queued proposals grouped by proposalType and ordered by queue
+ *       time (FIFO). Proposals of the same type execute in the order they were
+ *       queued; different types are independent. Each entry includes its
+ *       0-based execution position within its type.
+ *     tags: [Governance]
+ *     parameters:
+ *       - in: query
+ *         name: proposalType
+ *         schema:
+ *           type: string
+ *           enum: [PARAMETER_CHANGE, ADMIN_TRANSFER, TREASURY_SPEND, CONTRACT_UPGRADE, CUSTOM]
+ *     responses:
+ *       200:
+ *         description: Current execution queue grouped by type
+ *       400:
+ *         description: Validation error
+ *       500:
+ *         description: Server error
+ */
+router.get(
+  '/queue',
+  [
+    query('proposalType')
+      .optional()
+      .isIn(['PARAMETER_CHANGE', 'ADMIN_TRANSFER', 'TREASURY_SPEND', 'CONTRACT_UPGRADE', 'CUSTOM']),
+    validate,
+  ],
+  async (req: Request, res: Response) => {
+    try {
+      const { proposalType } = req.query;
+
+      const where: any = { status: 'QUEUED' };
+      if (proposalType) where.proposalType = proposalType;
+
+      // FIFO ordering: earliest-queued first.
+      const queued = await prisma.proposal.findMany({
+        where,
+        orderBy: { createdAt: 'asc' },
+      });
+
+      // Group by type and assign a 0-based position within each type queue.
+      const queues: Record<string, any[]> = {};
+      for (const p of queued) {
+        const list = (queues[p.proposalType] ??= []);
+        list.push({
+          proposalId: p.proposalId,
+          tokenId: p.tokenId,
+          title: p.title,
+          proposalType: p.proposalType,
+          status: p.status,
+          position: list.length,
+          queuedAt: p.createdAt,
+        });
+      }
+
+      res.json({
+        success: true,
+        data: {
+          total: queued.length,
+          queues,
+        },
+      });
+    } catch (error) {
+      console.error('Error fetching governance queue:', error);
+      res.status(500).json({
+        success: false,
+        error: 'Failed to fetch governance queue',
+      });
+    }
+  }
+);
+
+/**
+ * @openapi
  * /api/governance/stats:
  *   get:
  *     summary: Get governance statistics

--- a/contracts/token-factory/src/events.rs
+++ b/contracts/token-factory/src/events.rs
@@ -883,8 +883,40 @@ pub fn emit_queue_entry_removed(
     );
 }
 
+/// Emit a per-type FIFO queue entry-added event (#1366).
+///
+/// Published when a proposal is appended to its action-type FIFO execution
+/// queue. Topics: ("tq_add", proposal_id). Payload: (action_type, position).
+pub fn emit_type_queue_entry_added(
+    env: &Env,
+    proposal_id: u64,
+    action_type: crate::types::ActionType,
+    position: u32,
+) {
+    env.events().publish(
+        (symbol_short!("tq_add"), proposal_id),
+        (action_type, position),
+    );
+}
+
+/// Emit a per-type FIFO queue entry-removed event (#1366).
+///
+/// Published when a proposal is removed from its action-type FIFO queue,
+/// either because it executed or was cancelled.
+/// Topics: ("tq_rem", proposal_id). Payload: (action_type,).
+pub fn emit_type_queue_entry_removed(
+    env: &Env,
+    proposal_id: u64,
+    action_type: crate::types::ActionType,
+) {
+    env.events().publish(
+        (symbol_short!("tq_rem"), proposal_id),
+        (action_type,),
+    );
+}
+
 /// Emit enriched error detail event
-/// 
+///
 /// **Event Name**: err_det
 /// 
 /// **Topics** (indexed):

--- a/contracts/token-factory/src/lib.rs
+++ b/contracts/token-factory/src/lib.rs
@@ -37,6 +37,9 @@ mod pagination;
 mod payload_validation;
 #[cfg(feature = "legacy-tests")]
 mod proposal_queue;
+mod proposal_type_queue;
+#[cfg(test)]
+mod proposal_execution_queue_fifo_test;
 mod proposal_state_machine;
 mod storage;
 mod storage_migration;
@@ -3411,6 +3414,26 @@ impl TokenFactory {
 
     pub fn execute_proposal(env: Env, proposal_id: u64) -> Result<(), Error> {
         timelock::execute_proposal(&env, proposal_id)
+    }
+
+    /// Append a queued proposal to the FIFO execution queue for its action type
+    /// (#1366). Proposals of the same type then execute strictly in the order
+    /// they were enqueued. Returns the proposal's position in its type queue
+    /// (0 = front / next to execute).
+    pub fn enqueue_typed_proposal(env: Env, proposal_id: u64) -> Result<u32, Error> {
+        proposal_type_queue::enqueue(&env, proposal_id)
+    }
+
+    /// Return the ordered list of proposal ids queued for `action_type`.
+    /// Index 0 is the front of the queue (next eligible to execute).
+    pub fn get_type_queue(env: Env, action_type: types::ActionType) -> soroban_sdk::Vec<u64> {
+        proposal_type_queue::queue_for(&env, action_type)
+    }
+
+    /// Return the 0-based position of a proposal within its action-type FIFO
+    /// queue, or `None` if it is not currently enqueued.
+    pub fn get_proposal_queue_position(env: Env, proposal_id: u64) -> Option<u32> {
+        proposal_type_queue::position(&env, proposal_id)
     }
 
     pub fn get_proposal(env: Env, proposal_id: u64) -> Option<types::Proposal> {

--- a/contracts/token-factory/src/proposal_execution_queue_fifo_test.rs
+++ b/contracts/token-factory/src/proposal_execution_queue_fifo_test.rs
@@ -1,0 +1,224 @@
+//! FIFO execution queue with per-type dependency resolution (#1366).
+//!
+//! Governance proposals that mutate the same state must execute in a
+//! deterministic order. These tests exercise the per-[`ActionType`] FIFO queue:
+//!
+//! - **FIFO order enforced** — two same-type proposals must execute in the
+//!   order they were enqueued; executing the second before the first is
+//!   rejected with [`Error::ProposalNotAtQueueFront`].
+//! - **Cross-type independence** — proposals of different types live in
+//!   independent queues and execute without blocking one another.
+//! - Queue-position queries and the enqueue duplicate/state guards.
+
+#[cfg(test)]
+mod proposal_execution_queue_fifo_test {
+    use crate::proposal_type_queue;
+    use crate::storage;
+    use crate::test_helpers::{fee_change_payload, pause_payload};
+    use crate::timelock::{create_proposal, execute_proposal, queue_proposal, vote_proposal};
+    use crate::types::{ActionType, Error, ProposalState, VoteChoice};
+    use crate::TokenFactory;
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger},
+        Address, Bytes, Env, Vec,
+    };
+
+    // ── Harness ───────────────────────────────────────────────────────────
+
+    fn setup() -> (Env, Address, Address) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, TokenFactory);
+        let admin = Address::generate(&env);
+        env.as_contract(&contract_id, || {
+            storage::set_admin(&env, &admin);
+            storage::set_treasury(&env, &Address::generate(&env));
+            storage::set_base_fee(&env, 1_000_000);
+            storage::set_metadata_fee(&env, 500_000);
+            crate::timelock::initialize_timelock(&env, Some(3_600)).unwrap();
+        });
+        (env, contract_id, admin)
+    }
+
+    /// Create a proposal, pass it with a majority, advance past voting, and
+    /// queue it. Leaves the ledger at `end_time + 1` (before its eta) with the
+    /// proposal in `Queued` state. Returns its id.
+    fn make_queued(
+        env: &Env,
+        contract_id: &Address,
+        admin: &Address,
+        action_type: ActionType,
+        payload: Bytes,
+    ) -> u64 {
+        env.as_contract(contract_id, || {
+            let now = env.ledger().timestamp();
+            let start = now + 10;
+            let end = start + 1_000;
+            let eta = end + 10_000; // generous timelock so etas don't elapse early
+
+            let id = create_proposal(env, admin, action_type, payload, start, end, eta).unwrap();
+
+            // Vote during the active window: 2 for, 1 against → passes.
+            env.ledger().with_mut(|l| l.timestamp = start + 1);
+            vote_proposal(env, &Address::generate(env), id, VoteChoice::For).unwrap();
+            vote_proposal(env, &Address::generate(env), id, VoteChoice::For).unwrap();
+            vote_proposal(env, &Address::generate(env), id, VoteChoice::Against).unwrap();
+
+            // Advance past voting end and queue.
+            env.ledger().with_mut(|l| l.timestamp = end + 1);
+            queue_proposal(env, id).unwrap();
+
+            assert_eq!(storage::get_proposal(env, id).unwrap().state, ProposalState::Queued);
+            id
+        })
+    }
+
+    fn enq(env: &Env, contract_id: &Address, id: u64) -> Result<u32, Error> {
+        env.as_contract(contract_id, || proposal_type_queue::enqueue(env, id))
+    }
+
+    fn exec(env: &Env, contract_id: &Address, id: u64) -> Result<(), Error> {
+        env.as_contract(contract_id, || execute_proposal(env, id))
+    }
+
+    fn pos(env: &Env, contract_id: &Address, id: u64) -> Option<u32> {
+        env.as_contract(contract_id, || proposal_type_queue::position(env, id))
+    }
+
+    fn queue_ids(env: &Env, contract_id: &Address, action_type: ActionType) -> Vec<u64> {
+        env.as_contract(contract_id, || proposal_type_queue::queue_for(env, action_type))
+    }
+
+    fn state(env: &Env, contract_id: &Address, id: u64) -> ProposalState {
+        env.as_contract(contract_id, || storage::get_proposal(env, id).unwrap().state)
+    }
+
+    fn advance_past_etas(env: &Env) {
+        env.ledger().with_mut(|l| l.timestamp += 1_000_000);
+    }
+
+    fn fee(env: &Env) -> Bytes {
+        fee_change_payload(env, 2_000_000, 1_000_000)
+    }
+
+    // ── FIFO ordering for same-type proposals ────────────────────────────
+
+    #[test]
+    fn test_same_type_executes_in_fifo_order() {
+        let (env, contract_id, admin) = setup();
+
+        // Two fee-update proposals; `first` is queued before `second`.
+        let first = make_queued(&env, &contract_id, &admin, ActionType::FeeChange, fee(&env));
+        let second = make_queued(&env, &contract_id, &admin, ActionType::FeeChange, fee(&env));
+
+        assert_eq!(enq(&env, &contract_id, first).unwrap(), 0);
+        assert_eq!(enq(&env, &contract_id, second).unwrap(), 1);
+
+        advance_past_etas(&env);
+
+        // The second proposal cannot jump the queue.
+        assert_eq!(
+            exec(&env, &contract_id, second),
+            Err(Error::ProposalNotAtQueueFront)
+        );
+        assert_eq!(state(&env, &contract_id, second), ProposalState::Queued);
+
+        // The front proposal executes and is removed, promoting `second`.
+        exec(&env, &contract_id, first).unwrap();
+        assert_eq!(state(&env, &contract_id, first), ProposalState::Executed);
+        assert_eq!(pos(&env, &contract_id, second), Some(0));
+
+        // Now the second proposal may execute.
+        exec(&env, &contract_id, second).unwrap();
+        assert_eq!(state(&env, &contract_id, second), ProposalState::Executed);
+        assert_eq!(queue_ids(&env, &contract_id, ActionType::FeeChange).len(), 0);
+    }
+
+    // ── Cross-type proposals are independent ─────────────────────────────
+
+    #[test]
+    fn test_different_types_execute_independently() {
+        let (env, contract_id, admin) = setup();
+
+        // Two fee proposals (same queue) and one pause proposal (separate queue).
+        let fee1 = make_queued(&env, &contract_id, &admin, ActionType::FeeChange, fee(&env));
+        let fee2 = make_queued(&env, &contract_id, &admin, ActionType::FeeChange, fee(&env));
+        let pause =
+            make_queued(&env, &contract_id, &admin, ActionType::PauseContract, pause_payload(&env));
+
+        enq(&env, &contract_id, fee1).unwrap();
+        enq(&env, &contract_id, fee2).unwrap();
+        enq(&env, &contract_id, pause).unwrap();
+
+        advance_past_etas(&env);
+
+        // The pause proposal is the sole entry in its own type queue, so it can
+        // execute even though the fee queue still has fee1 ahead of fee2.
+        exec(&env, &contract_id, pause).unwrap();
+        assert_eq!(state(&env, &contract_id, pause), ProposalState::Executed);
+
+        // The fee queue is untouched by the pause execution: fee1 still front,
+        // and fee2 is still blocked behind it.
+        assert_eq!(pos(&env, &contract_id, fee1), Some(0));
+        assert_eq!(pos(&env, &contract_id, fee2), Some(1));
+        assert_eq!(
+            exec(&env, &contract_id, fee2),
+            Err(Error::ProposalNotAtQueueFront)
+        );
+
+        exec(&env, &contract_id, fee1).unwrap();
+        exec(&env, &contract_id, fee2).unwrap();
+        assert_eq!(state(&env, &contract_id, fee1), ProposalState::Executed);
+        assert_eq!(state(&env, &contract_id, fee2), ProposalState::Executed);
+    }
+
+    // ── enqueue guards ───────────────────────────────────────────────────
+
+    #[test]
+    fn test_enqueue_duplicate_rejected() {
+        let (env, contract_id, admin) = setup();
+        let id = make_queued(&env, &contract_id, &admin, ActionType::FeeChange, fee(&env));
+        enq(&env, &contract_id, id).unwrap();
+        assert_eq!(enq(&env, &contract_id, id), Err(Error::InvalidParameters));
+    }
+
+    #[test]
+    fn test_enqueue_non_queued_proposal_rejected() {
+        let (env, contract_id, admin) = setup();
+        // Created but never voted/queued → still in a non-Queued state.
+        let id = env.as_contract(&contract_id, || {
+            let now = env.ledger().timestamp();
+            create_proposal(
+                &env,
+                &admin,
+                ActionType::FeeChange,
+                fee(&env),
+                now + 10,
+                now + 1_000,
+                now + 11_000,
+            )
+            .unwrap()
+        });
+        assert_eq!(enq(&env, &contract_id, id), Err(Error::InvalidParameters));
+    }
+
+    #[test]
+    fn test_enqueue_nonexistent_proposal_rejected() {
+        let (env, contract_id, _admin) = setup();
+        assert_eq!(enq(&env, &contract_id, 999), Err(Error::ProposalNotFound));
+    }
+
+    // ── Backward compatibility: non-enqueued proposals are unconstrained ─
+
+    #[test]
+    fn test_non_enqueued_proposal_executes_without_fifo_constraint() {
+        let (env, contract_id, admin) = setup();
+        // Queued but deliberately NOT placed in the type queue.
+        let id = make_queued(&env, &contract_id, &admin, ActionType::FeeChange, fee(&env));
+        assert_eq!(pos(&env, &contract_id, id), None);
+
+        advance_past_etas(&env);
+        exec(&env, &contract_id, id).unwrap();
+        assert_eq!(state(&env, &contract_id, id), ProposalState::Executed);
+    }
+}

--- a/contracts/token-factory/src/proposal_type_queue.rs
+++ b/contracts/token-factory/src/proposal_type_queue.rs
@@ -1,0 +1,165 @@
+//! Per-type FIFO execution queue for governance proposals (#1366).
+//!
+//! Time-locked proposals that mutate the *same* piece of state (for example two
+//! consecutive fee-update proposals) must execute in a deterministic order,
+//! otherwise the final state depends on the order in which `execute_proposal`
+//! happens to be called. To guarantee determinism this module keeps one
+//! ordered list of proposal ids per [`ActionType`]:
+//!
+//! - Proposals of the **same** type execute strictly in the order they were
+//!   enqueued (FIFO). `execute_proposal` only permits the proposal at the front
+//!   of its type queue to run.
+//! - Proposals of **different** types live in independent queues and can be
+//!   executed in any relative order — they touch disjoint state.
+//!
+//! # Storage layout
+//! - [`DataKey::ProposalTypeQueue(action_type)`] → `Vec<u64>` ordered list of
+//!   queued proposal ids; index `0` is the front (next to execute).
+//!
+//! # Relationship to [`crate::timelock`]
+//! Enqueueing is a separate, explicit step performed after a proposal reaches
+//! the [`ProposalState::Queued`] state (mirroring the existing
+//! `proposal_queue` priority-queue design). A proposal that is never enqueued
+//! into its type queue is unconstrained by FIFO ordering, which keeps purely
+//! time-based execution paths unaffected.
+
+use crate::events;
+use crate::storage;
+use crate::types::{ActionType, DataKey, Error, ProposalState};
+use soroban_sdk::{Env, Vec};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Storage helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Return the FIFO queue (ordered list of proposal ids) for `action_type`.
+///
+/// Returns an empty vector if nothing of this type has been enqueued.
+pub fn queue_for(env: &Env, action_type: ActionType) -> Vec<u64> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::ProposalTypeQueue(action_type))
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+fn set_queue(env: &Env, action_type: ActionType, queue: &Vec<u64>) {
+    let key = DataKey::ProposalTypeQueue(action_type);
+    if queue.is_empty() {
+        env.storage().persistent().remove(&key);
+    } else {
+        env.storage().persistent().set(&key, queue);
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public API
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Append a queued proposal to the FIFO execution queue for its action type.
+///
+/// The proposal must already be in [`ProposalState::Queued`] state (i.e.
+/// `timelock::queue_proposal` must have been called first).
+///
+/// # Returns
+/// The 0-based position the proposal occupies in its type queue. A return value
+/// of `0` means the proposal is at the front and may be executed immediately
+/// once its timelock (`eta`) has elapsed.
+///
+/// # Errors
+/// * [`Error::ProposalNotFound`]  – proposal does not exist
+/// * [`Error::InvalidParameters`] – proposal is not in `Queued` state, or it is
+///   already present in its type queue (duplicate)
+pub fn enqueue(env: &Env, proposal_id: u64) -> Result<u32, Error> {
+    let proposal = storage::get_proposal(env, proposal_id).ok_or(Error::ProposalNotFound)?;
+
+    if proposal.state != ProposalState::Queued {
+        return Err(Error::InvalidParameters);
+    }
+
+    let action_type = proposal.action_type;
+    let mut queue = queue_for(env, action_type);
+
+    // Guard against duplicate entries.
+    for id in queue.iter() {
+        if id == proposal_id {
+            return Err(Error::InvalidParameters);
+        }
+    }
+
+    queue.push_back(proposal_id);
+    let position = queue.len() - 1;
+    set_queue(env, action_type, &queue);
+
+    events::emit_type_queue_entry_added(env, proposal_id, action_type, position);
+
+    Ok(position)
+}
+
+/// Return the front (next-to-execute) proposal id for `action_type`, if any.
+pub fn front(env: &Env, action_type: ActionType) -> Option<u64> {
+    queue_for(env, action_type).get(0)
+}
+
+/// Return the 0-based position of `proposal_id` within its type queue.
+///
+/// Returns `None` if the proposal does not exist or is not currently enqueued.
+pub fn position(env: &Env, proposal_id: u64) -> Option<u32> {
+    let proposal = storage::get_proposal(env, proposal_id)?;
+    let queue = queue_for(env, proposal.action_type);
+    for (i, id) in queue.iter().enumerate() {
+        if id == proposal_id {
+            return Some(i as u32);
+        }
+    }
+    None
+}
+
+/// Enforce the FIFO invariant for `proposal_id` ahead of execution.
+///
+/// If the proposal is enqueued in its type queue it must be at the front
+/// (index 0); otherwise execution is rejected. A proposal that is *not*
+/// enqueued is unconstrained and passes this check, leaving non-FIFO execution
+/// paths unaffected.
+///
+/// # Errors
+/// * [`Error::ProposalNotAtQueueFront`] – proposal is enqueued but not at front
+pub fn enforce_front(env: &Env, proposal_id: u64) -> Result<(), Error> {
+    match position(env, proposal_id) {
+        Some(0) => Ok(()),
+        Some(_) => Err(Error::ProposalNotAtQueueFront),
+        None => Ok(()), // not enqueued → no FIFO constraint
+    }
+}
+
+/// Remove `proposal_id` from its type queue, regardless of position.
+///
+/// Called when a proposal is executed (it is always the front entry at that
+/// point) or cancelled. A no-op if the proposal is not enqueued.
+pub fn remove(env: &Env, proposal_id: u64) {
+    let proposal = match storage::get_proposal(env, proposal_id) {
+        Some(p) => p,
+        None => return,
+    };
+    let action_type = proposal.action_type;
+    let queue = queue_for(env, action_type);
+
+    let mut next: Vec<u64> = Vec::new(env);
+    let mut removed = false;
+    for id in queue.iter() {
+        if id == proposal_id && !removed {
+            removed = true;
+            continue;
+        }
+        next.push_back(id);
+    }
+
+    if removed {
+        set_queue(env, action_type, &next);
+        events::emit_type_queue_entry_removed(env, proposal_id, action_type);
+    }
+}
+
+/// Number of proposals currently enqueued for `action_type`.
+pub fn queue_len(env: &Env, action_type: ActionType) -> u32 {
+    queue_for(env, action_type).len()
+}

--- a/contracts/token-factory/src/timelock.rs
+++ b/contracts/token-factory/src/timelock.rs
@@ -612,6 +612,10 @@ pub fn cancel_proposal(env: &Env, caller: &Address, proposal_id: u64) -> Result<
     proposal.cancelled_at = Some(env.ledger().timestamp());
     storage::set_proposal(env, proposal_id, &proposal);
 
+    // Drop the proposal from its per-type FIFO queue so it no longer blocks
+    // later same-type proposals (#1366). No-op if it was never enqueued.
+    crate::proposal_type_queue::remove(env, proposal_id);
+
     events::emit_proposal_cancelled(env, proposal_id, caller);
 
     Ok(())
@@ -1313,6 +1317,12 @@ pub fn execute_proposal(env: &Env, proposal_id: u64) -> Result<(), Error> {
         return Err(Error::TimelockNotExpired);
     }
 
+    // FIFO ordering (#1366): if this proposal was placed in its action-type
+    // execution queue, only the front-of-queue entry may execute. Proposals of
+    // the same type therefore execute in the order they were queued; proposals
+    // of different types are in independent queues and are unaffected.
+    crate::proposal_type_queue::enforce_front(env, proposal_id)?;
+
     // Emit event signalling the proposal is now executable (timelock elapsed)
     events::emit_proposal_executable(env, proposal_id, proposal.eta);
 
@@ -1360,6 +1370,11 @@ pub fn execute_proposal(env: &Env, proposal_id: u64) -> Result<(), Error> {
     proposal.state = crate::types::ProposalState::Executed;
     proposal.executed_at = Some(current_time);
     storage::set_proposal(env, proposal_id, &proposal);
+
+    // Advance the per-type FIFO queue: remove the just-executed front entry so
+    // the next proposal of this type becomes executable (#1366). No-op for
+    // proposals that were never enqueued.
+    crate::proposal_type_queue::remove(env, proposal_id);
 
     events::emit_proposal_executed(env, proposal_id, &proposal.proposer, true);
 

--- a/contracts/token-factory/src/types.rs
+++ b/contracts/token-factory/src/types.rs
@@ -680,6 +680,9 @@ pub enum DataKey {
     MetadataContentHash(u32),
     /// Pending vault-owner change: vault_id → (new_owner, approvals_bitmap)
     PendingVaultOwnerChange(u64),
+    /// FIFO execution queue of proposal ids for a given action type (#1366).
+    /// Stores an ordered `Vec<u64>`; index 0 is the front (next to execute).
+    ProposalTypeQueue(ActionType),
 }
 
 /// A point-in-time record of a token holder's balance.
@@ -975,6 +978,9 @@ impl Error {
     pub const VaultOwnerChangePending: Self = Self(97);
     pub const VaultOwnerChangeNotFound: Self = Self(98);
     pub const VaultOwnerChangeAlreadyApproved: Self = Self(99);
+    /// Attempted to execute a proposal that is not at the front of its
+    /// per-type FIFO execution queue (#1366).
+    pub const ProposalNotAtQueueFront: Self = Self(100);
 }
 
 impl From<Error> for soroban_sdk::Error {


### PR DESCRIPTION
## Summary

Implements a per-type FIFO execution queue with dependency resolution for governance proposals (Issue #1366). Previously, multiple queued proposals could execute in any order, so two proposals that mutate the same state (e.g. two fee-update proposals) could produce different final states depending on execution order. This change makes same-type execution deterministic while keeping different types independent.

## Behavior

- **FIFO per type** — a new ordered list of proposal ids is kept per `ActionType`. Proposals of the same type execute strictly in the order they were enqueued.
- **Cross-type independence** — different action types live in independent queues and can execute in any relative order (they touch disjoint state).
- **Front-of-queue enforcement** — `execute_proposal` only permits the front entry of a proposal's type queue to run; out-of-order execution is rejected with `ProposalNotAtQueueFront`. On successful execution (or cancellation) the entry is removed, promoting the next proposal of that type.
- **Backward compatible** — enqueueing is an explicit step (mirroring the existing `proposal_queue` design). A proposal that is never enqueued is unconstrained, so existing/time-based execution paths are unaffected.

## Changes

### Contracts (`token-factory`)
- `types.rs` — `DataKey::ProposalTypeQueue(ActionType)` (ordered `Vec<u64>`, index 0 = front) and `Error::ProposalNotAtQueueFront` (code 100).
- `proposal_type_queue.rs` (new) — `enqueue`, `front`, `position`, `enforce_front`, `remove`, `queue_for`/`queue_len`, with FIFO ordering plus duplicate and `Queued`-state guards.
- `timelock.rs` — `execute_proposal` enforces front-of-queue before acting and pops the front on success; `cancel_proposal` removes its entry.
- `lib.rs` — `enqueue_typed_proposal`, `get_type_queue`, `get_proposal_queue_position` entry points.
- `events.rs` — `tq_add` / `tq_rem` queue events.
- `proposal_execution_queue_fifo_test.rs` (new) — same-type FIFO order enforced, cross-type independence, enqueue guards (duplicate / non-queued / nonexistent), and non-enqueued passthrough.

### Backend
- `routes/governance.ts` — `GET /api/governance/queue` returns queued proposals grouped by `proposalType`, ordered by queue time, each with its 0-based execution position (optional `proposalType` filter).
- GraphQL — new `governanceQueue(proposalType)` query and a `Proposal.queuePosition` field resolver exposing each proposal's position in its type queue.

## Testing
`cargo test proposal_execution_queue` exercises the FIFO and cross-type independence scenarios. Note: `cargo` is unavailable in my environment, so the Rust code was reviewed but not compiled here; the backend TypeScript type-checks clean (pre-existing errors in unrelated files only).

Closes #1366