### PR TITLE
feat(frontend): admin factory panel backend integration for timelock and treasury policy

### DIFF
--- a/backend/src/routes/admin/__tests__/governance.test.ts
+++ b/backend/src/routes/admin/__tests__/governance.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+// Mock auth middleware to bypass JWT for tests
+vi.mock('../../middleware/auth', () => ({
+  authenticateAdmin: (_req: any, _res: any, next: any) => next(),
+}));
+
+// Import router after mocking
+const { default: governanceRouter } = await import('../governance');
+
+const app = express();
+app.use(express.json());
+app.use('/', governanceRouter);
+
+describe('GET /api/admin/governance/timelock', () => {
+  it('returns current timelock config', async () => {
+    const res = await request(app).get('/');
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(typeof res.body.data.minDelay).toBe('number');
+    expect(typeof res.body.data.maxDelay).toBe('number');
+  });
+});
+
+describe('PUT /api/admin/governance/timelock', () => {
+  it('updates timelock config with valid body', async () => {
+    const res = await request(app)
+      .put('/')
+      .send({ minDelay: 7200, maxDelay: 172800 });
+    expect(res.status).toBe(200);
+    expect(res.body.data.minDelay).toBe(7200);
+    expect(res.body.data.maxDelay).toBe(172800);
+  });
+
+  it('rejects non-number values', async () => {
+    const res = await request(app)
+      .put('/')
+      .send({ minDelay: 'bad', maxDelay: 86400 });
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+  });
+
+  it('rejects maxDelay less than minDelay', async () => {
+    const res = await request(app)
+      .put('/')
+      .send({ minDelay: 86400, maxDelay: 3600 });
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+  });
+
+  it('rejects negative minDelay', async () => {
+    const res = await request(app)
+      .put('/')
+      .send({ minDelay: -1, maxDelay: 3600 });
+    expect(res.status).toBe(400);
+  });
+});

--- a/backend/src/routes/admin/__tests__/treasury.test.ts
+++ b/backend/src/routes/admin/__tests__/treasury.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+vi.mock('../../middleware/auth', () => ({
+  authenticateAdmin: (_req: any, _res: any, next: any) => next(),
+}));
+
+const { default: treasuryRouter } = await import('../treasury');
+
+const app = express();
+app.use(express.json());
+app.use('/', treasuryRouter);
+
+describe('GET /api/admin/treasury/policy', () => {
+  it('returns current treasury policy', async () => {
+    const res = await request(app).get('/');
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(typeof res.body.data.dailyCap).toBe('string');
+    expect(/^\d+$/.test(res.body.data.dailyCap)).toBe(true);
+  });
+});
+
+describe('PUT /api/admin/treasury/policy', () => {
+  it('updates dailyCap with valid string integer', async () => {
+    const res = await request(app)
+      .put('/')
+      .send({ dailyCap: '5000000000' });
+    expect(res.status).toBe(200);
+    expect(res.body.data.dailyCap).toBe('5000000000');
+  });
+
+  it('rejects non-string dailyCap', async () => {
+    const res = await request(app)
+      .put('/')
+      .send({ dailyCap: 5000000000 });
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+  });
+
+  it('rejects non-numeric string dailyCap', async () => {
+    const res = await request(app)
+      .put('/')
+      .send({ dailyCap: 'bad-value' });
+    expect(res.status).toBe(400);
+  });
+});

--- a/backend/src/routes/admin/governance.ts
+++ b/backend/src/routes/admin/governance.ts
@@ -1,0 +1,37 @@
+/**
+ * GET/PUT /api/admin/governance/timelock
+ * Timelock configuration endpoints.
+ */
+import { Router, Request, Response } from 'express';
+import { authenticateAdmin } from '../../middleware/auth';
+import { successResponse, errorResponse } from '../../utils/response';
+
+const router = Router();
+
+// In-memory store — replace with DB persistence when ready
+let timelockConfig = { minDelay: 3600, maxDelay: 86400 };
+
+router.get('/', authenticateAdmin, (_req: Request, res: Response) => {
+  res.json(successResponse({ ...timelockConfig, fetchedAt: new Date().toISOString() }));
+});
+
+router.put('/', authenticateAdmin, (req: Request, res: Response) => {
+  const { minDelay, maxDelay } = req.body;
+
+  if (typeof minDelay !== 'number' || typeof maxDelay !== 'number') {
+    return res.status(400).json(
+      errorResponse({ code: 'INVALID_REQUEST', message: 'minDelay and maxDelay must be numbers' }),
+    );
+  }
+
+  if (minDelay < 0 || maxDelay < minDelay) {
+    return res.status(400).json(
+      errorResponse({ code: 'INVALID_REQUEST', message: 'maxDelay must be >= minDelay and both non-negative' }),
+    );
+  }
+
+  timelockConfig = { minDelay, maxDelay };
+  res.json(successResponse({ ...timelockConfig, updatedAt: new Date().toISOString() }));
+});
+
+export default router;

--- a/backend/src/routes/admin/index.ts
+++ b/backend/src/routes/admin/index.ts
@@ -5,6 +5,8 @@ import usersRouter from "./users";
 import auditRouter from "./audit";
 import operationalRouter from "./operational";
 import backupRouter from "./backup";
+import governanceRouter from "./governance";
+import treasuryRouter from "./treasury";
 
 const router = Router();
 
@@ -14,5 +16,7 @@ router.use("/users", usersRouter);
 router.use("/audit", auditRouter);
 router.use("/operational", operationalRouter);
 router.use("/backup", backupRouter);
+router.use("/governance/timelock", governanceRouter);
+router.use("/treasury/policy", treasuryRouter);
 
 export default router;

--- a/backend/src/routes/admin/treasury.ts
+++ b/backend/src/routes/admin/treasury.ts
@@ -1,0 +1,31 @@
+/**
+ * GET/PUT /api/admin/treasury/policy
+ * Treasury policy endpoints.
+ */
+import { Router, Request, Response } from 'express';
+import { authenticateAdmin } from '../../middleware/auth';
+import { successResponse, errorResponse } from '../../utils/response';
+
+const router = Router();
+
+// In-memory store — replace with DB persistence when ready
+let treasuryPolicy = { dailyCap: '1000000000' }; // stroops as string (bigint-safe)
+
+router.get('/', authenticateAdmin, (_req: Request, res: Response) => {
+  res.json(successResponse({ ...treasuryPolicy, fetchedAt: new Date().toISOString() }));
+});
+
+router.put('/', authenticateAdmin, (req: Request, res: Response) => {
+  const { dailyCap } = req.body;
+
+  if (typeof dailyCap !== 'string' || !/^\d+$/.test(dailyCap)) {
+    return res.status(400).json(
+      errorResponse({ code: 'INVALID_REQUEST', message: 'dailyCap must be a non-negative integer string' }),
+    );
+  }
+
+  treasuryPolicy = { dailyCap };
+  res.json(successResponse({ ...treasuryPolicy, updatedAt: new Date().toISOString() }));
+});
+
+export default router;

--- a/frontend/src/components/Admin/FactoryAdminPanel.tsx
+++ b/frontend/src/components/Admin/FactoryAdminPanel.tsx
@@ -14,6 +14,8 @@ import type { AdminPanelLoadState, AdminPanelState } from '../../types/admin';
 
 interface Props {
   network?: 'testnet' | 'mainnet';
+  /** Connected wallet address — used for role guard */
+  walletAddress?: string;
   /** Called when the user clicks a privileged action button — caller handles auth/confirmation */
   onPrivilegedAction?: (action: 'transfer_admin' | 'withdraw_fees' | 'execute_change' | 'cancel_change') => void;
 }
@@ -146,7 +148,7 @@ function LoadingPanel() {
   );
 }
 
-export function FactoryAdminPanel({ network = 'testnet', onPrivilegedAction }: Props) {
+export function FactoryAdminPanel({ network = 'testnet', walletAddress, onPrivilegedAction }: Props) {
   const [loadState, setLoadState] = useState<AdminPanelLoadState>({ status: 'idle' });
 
   const load = useCallback(async () => {
@@ -188,6 +190,17 @@ export function FactoryAdminPanel({ network = 'testnet', onPrivilegedAction }: P
 
   return (
     <div className="space-y-6">
+      {/* Role guard: only render for the contract admin */}
+      {loadState.status === 'loaded' && walletAddress &&
+        walletAddress !== loadState.data.adminState.admin && (
+        <div role="alert" className="rounded-lg border border-red-300 bg-red-50 px-5 py-4">
+          <p className="text-sm font-semibold text-red-800">Not authorized</p>
+          <p className="text-xs text-red-600 mt-1">
+            Only the contract admin ({loadState.data.adminState.admin}) can access this panel.
+          </p>
+        </div>
+      )}
+
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>

--- a/frontend/src/components/Admin/TimelockConfigCard.tsx
+++ b/frontend/src/components/Admin/TimelockConfigCard.tsx
@@ -1,14 +1,15 @@
 /**
  * TimelockConfigCard
  * Displays timelock configuration and any pending scheduled change.
- * Read-only — clearly labels pending changes and their execution window.
+ * Supports editing minDelay/maxDelay via backend API.
  */
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import type { TimelockConfig, PendingChange } from '../../types/admin';
 
 interface Props {
   config: TimelockConfig;
   pendingChange: PendingChange | null;
+  onSave?: (config: { minDelay: number; maxDelay: number }) => Promise<void>;
 }
 
 function formatDelay(seconds: number): string {
@@ -61,15 +62,72 @@ function PendingChangeRow({ change }: { change: PendingChange }) {
   );
 }
 
-export function TimelockConfigCard({ config, pendingChange }: Props) {
+export function TimelockConfigCard({ config, pendingChange, onSave }: Props) {
+  const [editing, setEditing] = useState(false);
+  const [minDelay, setMinDelay] = useState(config.minDelay);
+  const [maxDelay, setMaxDelay] = useState(config.maxDelay);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  // Fetch current config from backend on mount
+  useEffect(() => {
+    fetch('/api/admin/governance/timelock', {
+      headers: { Authorization: `Bearer ${localStorage.getItem('adminToken') ?? ''}` },
+    })
+      .then((r) => r.ok ? r.json() : null)
+      .then((body) => {
+        if (body?.data) {
+          setMinDelay(body.data.minDelay);
+          setMaxDelay(body.data.maxDelay);
+        }
+      })
+      .catch(() => { /* fallback to prop values */ });
+  }, []);
+
+  const handleSave = async () => {
+    const prev = { minDelay: config.minDelay, maxDelay: config.maxDelay };
+    setSaving(true);
+    setSaveError(null);
+    // Optimistic update — values already in state
+    try {
+      const res = await fetch('/api/admin/governance/timelock', {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${localStorage.getItem('adminToken') ?? ''}`,
+        },
+        body: JSON.stringify({ minDelay, maxDelay }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body?.error?.message ?? `HTTP ${res.status}`);
+      }
+      await onSave?.({ minDelay, maxDelay });
+      setEditing(false);
+    } catch (err) {
+      // Rollback
+      setMinDelay(prev.minDelay);
+      setMaxDelay(prev.maxDelay);
+      setSaveError(err instanceof Error ? err.message : 'Save failed');
+    } finally {
+      setSaving(false);
+    }
+  };
+
   return (
     <div className="bg-white rounded-lg shadow-md border border-gray-200">
       <div className="px-6 py-4 border-b border-gray-200 flex items-center gap-2">
         <span className="text-lg">⏱️</span>
         <h3 className="text-lg font-semibold text-gray-900">Timelock</h3>
-        <span className="ml-auto text-xs bg-blue-100 text-blue-700 px-2 py-0.5 rounded-full font-medium">
-          Read-only
-        </span>
+        {editing ? (
+          <span className="ml-auto text-xs bg-orange-100 text-orange-700 px-2 py-0.5 rounded-full font-medium">
+            Editing
+          </span>
+        ) : (
+          <span className="ml-auto text-xs bg-blue-100 text-blue-700 px-2 py-0.5 rounded-full font-medium">
+            Read-only
+          </span>
+        )}
       </div>
 
       <div className="p-6 space-y-5">
@@ -77,16 +135,71 @@ export function TimelockConfigCard({ config, pendingChange }: Props) {
         <div className="grid grid-cols-2 gap-4">
           <div>
             <p className="text-xs font-medium text-gray-500 uppercase tracking-wide">Min Delay</p>
-            <p className="text-xl font-mono font-semibold text-gray-900 mt-0.5">
-              {formatDelay(config.minDelay)}
-            </p>
+            {editing ? (
+              <input
+                type="number"
+                min={0}
+                value={minDelay}
+                onChange={(e) => setMinDelay(Number(e.target.value))}
+                className="mt-0.5 w-full border border-gray-300 rounded px-2 py-1 text-sm font-mono"
+                aria-label="Min delay in seconds"
+              />
+            ) : (
+              <p className="text-xl font-mono font-semibold text-gray-900 mt-0.5">
+                {formatDelay(minDelay)}
+              </p>
+            )}
           </div>
           <div>
             <p className="text-xs font-medium text-gray-500 uppercase tracking-wide">Max Delay</p>
-            <p className="text-xl font-mono font-semibold text-gray-900 mt-0.5">
-              {formatDelay(config.maxDelay)}
-            </p>
+            {editing ? (
+              <input
+                type="number"
+                min={0}
+                value={maxDelay}
+                onChange={(e) => setMaxDelay(Number(e.target.value))}
+                className="mt-0.5 w-full border border-gray-300 rounded px-2 py-1 text-sm font-mono"
+                aria-label="Max delay in seconds"
+              />
+            ) : (
+              <p className="text-xl font-mono font-semibold text-gray-900 mt-0.5">
+                {formatDelay(maxDelay)}
+              </p>
+            )}
           </div>
+        </div>
+
+        {saveError && (
+          <p className="text-xs text-red-600" role="alert">{saveError}</p>
+        )}
+
+        {/* Edit/Save controls */}
+        <div className="flex gap-2">
+          {editing ? (
+            <>
+              <button
+                onClick={handleSave}
+                disabled={saving}
+                className="text-xs px-3 py-1.5 rounded border border-blue-400 text-blue-700 bg-blue-50 hover:bg-blue-100 font-medium disabled:opacity-50"
+              >
+                {saving ? 'Saving…' : 'Save'}
+              </button>
+              <button
+                onClick={() => { setEditing(false); setSaveError(null); setMinDelay(config.minDelay); setMaxDelay(config.maxDelay); }}
+                disabled={saving}
+                className="text-xs px-3 py-1.5 rounded border border-gray-300 text-gray-600 hover:bg-gray-50 font-medium disabled:opacity-50"
+              >
+                Cancel
+              </button>
+            </>
+          ) : (
+            <button
+              onClick={() => setEditing(true)}
+              className="text-xs px-3 py-1.5 rounded border border-gray-300 text-gray-600 hover:bg-gray-50 font-medium"
+            >
+              Edit
+            </button>
+          )}
         </div>
 
         {/* Pending change */}

--- a/frontend/src/components/Admin/TreasuryPolicyCard.tsx
+++ b/frontend/src/components/Admin/TreasuryPolicyCard.tsx
@@ -1,14 +1,14 @@
 /**
  * TreasuryPolicyCard
- * Read-only display of treasury policy state: daily cap, withdrawn today,
- * remaining capacity, and the recipient allowlist.
- * No mutating actions — privileged operations are clearly separated.
+ * Read-only display of treasury policy state with editable daily cap wired
+ * to PUT /api/admin/treasury/policy.
  */
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import type { TreasuryPolicy } from '../../types/admin';
 
 interface Props {
   policy: TreasuryPolicy;
+  onSave?: (policy: { dailyCap: string }) => Promise<void>;
 }
 
 function stroopsToXlm(stroops: bigint): string {
@@ -34,24 +34,87 @@ function CapacityBar({ used, total }: { used: bigint; total: bigint }) {
   );
 }
 
-export function TreasuryPolicyCard({ policy }: Props) {
+export function TreasuryPolicyCard({ policy, onSave }: Props) {
+  const [editing, setEditing] = useState(false);
+  const [dailyCap, setDailyCap] = useState(policy.dailyCap.toString());
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  // Fetch current policy from backend on mount
+  useEffect(() => {
+    fetch('/api/admin/treasury/policy', {
+      headers: { Authorization: `Bearer ${localStorage.getItem('adminToken') ?? ''}` },
+    })
+      .then((r) => r.ok ? r.json() : null)
+      .then((body) => {
+        if (body?.data?.dailyCap) setDailyCap(body.data.dailyCap);
+      })
+      .catch(() => { /* fallback to prop values */ });
+  }, []);
+
+  const handleSave = async () => {
+    const prevCap = policy.dailyCap.toString();
+    setSaving(true);
+    setSaveError(null);
+    try {
+      const res = await fetch('/api/admin/treasury/policy', {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${localStorage.getItem('adminToken') ?? ''}`,
+        },
+        body: JSON.stringify({ dailyCap }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body?.error?.message ?? `HTTP ${res.status}`);
+      }
+      await onSave?.({ dailyCap });
+      setEditing(false);
+    } catch (err) {
+      setDailyCap(prevCap);
+      setSaveError(err instanceof Error ? err.message : 'Save failed');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const displayCap = BigInt(dailyCap || '0');
+
   return (
     <div className="bg-white rounded-lg shadow-md border border-gray-200">
       <div className="px-6 py-4 border-b border-gray-200 flex items-center gap-2">
         <span className="text-lg">🏦</span>
         <h3 className="text-lg font-semibold text-gray-900">Treasury Policy</h3>
-        <span className="ml-auto text-xs bg-blue-100 text-blue-700 px-2 py-0.5 rounded-full font-medium">
-          Read-only
-        </span>
+        {editing ? (
+          <span className="ml-auto text-xs bg-orange-100 text-orange-700 px-2 py-0.5 rounded-full font-medium">
+            Editing
+          </span>
+        ) : (
+          <span className="ml-auto text-xs bg-blue-100 text-blue-700 px-2 py-0.5 rounded-full font-medium">
+            Read-only
+          </span>
+        )}
       </div>
 
       <div className="p-6 space-y-5">
         {/* Daily cap */}
         <div>
           <p className="text-xs font-medium text-gray-500 uppercase tracking-wide">Daily Cap</p>
-          <p className="text-xl font-mono font-semibold text-gray-900 mt-0.5">
-            {stroopsToXlm(policy.dailyCap)} XLM
-          </p>
+          {editing ? (
+            <input
+              type="text"
+              value={dailyCap}
+              onChange={(e) => /^\d*$/.test(e.target.value) && setDailyCap(e.target.value)}
+              className="mt-0.5 w-full border border-gray-300 rounded px-2 py-1 text-sm font-mono"
+              aria-label="Daily cap in stroops"
+              placeholder="Stroops (integer)"
+            />
+          ) : (
+            <p className="text-xl font-mono font-semibold text-gray-900 mt-0.5">
+              {stroopsToXlm(displayCap)} XLM
+            </p>
+          )}
         </div>
 
         {/* Usage bar */}
@@ -59,13 +122,46 @@ export function TreasuryPolicyCard({ policy }: Props) {
           <p className="text-xs font-medium text-gray-500 uppercase tracking-wide">
             Today's Usage
           </p>
-          <CapacityBar used={policy.withdrawnToday} total={policy.dailyCap} />
+          <CapacityBar used={policy.withdrawnToday} total={displayCap} />
           <p className="text-sm text-gray-600 mt-2">
             <span className="font-medium text-green-700">
               {stroopsToXlm(policy.remainingCapacity)} XLM
             </span>{' '}
             remaining today
           </p>
+        </div>
+
+        {saveError && (
+          <p className="text-xs text-red-600" role="alert">{saveError}</p>
+        )}
+
+        {/* Edit/Save controls */}
+        <div className="flex gap-2">
+          {editing ? (
+            <>
+              <button
+                onClick={handleSave}
+                disabled={saving}
+                className="text-xs px-3 py-1.5 rounded border border-blue-400 text-blue-700 bg-blue-50 hover:bg-blue-100 font-medium disabled:opacity-50"
+              >
+                {saving ? 'Saving…' : 'Save'}
+              </button>
+              <button
+                onClick={() => { setEditing(false); setSaveError(null); setDailyCap(policy.dailyCap.toString()); }}
+                disabled={saving}
+                className="text-xs px-3 py-1.5 rounded border border-gray-300 text-gray-600 hover:bg-gray-50 font-medium disabled:opacity-50"
+              >
+                Cancel
+              </button>
+            </>
+          ) : (
+            <button
+              onClick={() => setEditing(true)}
+              className="text-xs px-3 py-1.5 rounded border border-gray-300 text-gray-600 hover:bg-gray-50 font-medium"
+            >
+              Edit
+            </button>
+          )}
         </div>
 
         {/* Allowlist */}


### PR DESCRIPTION
## Summary

Wires `TimelockConfigCard` and `TreasuryPolicyCard` to backend admin endpoints, adds role guard to `FactoryAdminPanel`.

## Changes

**Backend**
- `GET/PUT /api/admin/governance/timelock` — timelock delay config endpoint
- `GET/PUT /api/admin/treasury/policy` — treasury daily cap endpoint
- Both protected by `authenticateAdmin` middleware
- Route tests for both endpoints

**Frontend**
- `TimelockConfigCard`: fetches current config on mount, inline edit with Save/Cancel, optimistic update + rollback on error
- `TreasuryPolicyCard`: fetches current policy on mount, inline edit for daily cap, optimistic update + rollback
- `FactoryAdminPanel`: add `walletAddress` prop; shows "Not authorized" if wallet doesn't match contract admin

Closes #1394