### PR TITLE
feat(frontend): live vote count updates and quorum progress bar

### DIFF
--- a/backend/src/graphql/resolvers.ts
+++ b/backend/src/graphql/resolvers.ts
@@ -53,6 +53,7 @@ export const SUBSCRIPTION_TOPICS = {
   tokenDeployed: "token.deployed",
   burnExecuted: "burn.executed",
   proposalStatusChanged: "governance.proposal.statusChanged",
+  proposalVoteCast: "governance.proposal.voteCast",
   vaultMatured: "vault.matured",
 } as const;
 
@@ -96,6 +97,19 @@ export interface ProposalStatusChangedPayload extends TenantScopedPayload {
   tokenAddress: string;
   status: string;
   previousStatus?: string | null;
+  txHash: string;
+  timestamp: string;
+}
+
+export interface ProposalVoteCastPayload extends TenantScopedPayload {
+  proposalId: number;
+  tokenAddress: string;
+  voter: string;
+  support: boolean;
+  weight: string | bigint;
+  votesFor: string | bigint;
+  votesAgainst: string | bigint;
+  reason?: string | null;
   txHash: string;
   timestamp: string;
 }
@@ -373,6 +387,21 @@ export const resolvers = {
         ),
       resolve: (payload: ProposalStatusChangedPayload) =>
         bigintToString(payload),
+    },
+
+    proposalVoteCast: {
+      subscribe: (
+        _root: unknown,
+        args: { proposalId?: number | null },
+        ctx: SubscriptionContext
+      ) =>
+        eventBusAsyncIterator<ProposalVoteCastPayload>(
+          SUBSCRIPTION_TOPICS.proposalVoteCast,
+          (p) =>
+            tenantOwnsEvent(ctx, p) &&
+            (args.proposalId == null || p.proposalId === args.proposalId)
+        ),
+      resolve: (payload: ProposalVoteCastPayload) => bigintToString(payload),
     },
 
     vaultMatured: {

--- a/backend/src/graphql/schema.ts
+++ b/backend/src/graphql/schema.ts
@@ -237,6 +237,20 @@ export const typeDefs = /* GraphQL */ `
     timestamp: DateTime!
   }
 
+  type ProposalVoteCastEvent {
+    proposalId: Int!
+    tokenAddress: String!
+    creatorAddress: String!
+    voter: String!
+    support: Boolean!
+    weight: String!
+    votesFor: String!
+    votesAgainst: String!
+    reason: String
+    txHash: String!
+    timestamp: DateTime!
+  }
+
   # ── Root Subscription ───────────────────────────────────────────────────────
   #
   # All subscriptions are tenant scoped via the connection JWT. The optional
@@ -253,6 +267,12 @@ export const typeDefs = /* GraphQL */ `
     # Emitted when a governance proposal transitions status. Optionally filter
     # to the proposals of a specific token address.
     proposalStatusChanged(tokenAddress: String): ProposalStatusChangedEvent!
+
+    # Emitted whenever a vote is cast on a governance proposal. Optionally
+    # filter to a specific proposal (by its on-chain proposalId). Carries the
+    # running for/against tallies so subscribers can update vote counts and
+    # quorum progress without a full refetch.
+    proposalVoteCast(proposalId: Int): ProposalVoteCastEvent!
 
     # Emitted when a vesting vault matures. Optionally filter to a recipient.
     vaultMatured(recipientAddress: String): VaultMaturedEvent!

--- a/frontend/src/components/Governance/ProposalDetail.tsx
+++ b/frontend/src/components/Governance/ProposalDetail.tsx
@@ -5,7 +5,7 @@
  * Issue: #617 - Add Governance Read Integration to Frontend Dashboard
  */
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { Card } from '../UI/Card';
 import { Spinner } from '../UI/Spinner';
 import { Button } from '../UI/Button';
@@ -18,6 +18,7 @@ import {
     type ExecutionEntry,
 } from '../../services/governanceApi';
 import type { GovernanceProposal, GovernanceVote, WalletState } from '../../types';
+import { QuorumProgressBar } from './QuorumProgressBar';
 
 export interface ProposalDetailProps {
     /** Proposal ID */
@@ -94,6 +95,27 @@ export function ProposalDetail({
     useEffect(() => {
         fetchData();
     }, [fetchData]);
+
+    // Poll for live vote updates every 5 seconds while proposal is active
+    const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+    useEffect(() => {
+        if (proposal?.status !== 'active') return;
+        pollRef.current = setInterval(async () => {
+            try {
+                const [proposalData, votesData] = await Promise.all([
+                    fetchProposal(proposalId),
+                    fetchProposalVotes(proposalId, 1, 20),
+                ]);
+                setProposal(proposalData);
+                setVotes(votesData.votes);
+            } catch {
+                // silent — don't surface poll errors
+            }
+        }, 5_000);
+        return () => {
+            if (pollRef.current) clearInterval(pollRef.current);
+        };
+    }, [proposal?.status, proposalId]);
 
     /**
      * Submit a vote
@@ -224,6 +246,15 @@ export function ProposalDetail({
                             style={{ width: `${againstPercentage}%` }}
                         />
                     </div>
+                </div>
+
+                {/* Quorum progress */}
+                <div className="mt-4">
+                    <QuorumProgressBar
+                        votesFor={proposal.votesFor}
+                        votesAgainst={proposal.votesAgainst}
+                        quorum={proposal.quorum}
+                    />
                 </div>
             </div>
 

--- a/frontend/src/components/Governance/QuorumProgressBar.tsx
+++ b/frontend/src/components/Governance/QuorumProgressBar.tsx
@@ -1,0 +1,37 @@
+/**
+ * QuorumProgressBar
+ * Displays how close the total votes are to reaching the quorum threshold.
+ */
+
+interface QuorumProgressBarProps {
+    votesFor: string;
+    votesAgainst: string;
+    quorum: string;
+}
+
+export function QuorumProgressBar({ votesFor, votesAgainst, quorum }: QuorumProgressBarProps) {
+    const total = parseInt(votesFor) + parseInt(votesAgainst);
+    const quorumTarget = parseInt(quorum);
+    const percentage = quorumTarget > 0 ? Math.min((total / quorumTarget) * 100, 100) : 0;
+    const reached = total >= quorumTarget;
+
+    return (
+        <div data-testid="quorum-progress-bar">
+            <div className="flex items-center justify-between text-sm mb-1">
+                <span className="text-gray-600 font-medium">Quorum Progress</span>
+                <span className={reached ? 'text-green-600 font-medium' : 'text-gray-500'}>
+                    {total} / {quorum} {reached && '✓'}
+                </span>
+            </div>
+            <div className="h-3 bg-gray-200 rounded-full overflow-hidden">
+                <div
+                    className={`h-full rounded-full transition-all duration-300 ${reached ? 'bg-green-500' : 'bg-blue-500'}`}
+                    style={{ width: `${percentage}%` }}
+                    data-testid="quorum-bar-fill"
+                />
+            </div>
+        </div>
+    );
+}
+
+export default QuorumProgressBar;

--- a/frontend/src/components/Governance/__tests__/QuorumProgressBar.test.tsx
+++ b/frontend/src/components/Governance/__tests__/QuorumProgressBar.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { QuorumProgressBar } from '../QuorumProgressBar';
+
+describe('QuorumProgressBar', () => {
+    it('renders with correct vote counts', () => {
+        render(<QuorumProgressBar votesFor="300" votesAgainst="100" quorum="500" />);
+        expect(screen.getByTestId('quorum-progress-bar')).toBeDefined();
+        expect(screen.getByText(/400 \/ 500/)).toBeDefined();
+    });
+
+    it('shows quorum reached when total >= quorum', () => {
+        render(<QuorumProgressBar votesFor="400" votesAgainst="200" quorum="500" />);
+        expect(screen.getByText(/✓/)).toBeDefined();
+    });
+
+    it('fills bar proportionally', () => {
+        render(<QuorumProgressBar votesFor="250" votesAgainst="0" quorum="500" />);
+        const fill = screen.getByTestId('quorum-bar-fill');
+        expect(fill.style.width).toBe('50%');
+    });
+
+    it('clamps bar at 100% when votes exceed quorum', () => {
+        render(<QuorumProgressBar votesFor="800" votesAgainst="200" quorum="500" />);
+        const fill = screen.getByTestId('quorum-bar-fill');
+        expect(fill.style.width).toBe('100%');
+    });
+
+    it('renders 0% when no votes', () => {
+        render(<QuorumProgressBar votesFor="0" votesAgainst="0" quorum="500" />);
+        const fill = screen.getByTestId('quorum-bar-fill');
+        expect(fill.style.width).toBe('0%');
+    });
+
+    it('handles zero quorum without crashing', () => {
+        render(<QuorumProgressBar votesFor="100" votesAgainst="50" quorum="0" />);
+        expect(screen.getByTestId('quorum-progress-bar')).toBeDefined();
+    });
+});


### PR DESCRIPTION
## Summary

Adds live vote polling and quorum visualization to the governance proposal detail page.

## Changes
- Add `proposalVoteCast` subscription type and resolver to GraphQL schema
- Add `QuorumProgressBar` component with color-coded fill
- Poll for live vote updates every 5s on active proposals
- Render `QuorumProgressBar` in vote progress section of `ProposalDetail`
- Component tests for `QuorumProgressBar`

Closes #1391