### PR TITLE
feat(contracts): keyset-cursor pagination for large stream collections

### DIFF
--- a/backend/src/__tests__/streams.routes.test.ts
+++ b/backend/src/__tests__/streams.routes.test.ts
@@ -109,6 +109,102 @@ describe("Stream Routes", () => {
   });
 
   // -------------------------------------------------------------------------
+  // GET /api/streams/creator/:address/paginated (keyset cursor pagination)
+  // -------------------------------------------------------------------------
+
+  describe("GET /api/streams/creator/:address/paginated", () => {
+    it("returns the first page ordered by streamId ascending when no cursor is given", async () => {
+      for (let i = 1; i <= 5; i++) {
+        await seedStream({ creator: "GKEYSET_A", streamId: i, txHash: `tx-keyset-${i}` });
+      }
+
+      const res = await request(app).get("/api/streams/creator/GKEYSET_A/paginated?limit=3");
+      expect(res.status).toBe(200);
+      expect(res.body.data.streams).toHaveLength(3);
+      expect(res.body.data.streams.map((s: any) => s.streamId)).toEqual([1, 2, 3]);
+      expect(res.body.data.hasMore).toBe(true);
+      expect(res.body.data.nextCursor).toBe(3);
+    });
+
+    it("returns the next page using the previous page's nextCursor, with no overlap or gap", async () => {
+      for (let i = 1; i <= 5; i++) {
+        await seedStream({ creator: "GKEYSET_B", streamId: i, txHash: `tx-keyset-b-${i}` });
+      }
+
+      const page1 = await request(app).get("/api/streams/creator/GKEYSET_B/paginated?limit=3");
+      expect(page1.body.data.streams.map((s: any) => s.streamId)).toEqual([1, 2, 3]);
+
+      const page2 = await request(app).get(
+        `/api/streams/creator/GKEYSET_B/paginated?limit=3&cursor=${page1.body.data.nextCursor}`
+      );
+      expect(page2.status).toBe(200);
+      expect(page2.body.data.streams.map((s: any) => s.streamId)).toEqual([4, 5]);
+      expect(page2.body.data.hasMore).toBe(false);
+      expect(page2.body.data.nextCursor).toBeNull();
+    });
+
+    it("a stream inserted between page fetches is not skipped or duplicated", async () => {
+      for (let i = 1; i <= 3; i++) {
+        await seedStream({ creator: "GKEYSET_C", streamId: i, txHash: `tx-keyset-c-${i}` });
+      }
+
+      const page1 = await request(app).get("/api/streams/creator/GKEYSET_C/paginated?limit=2");
+      expect(page1.body.data.streams.map((s: any) => s.streamId)).toEqual([1, 2]);
+      expect(page1.body.data.hasMore).toBe(true);
+
+      // Simulate a stream created concurrently with paging.
+      await seedStream({ creator: "GKEYSET_C", streamId: 4, txHash: "tx-keyset-c-4" });
+
+      const page2 = await request(app).get(
+        `/api/streams/creator/GKEYSET_C/paginated?limit=10&cursor=${page1.body.data.nextCursor}`
+      );
+      expect(page2.body.data.streams.map((s: any) => s.streamId)).toEqual([3, 4]);
+      expect(page2.body.data.hasMore).toBe(false);
+    });
+
+    it("returns hasMore=false and nextCursor=null on the last page", async () => {
+      for (let i = 1; i <= 4; i++) {
+        await seedStream({ creator: "GKEYSET_D", streamId: i, txHash: `tx-keyset-d-${i}` });
+      }
+
+      const res = await request(app).get("/api/streams/creator/GKEYSET_D/paginated?limit=10");
+      expect(res.status).toBe(200);
+      expect(res.body.data.streams).toHaveLength(4);
+      expect(res.body.data.hasMore).toBe(false);
+      expect(res.body.data.nextCursor).toBeNull();
+    });
+
+    it("returns an empty page for a creator with no streams", async () => {
+      const res = await request(app).get("/api/streams/creator/GKEYSET_EMPTY/paginated");
+      expect(res.status).toBe(200);
+      expect(res.body.data.streams).toHaveLength(0);
+      expect(res.body.data.hasMore).toBe(false);
+      expect(res.body.data.nextCursor).toBeNull();
+    });
+
+    it("clamps limit to a maximum of 50", async () => {
+      for (let i = 1; i <= 60; i++) {
+        await seedStream({ creator: "GKEYSET_MAX", streamId: i, txHash: `tx-keyset-max-${i}` });
+      }
+
+      const res = await request(app).get("/api/streams/creator/GKEYSET_MAX/paginated?limit=1000");
+      expect(res.status).toBe(200);
+      expect(res.body.data.streams).toHaveLength(50);
+      expect(res.body.data.hasMore).toBe(true);
+    });
+
+    it("returns 400 for a non-numeric cursor", async () => {
+      const res = await request(app).get("/api/streams/creator/GKEYSET_A/paginated?cursor=abc");
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 for invalid status", async () => {
+      const res = await request(app).get("/api/streams/creator/GKEYSET_A/paginated?status=BOGUS");
+      expect(res.status).toBe(400);
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // GET /api/streams/recipient/:address
   // -------------------------------------------------------------------------
 

--- a/backend/src/routes/streams.ts
+++ b/backend/src/routes/streams.ts
@@ -15,6 +15,28 @@ function parseListOpts(query: any) {
   return { limit, offset, status };
 }
 
+/** Max streams per page for keyset pagination (mirrors the on-chain contract limit). */
+const MAX_KEYSET_LIMIT = 50;
+
+function parseKeysetOpts(query: any) {
+  const limit = Math.min(parseInt(query.limit as string) || MAX_KEYSET_LIMIT, MAX_KEYSET_LIMIT);
+  const status = query.status as StreamStatus | undefined;
+  if (status && !Object.values(StreamStatus).includes(status)) {
+    return { error: `Invalid status. Must be one of: ${Object.values(StreamStatus).join(", ")}` };
+  }
+
+  let cursor: number | undefined;
+  if (query.cursor !== undefined) {
+    const parsed = parseInt(query.cursor as string);
+    if (isNaN(parsed)) {
+      return { error: "Invalid cursor. Must be the numeric streamId of the last item from the previous page." };
+    }
+    cursor = parsed;
+  }
+
+  return { limit, cursor, status };
+}
+
 /**
  * GET /api/streams/stats/:address?
  * Stream statistics for an address (creator or recipient), or global.
@@ -38,6 +60,29 @@ router.get("/creator/:address", async (req, res) => {
   try {
     const streams = await streamProjectionService.getStreamsByCreator(req.params.address, opts);
     res.json(successResponse(streams));
+  } catch {
+    res.status(500).json(errorResponse({ code: "INTERNAL_SERVER_ERROR", message: "Failed to fetch creator streams" }));
+  }
+});
+
+/**
+ * GET /api/streams/creator/:address/paginated?status=CREATED&cursor=123&limit=50
+ *
+ * Keyset (cursor-based) pagination over streams created by `address`, ordered
+ * by `streamId` ascending. Use this instead of the offset-based
+ * `/creator/:address` endpoint for wallets with large stream collections:
+ * offset pagination can skip or duplicate rows when streams are created
+ * between page fetches, while this cursor always resumes strictly after the
+ * last `streamId` returned. Mirrors the on-chain `list_streams_paginated`
+ * keyset entry point. Pass `nextCursor` from the previous response as
+ * `cursor` to fetch the next page; stop once `hasMore` is `false`.
+ */
+router.get("/creator/:address/paginated", async (req, res) => {
+  const opts = parseKeysetOpts(req.query);
+  if ("error" in opts) return res.status(400).json(errorResponse({ code: "INVALID_INPUT", message: opts.error! }));
+  try {
+    const page = await streamProjectionService.getStreamsByCreatorKeyset(req.params.address, opts);
+    res.json(successResponse(page));
   } catch {
     res.status(500).json(errorResponse({ code: "INTERNAL_SERVER_ERROR", message: "Failed to fetch creator streams" }));
   }

--- a/backend/src/services/streamProjectionService.ts
+++ b/backend/src/services/streamProjectionService.ts
@@ -29,6 +29,22 @@ export interface StreamListOptions {
   offset?: number;
 }
 
+export interface StreamKeysetOptions {
+  status?: StreamStatus;
+  /** Last `streamId` seen on the previous page; omit for the first page. */
+  cursor?: number;
+  limit?: number;
+}
+
+export interface StreamKeysetPage {
+  streams: StreamProjection[];
+  nextCursor: number | null;
+  hasMore: boolean;
+}
+
+/** Hard upper bound on page size for keyset-paginated stream listings. */
+const MAX_KEYSET_PAGE_SIZE = 50;
+
 export class StreamProjectionService {
   async getStreamById(streamId: number): Promise<StreamProjection | null> {
     const stream = await prisma.stream.findUnique({ where: { streamId } });
@@ -61,6 +77,46 @@ export class StreamProjectionService {
       skip: offset,
     });
     return streams.map((s) => this.buildProjection(s));
+  }
+
+  /**
+   * Keyset-paginated listing of streams created by `creator`, ordered by
+   * `streamId` ascending. `streamId` is monotonically increasing and unique
+   * across the whole projection, so it doubles as a stable cursor: unlike
+   * offset pagination, a stream inserted between two page fetches can never
+   * cause this method to skip or duplicate a row on the next page, because
+   * each page resumes strictly after the last `streamId` it returned.
+   *
+   * Mirrors the on-chain `list_streams_paginated` keyset cursor exposed by
+   * the token-factory contract (`(created_ledger, stream_id)`), using
+   * `streamId` alone since it is already a total order for this projection.
+   */
+  async getStreamsByCreatorKeyset(
+    creator: string,
+    opts: StreamKeysetOptions = {}
+  ): Promise<StreamKeysetPage> {
+    const { status, cursor, limit = MAX_KEYSET_PAGE_SIZE } = opts;
+    const pageSize = Math.min(Math.max(limit, 1), MAX_KEYSET_PAGE_SIZE);
+
+    const streams = await prisma.stream.findMany({
+      where: {
+        creator,
+        ...(status ? { status } : {}),
+        ...(cursor !== undefined ? { streamId: { gt: cursor } } : {}),
+      },
+      orderBy: { streamId: "asc" },
+      take: pageSize + 1,
+    });
+
+    const hasMore = streams.length > pageSize;
+    const page = hasMore ? streams.slice(0, pageSize) : streams;
+    const nextCursor = hasMore ? page[page.length - 1].streamId : null;
+
+    return {
+      streams: page.map((s) => this.buildProjection(s)),
+      nextCursor,
+      hasMore,
+    };
   }
 
   async getStreamStats(address?: string): Promise<StreamStats> {

--- a/contracts/token-factory/src/campaign.rs
+++ b/contracts/token-factory/src/campaign.rs
@@ -379,14 +379,6 @@ mod tests {
             assert_eq!(result, Err(Error::Unauthorized));
         });
     }
-                created_at: env.ledger().timestamp(),
-            };
-            storage::set_campaign(env, 1, &campaign);
-
-            let result = pause_campaign(env, &attacker, 1);
-            assert_eq!(result, Err(Error::Unauthorized));
-        });
-    }
 
     #[test]
     fn test_state_transition_validation() {

--- a/contracts/token-factory/src/lib.rs
+++ b/contracts/token-factory/src/lib.rs
@@ -154,6 +154,9 @@ mod batch_atomicity_test;
 #[cfg(test)]
 mod vault_deposit_withdraw_test;
 
+#[cfg(test)]
+mod stream_keyset_pagination_test;
+
 use soroban_sdk::{contract, contractimpl, symbol_short, Address, Bytes, BytesN, Env, String, Symbol, Vec};
 use types::{
     AuctionStatus, BurnAuction, BuybackCampaign, CampaignStatus, ContractMetadata,
@@ -2064,6 +2067,32 @@ impl TokenFactory {
             token_indices,
             next_cursor,
         }
+    }
+
+    /// Return a keyset-paginated list of streams created by `owner`.
+    ///
+    /// Unlike `get_streams_by_beneficiary` (offset-based), this entry point
+    /// uses a `(created_ledger, stream_id)` cursor so that streams created
+    /// concurrently with paging never get skipped or duplicated across page
+    /// fetches. Intended for wallets with large stream collections where
+    /// offset pagination would otherwise drift.
+    ///
+    /// # Arguments
+    /// * `env` - The contract environment
+    /// * `owner` - The stream creator to list streams for
+    /// * `cursor` - `None` for the first page; otherwise the `next_cursor`
+    ///   returned by the previous call
+    /// * `limit` - Maximum streams to return, clamped to a maximum of 50
+    ///
+    /// # Returns
+    /// `PaginatedStreamsResponse { streams, next_cursor, has_more }`
+    pub fn list_streams_paginated(
+        env: Env,
+        owner: Address,
+        cursor: Option<types::StreamCursor>,
+        limit: u32,
+    ) -> types::PaginatedStreamsResponse {
+        pagination::list_streams_paginated(&env, &owner, cursor, limit)
     }
     // ═══════════════════════════════════════════════════════════════════════
     // Timelock Functions

--- a/contracts/token-factory/src/pagination.rs
+++ b/contracts/token-factory/src/pagination.rs
@@ -1,11 +1,16 @@
 use soroban_sdk::{Address, Env, Vec};
 
 use crate::storage;
-use crate::types::{Error, PaginatedTokens, PaginationCursor, TokenInfo};
+use crate::types::{
+    Error, PaginatedStreamsResponse, PaginatedTokens, PaginationCursor, StreamCursor, TokenInfo,
+};
 
 const MAX_PAGE_SIZE: u32 = 100;
 const DEFAULT_PAGE_SIZE: u32 = 20;
 const NO_CURSOR: u32 = u32::MAX;
+
+/// Maximum number of streams returned per page by `list_streams_paginated`.
+const MAX_STREAM_PAGE_SIZE: u32 = 50;
 
 pub fn get_tokens_by_creator(
     env: &Env,
@@ -71,6 +76,85 @@ pub fn get_tokens_by_creator(
 
 pub fn get_creator_token_count(env: &Env, creator: &Address) -> u32 {
     storage::get_creator_token_count(env, creator)
+}
+
+/// Keyset (cursor-based) pagination over an owner's streams.
+///
+/// Unlike offset pagination — where inserting a new stream between two page
+/// fetches shifts every subsequent index and can cause callers to skip or
+/// duplicate rows — keyset pagination resumes strictly *after* the last
+/// `(created_ledger, stream_id)` pair the caller has already seen. Because
+/// streams are appended to the owner's index in creation order (and both
+/// `created_ledger` and `stream_id` are monotonically non-decreasing), the
+/// index is always sorted ascending and a linear scan from the cursor
+/// position is sufficient — no re-sorting is needed on read.
+///
+/// # Arguments
+/// * `env` - The contract environment
+/// * `owner` - The stream creator whose streams should be listed
+/// * `cursor` - `None` to start from the beginning; otherwise resume strictly
+///   after this `(created_ledger, stream_id)` position
+/// * `limit` - Maximum streams to return, clamped to `[1, 50]`
+///
+/// # Returns
+/// A `PaginatedStreamsResponse` containing the page of streams ordered by
+/// `(created_ledger, stream_id)` ascending, the cursor for the next page
+/// (`None` if this is the last page), and a `has_more` flag.
+pub fn list_streams_paginated(
+    env: &Env,
+    owner: &Address,
+    cursor: Option<StreamCursor>,
+    limit: u32,
+) -> PaginatedStreamsResponse {
+    let page_size = limit.clamp(1, MAX_STREAM_PAGE_SIZE);
+
+    let index = storage::get_creator_stream_index(env, owner);
+
+    // Find the first position strictly after the cursor. Since `index` is
+    // sorted ascending, a linear scan suffices and keeps the logic simple;
+    // owners with very large stream counts can later be optimized with a
+    // binary search over the same invariant without changing the API.
+    let start_pos: u32 = match cursor {
+        None => 0,
+        Some(after) => {
+            let mut pos = index.len();
+            for i in 0..index.len() {
+                let entry = index.get(i).unwrap();
+                if after.is_before(&entry) {
+                    pos = i;
+                    break;
+                }
+            }
+            pos
+        }
+    };
+
+    let mut streams = Vec::new(env);
+    let mut pos = start_pos;
+    let mut returned: u32 = 0;
+
+    while pos < index.len() && returned < page_size {
+        let entry = index.get(pos).unwrap();
+        if let Some(stream_info) = storage::get_stream(env, entry.stream_id) {
+            streams.push_back(stream_info);
+            returned += 1;
+        }
+        pos += 1;
+    }
+
+    let has_more = pos < index.len();
+    let next_cursor = if has_more {
+        // Cursor is the last returned entry's position, i.e. `pos - 1`.
+        Some(index.get(pos - 1).unwrap())
+    } else {
+        None
+    };
+
+    PaginatedStreamsResponse {
+        streams,
+        next_cursor,
+        has_more,
+    }
 }
 
 #[cfg(test)]

--- a/contracts/token-factory/src/storage.rs
+++ b/contracts/token-factory/src/storage.rs
@@ -1,6 +1,6 @@
 use soroban_sdk::{Address, Env};
 
-use crate::types::{BuybackCampaign, DataKey, Error, FactoryState, TokenInfo};
+use crate::types::{BuybackCampaign, DataKey, Error, FactoryState, StreamCursor, TokenInfo};
 
 // ============================================================
 // TTL Bump Constants (#1128)
@@ -1042,6 +1042,38 @@ pub fn get_next_stream_id(env: &Env) -> u64 {
         .instance()
         .set(&DataKey::NextStreamId, &(id + 1));
     id
+}
+
+// ── Keyset pagination index (per-owner streams) ─────────────────
+
+/// Append a `(created_ledger, stream_id)` entry to the owner's keyset index.
+///
+/// Streams are appended in creation order, and since `created_ledger` is
+/// non-decreasing over time and `stream_id` is monotonically increasing,
+/// the resulting vector is always sorted ascending by `(created_ledger,
+/// stream_id)` without needing an explicit sort on read.
+pub fn add_creator_stream_index(env: &Env, owner: &Address, created_ledger: u32, stream_id: u64) {
+    let key = DataKey::CreatorStreamIndex(owner.clone());
+    let mut index: soroban_sdk::Vec<StreamCursor> = env
+        .storage()
+        .persistent()
+        .get(&key)
+        .unwrap_or(soroban_sdk::Vec::new(env));
+
+    index.push_back(StreamCursor {
+        created_ledger,
+        stream_id,
+    });
+
+    env.storage().persistent().set(&key, &index);
+}
+
+/// Get the full keyset index (ascending `(created_ledger, stream_id)`) for an owner.
+pub fn get_creator_stream_index(env: &Env, owner: &Address) -> soroban_sdk::Vec<StreamCursor> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::CreatorStreamIndex(owner.clone()))
+        .unwrap_or(soroban_sdk::Vec::new(env))
 }
 
 // ── Vault storage functions ───────────────────────────────

--- a/contracts/token-factory/src/stream_keyset_pagination_test.rs
+++ b/contracts/token-factory/src/stream_keyset_pagination_test.rs
@@ -1,0 +1,281 @@
+//! Tests for keyset (cursor-based) stream pagination.
+//!
+//! `stream_pagination_test.rs` covers the legacy offset-based
+//! `get_streams_page`-style semantics, which drift when streams are created
+//! concurrently with paging (see issue #1386). This module exercises the
+//! new `(created_ledger, stream_id)` keyset cursor, exposed publicly via
+//! `TokenFactory::list_streams_paginated` and internally via
+//! `pagination::list_streams_paginated`.
+
+#[cfg(test)]
+extern crate std;
+
+#[cfg(test)]
+mod stream_keyset_pagination_tests {
+    use crate::pagination;
+    use crate::streaming;
+    use crate::storage;
+    use crate::types::{StreamParams, TokenInfo};
+    use soroban_sdk::{testutils::{Address as _, Ledger}, Address, Env, String};
+
+    /// Sets up a bare environment (no deployed contract needed: `streaming`
+    /// and `pagination` are plain module functions operating on `env`
+    /// storage directly, mirroring the pattern used by
+    /// `stream_lifecycle_integration_test.rs`).
+    fn setup() -> (Env, Address, Address) {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let creator = Address::generate(&env);
+
+        storage::set_admin(&env, &admin);
+        storage::set_paused(&env, false);
+
+        let token_info = TokenInfo {
+            address: Address::generate(&env),
+            creator: creator.clone(),
+            name: String::from_str(&env, "Test Token"),
+            symbol: String::from_str(&env, "TST"),
+            decimals: 7,
+            total_supply: 1_000_000_0000000,
+            initial_supply: 1_000_000_0000000,
+            max_supply: None,
+            total_burned: 0,
+            burn_count: 0,
+            metadata_uri: None,
+            metadata_version: 0,
+            created_at: env.ledger().timestamp(),
+            is_paused: false,
+            clawback_enabled: false,
+            freeze_enabled: false,
+        };
+        storage::set_token_info(&env, 0, &token_info);
+
+        (env, admin, creator)
+    }
+
+    /// Creates a stream at the given ledger sequence number, returning its id.
+    fn create_stream_at_ledger(env: &Env, creator: &Address, recipient: &Address, ledger_seq: u32) -> u64 {
+        env.ledger().set_sequence_number(ledger_seq);
+        let params = StreamParams {
+            recipient: recipient.clone(),
+            token_index: 0,
+            total_amount: 1_000_0000000,
+            start_time: 100,
+            end_time: 200,
+            cliff_time: 100,
+        };
+        streaming::create_stream(env, creator, &params).unwrap()
+    }
+
+    #[test]
+    fn test_first_page_no_cursor() {
+        let (env, _admin, creator) = setup();
+        let recipient = Address::generate(&env);
+
+        for i in 0..5u32 {
+            create_stream_at_ledger(&env, &creator, &recipient, 100 + i);
+        }
+
+        let page = pagination::list_streams_paginated(&env, &creator, None, 3);
+        assert_eq!(page.streams.len(), 3);
+        assert!(page.has_more);
+        assert!(page.next_cursor.is_some());
+
+        // Ascending order by (created_ledger, stream_id): ids 0,1,2
+        assert_eq!(page.streams.get(0).unwrap().id, 0);
+        assert_eq!(page.streams.get(1).unwrap().id, 1);
+        assert_eq!(page.streams.get(2).unwrap().id, 2);
+
+        let cursor = page.next_cursor.unwrap();
+        assert_eq!(cursor.stream_id, 2);
+        assert_eq!(cursor.created_ledger, 102);
+    }
+
+    #[test]
+    fn test_second_page_continues_without_overlap_or_gap() {
+        let (env, _admin, creator) = setup();
+        let recipient = Address::generate(&env);
+
+        for i in 0..5u32 {
+            create_stream_at_ledger(&env, &creator, &recipient, 100 + i);
+        }
+
+        let page1 = pagination::list_streams_paginated(&env, &creator, None, 3);
+        assert_eq!(page1.streams.len(), 3);
+        assert!(page1.has_more);
+
+        let page2 = pagination::list_streams_paginated(&env, &creator, page1.next_cursor, 3);
+        assert_eq!(page2.streams.len(), 2);
+        assert!(!page2.has_more);
+        assert!(page2.next_cursor.is_none());
+
+        // No overlap, no gap: page2 picks up exactly where page1 left off.
+        assert_eq!(page2.streams.get(0).unwrap().id, 3);
+        assert_eq!(page2.streams.get(1).unwrap().id, 4);
+
+        // Combined pages cover all 5 streams exactly once.
+        let mut all_ids = soroban_sdk::Vec::new(&env);
+        for s in page1.streams.iter() {
+            all_ids.push_back(s.id);
+        }
+        for s in page2.streams.iter() {
+            all_ids.push_back(s.id);
+        }
+        assert_eq!(all_ids.len(), 5);
+        for i in 0..5u64 {
+            assert_eq!(all_ids.get(i as u32).unwrap(), i);
+        }
+    }
+
+    #[test]
+    fn test_new_stream_inserted_between_pages_is_not_skipped_or_duplicated() {
+        // This is the exact scenario offset pagination gets wrong: a new
+        // stream is created *after* page 1 is fetched but *before* page 2
+        // is fetched. Keyset pagination must still resume cleanly.
+        let (env, _admin, creator) = setup();
+        let recipient = Address::generate(&env);
+
+        for i in 0..3u32 {
+            create_stream_at_ledger(&env, &creator, &recipient, 100 + i);
+        }
+
+        let page1 = pagination::list_streams_paginated(&env, &creator, None, 2);
+        assert_eq!(page1.streams.len(), 2);
+        assert!(page1.has_more);
+
+        // Simulate a concurrent insert between page fetches.
+        create_stream_at_ledger(&env, &creator, &recipient, 103);
+
+        let page2 = pagination::list_streams_paginated(&env, &creator, page1.next_cursor, 10);
+        // Stream 2 (already existed) plus the newly inserted stream 3.
+        assert_eq!(page2.streams.len(), 2);
+        assert!(!page2.has_more);
+        assert_eq!(page2.streams.get(0).unwrap().id, 2);
+        assert_eq!(page2.streams.get(1).unwrap().id, 3);
+    }
+
+    #[test]
+    fn test_last_page_has_more_false_and_next_cursor_none() {
+        let (env, _admin, creator) = setup();
+        let recipient = Address::generate(&env);
+
+        for i in 0..4u32 {
+            create_stream_at_ledger(&env, &creator, &recipient, 100 + i);
+        }
+
+        // Exactly enough room for the remaining streams.
+        let page = pagination::list_streams_paginated(&env, &creator, None, 10);
+        assert_eq!(page.streams.len(), 4);
+        assert!(!page.has_more);
+        assert!(page.next_cursor.is_none());
+    }
+
+    #[test]
+    fn test_empty_result_for_owner_with_no_streams() {
+        let (env, _admin, _creator) = setup();
+        let owner_without_streams = Address::generate(&env);
+
+        let page = pagination::list_streams_paginated(&env, &owner_without_streams, None, 10);
+        assert_eq!(page.streams.len(), 0);
+        assert!(!page.has_more);
+        assert!(page.next_cursor.is_none());
+    }
+
+    #[test]
+    fn test_limit_is_clamped_to_max_50() {
+        let (env, _admin, creator) = setup();
+        let recipient = Address::generate(&env);
+
+        for i in 0..60u32 {
+            create_stream_at_ledger(&env, &creator, &recipient, 100 + i);
+        }
+
+        let page = pagination::list_streams_paginated(&env, &creator, None, 1000);
+        assert_eq!(page.streams.len(), 50);
+        assert!(page.has_more);
+    }
+
+    #[test]
+    fn test_limit_zero_clamped_to_minimum_one() {
+        let (env, _admin, creator) = setup();
+        let recipient = Address::generate(&env);
+        create_stream_at_ledger(&env, &creator, &recipient, 100);
+
+        let page = pagination::list_streams_paginated(&env, &creator, None, 0);
+        assert_eq!(page.streams.len(), 1);
+    }
+
+    #[test]
+    fn test_streams_from_other_owners_are_excluded() {
+        let (env, _admin, creator) = setup();
+        let other_creator = Address::generate(&env);
+        let recipient = Address::generate(&env);
+
+        create_stream_at_ledger(&env, &creator, &recipient, 100);
+        create_stream_at_ledger(&env, &other_creator, &recipient, 101);
+        create_stream_at_ledger(&env, &creator, &recipient, 102);
+
+        let page = pagination::list_streams_paginated(&env, &creator, None, 10);
+        assert_eq!(page.streams.len(), 2);
+        for s in page.streams.iter() {
+            assert_eq!(s.creator, creator);
+        }
+    }
+
+    #[test]
+    fn test_contract_entry_point_matches_module_function() {
+        // Smoke test the public TokenFactory::list_streams_paginated entry
+        // point end-to-end through a deployed contract instance.
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, crate::TokenFactory);
+        let client = crate::TokenFactoryClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let treasury = Address::generate(&env);
+        client.initialize(&admin, &treasury, &1_000_000, &500_000);
+
+        let creator = Address::generate(&env);
+        let recipient = Address::generate(&env);
+
+        env.as_contract(&contract_id, || {
+            let token_info = TokenInfo {
+                address: Address::generate(&env),
+                creator: creator.clone(),
+                name: String::from_str(&env, "Test Token"),
+                symbol: String::from_str(&env, "TST"),
+                decimals: 7,
+                total_supply: 1_000_000_0000000,
+                initial_supply: 1_000_000_0000000,
+                max_supply: None,
+                total_burned: 0,
+                burn_count: 0,
+                metadata_uri: None,
+                metadata_version: 0,
+                created_at: env.ledger().timestamp(),
+                is_paused: false,
+                clawback_enabled: false,
+                freeze_enabled: false,
+            };
+            storage::set_token_info(&env, 0, &token_info);
+
+            for i in 0..3u32 {
+                create_stream_at_ledger(&env, &creator, &recipient, 100 + i);
+            }
+        });
+
+        let page = client.list_streams_paginated(&creator, &None, &2);
+        assert_eq!(page.streams.len(), 2);
+        assert!(page.has_more);
+        assert_eq!(page.streams.get(0).unwrap().id, 0);
+        assert_eq!(page.streams.get(1).unwrap().id, 1);
+
+        let page2 = client.list_streams_paginated(&creator, &page.next_cursor, &2);
+        assert_eq!(page2.streams.len(), 1);
+        assert!(!page2.has_more);
+        assert_eq!(page2.streams.get(0).unwrap().id, 2);
+    }
+}

--- a/contracts/token-factory/src/streaming.rs
+++ b/contracts/token-factory/src/streaming.rs
@@ -56,6 +56,10 @@ pub fn create_stream(env: &Env, creator: &Address, params: &StreamParams) -> Res
     // Store stream
     storage::set_stream(env, stream_id, &stream);
 
+    // Maintain the keyset pagination index (created_ledger, stream_id) for the owner
+    let created_ledger = env.ledger().sequence();
+    storage::add_creator_stream_index(env, creator, created_ledger, stream_id);
+
     // Emit event
     events::emit_stream_created(
         env,

--- a/contracts/token-factory/src/types.rs
+++ b/contracts/token-factory/src/types.rs
@@ -618,6 +618,8 @@ pub enum DataKey {
     TokenStreams(u32),
     TokenStreamCount(u32),
     NextStreamId,
+    // Keyset pagination index: ordered (created_ledger, stream_id) entries per owner
+    CreatorStreamIndex(Address),
     GovernanceConfig,
     Vault(u64),
     VaultCount,
@@ -1152,6 +1154,46 @@ pub struct PaginatedTokens {
     pub tokens: soroban_sdk::Vec<TokenInfo>,
     pub has_more: bool,
     pub cursor: PaginationCursor,
+}
+
+/// Keyset cursor for stream pagination.
+///
+/// Identifies a position in the `(created_ledger, stream_id)` ascending
+/// ordering of an owner's streams. Unlike offset-based pagination, this
+/// cursor is stable across concurrent inserts: a stream created after the
+/// cursor was issued can never be skipped or duplicated by a subsequent
+/// page fetch, because the scan always resumes strictly after the last
+/// `(created_ledger, stream_id)` pair returned.
+///
+/// # Fields
+/// * `created_ledger` - Ledger sequence number when the stream was created
+/// * `stream_id` - Unique stream identifier (tiebreaker for same-ledger creates)
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct StreamCursor {
+    pub created_ledger: u32,
+    pub stream_id: u64,
+}
+
+impl StreamCursor {
+    /// True if `self` sorts strictly before `other` in `(created_ledger, stream_id)` order.
+    pub fn is_before(&self, other: &StreamCursor) -> bool {
+        (self.created_ledger, self.stream_id) < (other.created_ledger, other.stream_id)
+    }
+}
+
+/// Response for keyset-paginated stream listings.
+///
+/// # Fields
+/// * `streams` - Page of streams ordered by `(created_ledger, stream_id)` ascending
+/// * `next_cursor` - Cursor to pass to the next call (`None` when this is the last page)
+/// * `has_more` - Whether additional streams exist beyond this page
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PaginatedStreamsResponse {
+    pub streams: soroban_sdk::Vec<StreamInfo>,
+    pub next_cursor: Option<StreamCursor>,
+    pub has_more: bool,
 }
 
 /// Paginated vault result


### PR DESCRIPTION
## Summary
- Adds keyset-cursor based pagination for stream collections to avoid offset-pagination cost on large stream sets.

Closes #1386

