### PR TITLE
feat(backend): priority-queue event buffer for out-of-order campaign events

### DIFF
--- a/backend/src/__tests__/campaignProjection.ingestion.integration.test.ts
+++ b/backend/src/__tests__/campaignProjection.ingestion.integration.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi, beforeAll } from "vitest";
+import { describe, it, expect, beforeEach, vi, beforeAll, afterEach } from "vitest";
 
 // ── In-memory stores ─────────────────────────────────────────────────────────
 const mockCampaigns = new Map<number, any>();
@@ -208,5 +208,66 @@ describe("Campaign Projection Ingestion", () => {
     expect(active.every((c: any) => c.status === "ACTIVE")).toBe(true);
     expect(active.length).toBe(1);
     expect(active[0].campaignId).toBe(1);
+  });
+});
+
+describe("Event Buffer", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("in-order events are processed immediately without buffering", async () => {
+    const { EventBuffer } = await import("../services/campaignProjectionService");
+    const processed: number[] = [];
+    const buf = new EventBuffer<number>(async (e) => { processed.push(e.ledger); });
+
+    await buf.ingest({ ledger: 1, payload: 1 });
+    await buf.ingest({ ledger: 2, payload: 2 });
+    await buf.ingest({ ledger: 3, payload: 3 });
+
+    expect(processed).toEqual([1, 2, 3]);
+  });
+
+  it("out-of-order events are buffered and processed in ledger order", async () => {
+    const { EventBuffer } = await import("../services/campaignProjectionService");
+    const processed: number[] = [];
+    const buf = new EventBuffer<number>(async (e) => { processed.push(e.ledger); });
+
+    await buf.ingest({ ledger: 1, payload: 1 });
+    await buf.ingest({ ledger: 3, payload: 3 });
+    await buf.ingest({ ledger: 2, payload: 2 }); // out-of-order triggers reorder + drain
+
+    expect(processed).toEqual([1, 2, 3]);
+  });
+
+  it("timeout flush processes remaining buffered events in ledger order", async () => {
+    vi.useFakeTimers();
+    const { EventBuffer } = await import("../services/campaignProjectionService");
+    const processed: number[] = [];
+    const buf = new EventBuffer<number>(async (e) => { processed.push(e.ledger); }, 5_000);
+
+    await buf.ingest({ ledger: 1, payload: 1 });
+    await buf.ingest({ ledger: 3, payload: 3 }); // gap — stays buffered
+    expect(processed).toEqual([1]);
+
+    await vi.runAllTimersAsync();
+    expect(processed).toEqual([1, 3]);
+  });
+
+  it("campaign.event_reordered metric emitted on reorder", async () => {
+    const { EventBuffer } = await import("../services/campaignProjectionService");
+    const metrics: string[] = [];
+    const buf = new EventBuffer<number>(
+      async () => {},
+      10_000,
+      (m) => metrics.push(m)
+    );
+
+    // Process ledgers 1 and 2, then receive ledger 1 again (below lastProcessed → reorder)
+    await buf.ingest({ ledger: 1, payload: 1 });
+    await buf.ingest({ ledger: 2, payload: 2 });
+    await buf.ingest({ ledger: 1, payload: 1 }); // ledger 1 <= lastProcessed(2) → reorder
+
+    expect(metrics).toContain("campaign.event_reordered");
   });
 });

--- a/backend/src/lib/metrics/index.ts
+++ b/backend/src/lib/metrics/index.ts
@@ -328,6 +328,20 @@ export const eventsProcessedTotal = new Counter({
   registers: [register],
 });
 
+/**
+ * Counts occurrences of the `campaign.event_reordered` projection event —
+ * emitted whenever the campaign event buffer (see
+ * `services/campaignEventBuffer.ts`) detects that an incoming Stellar event
+ * arrived out of ledger order for its campaign stream and had to be held
+ * back / reordered before being applied to the projection.
+ */
+export const campaignEventReorderedTotal = new Counter({
+  name: "campaign_event_reordered_total",
+  help: "Total number of campaign projection events buffered due to out-of-order ledger delivery (campaign.event_reordered)",
+  labelNames: ["event_type", "reason"],
+  registers: [register],
+});
+
 // ---------------------------------------------------------------------------
 // Webhook Metrics
 // ---------------------------------------------------------------------------
@@ -449,6 +463,20 @@ export class IntegrationMetrics {
     status: "success" | "failure"
   ): void {
     eventsProcessedTotal.inc({ event_type: eventType, status });
+  }
+
+  /**
+   * Emits the `campaign.event_reordered` metric. Call this whenever the
+   * campaign event buffer holds back an out-of-order event (ledger sequence
+   * lower than the last-applied sequence for that campaign stream) so it can
+   * be replayed in the correct order, or flushes a buffer window that was
+   * never fully back in order before the buffer timeout elapsed.
+   */
+  static recordCampaignEventReordered(
+    eventType: string,
+    reason: "out_of_order" | "timeout_flush" = "out_of_order"
+  ): void {
+    campaignEventReorderedTotal.inc({ event_type: eventType, reason });
   }
 
   static recordWebhookDelivery(

--- a/backend/src/services/campaignProjectionService.ts
+++ b/backend/src/services/campaignProjectionService.ts
@@ -266,3 +266,63 @@ export class CampaignProjectionService {
 }
 
 export const campaignProjectionService = new CampaignProjectionService();
+
+export interface BufferedEvent<T> {
+  ledger: number;
+  payload: T;
+}
+
+export class EventBuffer<T> {
+  private buffer: BufferedEvent<T>[] = [];
+  private lastProcessedLedger = -1;
+  private flushTimer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(
+    private readonly processEvent: (event: BufferedEvent<T>) => Promise<void>,
+    private readonly flushTimeoutMs = 10_000,
+    private readonly onReorder?: (metric: string) => void
+  ) {}
+
+  async ingest(event: BufferedEvent<T>): Promise<void> {
+    this.resetTimer();
+
+    if (event.ledger === this.lastProcessedLedger + 1 && this.buffer.length === 0) {
+      this.lastProcessedLedger = event.ledger;
+      await this.processEvent(event);
+      return;
+    }
+
+    if (event.ledger <= this.lastProcessedLedger) {
+      this.onReorder?.("campaign.event_reordered");
+    }
+
+    this.buffer.push(event);
+    this.buffer.sort((a, b) => a.ledger - b.ledger);
+    await this.drainBuffer();
+  }
+
+  private async drainBuffer(): Promise<void> {
+    while (this.buffer.length > 0 && this.buffer[0].ledger === this.lastProcessedLedger + 1) {
+      const next = this.buffer.shift()!;
+      this.lastProcessedLedger = next.ledger;
+      await this.processEvent(next);
+    }
+  }
+
+  private resetTimer(): void {
+    if (this.flushTimer !== null) clearTimeout(this.flushTimer);
+    this.flushTimer = setTimeout(() => this.flush(), this.flushTimeoutMs);
+  }
+
+  async flush(): Promise<void> {
+    if (this.flushTimer !== null) {
+      clearTimeout(this.flushTimer);
+      this.flushTimer = null;
+    }
+    while (this.buffer.length > 0) {
+      const next = this.buffer.shift()!;
+      this.lastProcessedLedger = next.ledger;
+      await this.processEvent(next);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds an `EventBuffer<T>` class to `campaignProjectionService.ts` that reorders incoming campaign events by ledger sequence before processing, with a flush-on-timeout fallback.

## Changes
- `EventBuffer<T>` with `ingest()`, `flush()`, priority-queue by ledger sequence
- Emits `campaign.event_reordered` metric via callback when reordering detected
- Flush-on-timeout (default 10s): processes all buffered events in ledger order
- Tests: in-order events (no buffering), out-of-order (buffered and re-sorted), timeout flush, reorder metric emitted

Closes #1393