### PR TITLE
feat(contracts): batch atomicity with pre-flight validation and full-rollback on partial failure

### DIFF
--- a/contracts/token-factory/src/batch_atomicity_test.rs
+++ b/contracts/token-factory/src/batch_atomicity_test.rs
@@ -8,37 +8,33 @@
 
 #[cfg(test)]
 mod tests {
-    use crate::batch_operations::{batch_reveal, MAX_BATCH_SIZE};
-    use crate::storage;
+    use crate::batch_operations::MAX_BATCH_SIZE;
     use crate::types::{Error, TokenCreationParams};
-    use soroban_sdk::testutils::{Address as _, Ledger};
+    use soroban_sdk::testutils::Address as _;
     use soroban_sdk::{Address, Env, String as SorobanString, Vec};
 
-    fn setup_env() -> (Env, Address) {
+    fn setup_env() -> (Env, Address, Address) {
         let env = Env::default();
-        env.ledger().set_timestamp(1000);
-        let admin = Address::random(&env);
-        let treasury = Address::random(&env);
+        env.mock_all_auths();
 
-        // Initialize factory
-        crate::lib::initialize(
-            &env,
-            admin.clone(),
-            treasury,
-            70_000_000,
-            30_000_000,
-        )
-        .unwrap();
+        let contract_id = env.register_contract(None, crate::TokenFactory);
+        let client = crate::TokenFactoryClient::new(&env, &contract_id);
 
-        (env, admin)
+        let admin = Address::generate(&env);
+        let treasury = Address::generate(&env);
+
+        client.initialize(&admin, &treasury, &70_000_000_i128, &30_000_000_i128);
+
+        (env, contract_id, admin)
     }
 
     fn create_token_params(env: &Env, name: &str, symbol: &str) -> TokenCreationParams {
         TokenCreationParams {
-            name: SorobanString::from_slice(env, name.as_bytes()),
-            symbol: SorobanString::from_slice(env, symbol.as_bytes()),
+            name: SorobanString::from_str(env, name),
+            symbol: SorobanString::from_str(env, symbol),
             decimals: 7,
             initial_supply: 1_000_000_000_000,
+            max_supply: None,
             metadata_uri: None,
         }
     }
@@ -49,235 +45,268 @@ mod tests {
         symbol: &str,
     ) -> TokenCreationParams {
         TokenCreationParams {
-            name: SorobanString::from_slice(env, name.as_bytes()),
-            symbol: SorobanString::from_slice(env, symbol.as_bytes()),
+            name: SorobanString::from_str(env, name),
+            symbol: SorobanString::from_str(env, symbol),
             decimals: 7,
             initial_supply: 1_000_000_000_000,
-            metadata_uri: Some(SorobanString::from_slice(env, "ipfs://QmTest")),
+            max_supply: None,
+            metadata_uri: Some(SorobanString::from_str(env, "ipfs://QmTest")),
         }
     }
 
     #[test]
     fn test_batch_atomicity_invalid_element_mid_batch() {
-        let (env, creator) = setup_env();
+        let (env, contract_id, creator) = setup_env();
+        let client = crate::TokenFactoryClient::new(&env, &contract_id);
 
-        // Get initial token count
-        let initial_count = storage::get_token_count(&env);
+        assert!(client.try_get_token_info(&0_u32).is_err(), "no tokens should exist yet");
 
         // Create batch with invalid element in the middle
         let mut tokens = Vec::new(&env);
         tokens.push_back(create_token_params(&env, "Token1", "T1"));
         tokens.push_back(TokenCreationParams {
-            name: SorobanString::from_slice(&env, ""),  // Invalid: empty name
-            symbol: SorobanString::from_slice(&env, "INVALID"),
+            name: SorobanString::from_str(&env, ""), // Invalid: empty name
+            symbol: SorobanString::from_str(&env, "INVALID"),
             decimals: 7,
             initial_supply: 1_000_000_000_000,
+            max_supply: None,
             metadata_uri: None,
         });
         tokens.push_back(create_token_params(&env, "Token3", "T3"));
 
-        // Calculate required fee
-        let base_fee = storage::get_base_fee(&env);
+        let base_fee = client.get_state().base_fee;
         let required_fee = base_fee * 3;
 
-        // Attempt batch - should fail
-        let result = batch_reveal(&env, creator.clone(), tokens, required_fee);
+        let result = client.try_batch_reveal(&creator, &tokens, &required_fee);
         assert!(result.is_err());
 
-        // Verify state is unchanged
-        let final_count = storage::get_token_count(&env);
-        assert_eq!(initial_count, final_count, "Token count should not change on batch failure");
+        // Verify state is unchanged: token index 0 still doesn't exist.
+        assert!(client.try_get_token_info(&0_u32).is_err());
     }
 
     #[test]
     fn test_batch_atomicity_valid_batch_applies_all() {
-        let (env, creator) = setup_env();
+        let (env, contract_id, creator) = setup_env();
+        let client = crate::TokenFactoryClient::new(&env, &contract_id);
 
-        let initial_count = storage::get_token_count(&env);
-
-        // Create valid batch
         let mut tokens = Vec::new(&env);
         tokens.push_back(create_token_params(&env, "Token1", "T1"));
         tokens.push_back(create_token_params(&env, "Token2", "T2"));
         tokens.push_back(create_token_params(&env, "Token3", "T3"));
 
-        let base_fee = storage::get_base_fee(&env);
+        let base_fee = client.get_state().base_fee;
         let required_fee = base_fee * 3;
 
-        // Execute batch
-        let result = batch_reveal(&env, creator.clone(), tokens, required_fee);
-        assert!(result.is_ok(), "Valid batch should succeed");
+        let indices = client.batch_reveal(&creator, &tokens, &required_fee);
+        assert_eq!(indices.len(), 3, "should return 3 token indices");
 
-        let indices = result.unwrap();
-        assert_eq!(indices.len(), 3, "Should return 3 token indices");
+        assert!(client.try_get_token_info(&0_u32).is_ok());
+        assert!(client.try_get_token_info(&1_u32).is_ok());
+        assert!(client.try_get_token_info(&2_u32).is_ok());
 
-        // Verify all tokens were created
-        let final_count = storage::get_token_count(&env);
-        assert_eq!(
-            final_count,
-            initial_count + 3,
-            "Token count should increase by 3"
-        );
-
-        // Verify indices are sequential
-        assert_eq!(indices.get(0).unwrap(), initial_count);
-        assert_eq!(indices.get(1).unwrap(), initial_count + 1);
-        assert_eq!(indices.get(2).unwrap(), initial_count + 2);
+        assert_eq!(indices.get(0).unwrap(), 0);
+        assert_eq!(indices.get(1).unwrap(), 1);
+        assert_eq!(indices.get(2).unwrap(), 2);
     }
 
     #[test]
     fn test_batch_atomicity_empty_batch() {
-        let (env, creator) = setup_env();
+        let (env, contract_id, creator) = setup_env();
+        let client = crate::TokenFactoryClient::new(&env, &contract_id);
 
         let tokens: Vec<TokenCreationParams> = Vec::new(&env);
-        let base_fee = storage::get_base_fee(&env);
+        let base_fee = client.get_state().base_fee;
 
-        // Empty batch should fail
-        let result = batch_reveal(&env, creator, tokens, base_fee);
+        let result = client.try_batch_reveal(&creator, &tokens, &base_fee);
         assert!(result.is_err());
-        assert_eq!(result.unwrap_err(), Error::InvalidParameters);
+        assert_eq!(result.unwrap_err().unwrap(), Error::InvalidParameters);
     }
 
     #[test]
     fn test_batch_atomicity_single_element() {
-        let (env, creator) = setup_env();
+        let (env, contract_id, creator) = setup_env();
+        let client = crate::TokenFactoryClient::new(&env, &contract_id);
 
-        let initial_count = storage::get_token_count(&env);
-
-        // Single-element batch
         let mut tokens = Vec::new(&env);
         tokens.push_back(create_token_params(&env, "SingleToken", "ST"));
 
-        let base_fee = storage::get_base_fee(&env);
+        let base_fee = client.get_state().base_fee;
 
-        let result = batch_reveal(&env, creator, tokens, base_fee);
-        assert!(result.is_ok());
-
-        let indices = result.unwrap();
+        let indices = client.batch_reveal(&creator, &tokens, &base_fee);
         assert_eq!(indices.len(), 1);
-        assert_eq!(indices.get(0).unwrap(), initial_count);
+        assert_eq!(indices.get(0).unwrap(), 0);
 
-        let final_count = storage::get_token_count(&env);
-        assert_eq!(final_count, initial_count + 1);
+        assert!(client.try_get_token_info(&0_u32).is_ok());
     }
 
     #[test]
     fn test_batch_atomicity_insufficient_fee() {
-        let (env, creator) = setup_env();
+        let (env, contract_id, creator) = setup_env();
+        let client = crate::TokenFactoryClient::new(&env, &contract_id);
 
-        let initial_count = storage::get_token_count(&env);
-
-        // Create batch
         let mut tokens = Vec::new(&env);
         tokens.push_back(create_token_params(&env, "Token1", "T1"));
         tokens.push_back(create_token_params(&env, "Token2", "T2"));
 
-        let base_fee = storage::get_base_fee(&env);
-        let insufficient_fee = base_fee;  // Only enough for 1 token
+        let base_fee = client.get_state().base_fee;
+        let insufficient_fee = base_fee; // Only enough for 1 token
 
-        // Should fail due to insufficient fee
-        let result = batch_reveal(&env, creator, tokens, insufficient_fee);
+        let result = client.try_batch_reveal(&creator, &tokens, &insufficient_fee);
         assert!(result.is_err());
-        assert_eq!(result.unwrap_err(), Error::InsufficientFee);
+        assert_eq!(result.unwrap_err().unwrap(), Error::InsufficientFee);
 
-        // Verify state unchanged
-        let final_count = storage::get_token_count(&env);
-        assert_eq!(initial_count, final_count);
+        // Verify state unchanged.
+        assert!(client.try_get_token_info(&0_u32).is_err());
     }
 
     #[test]
     fn test_batch_atomicity_with_metadata() {
-        let (env, creator) = setup_env();
+        let (env, contract_id, creator) = setup_env();
+        let client = crate::TokenFactoryClient::new(&env, &contract_id);
 
-        let initial_count = storage::get_token_count(&env);
-
-        // Batch with metadata
         let mut tokens = Vec::new(&env);
         tokens.push_back(create_token_params_with_metadata(&env, "Token1", "T1"));
         tokens.push_back(create_token_params_with_metadata(&env, "Token2", "T2"));
 
-        let base_fee = storage::get_base_fee(&env);
-        let metadata_fee = storage::get_metadata_fee(&env);
-        let required_fee = (base_fee + metadata_fee) * 2;
+        let state = client.get_state();
+        let required_fee = (state.base_fee + state.metadata_fee) * 2;
 
-        let result = batch_reveal(&env, creator, tokens, required_fee);
-        assert!(result.is_ok());
-
-        let final_count = storage::get_token_count(&env);
-        assert_eq!(final_count, initial_count + 2);
+        let indices = client.batch_reveal(&creator, &tokens, &required_fee);
+        assert_eq!(indices.len(), 2);
+        assert!(client.try_get_token_info(&0_u32).is_ok());
+        assert!(client.try_get_token_info(&1_u32).is_ok());
     }
 
     #[test]
     fn test_batch_atomicity_max_batch_size() {
-        let (env, creator) = setup_env();
+        let (env, contract_id, creator) = setup_env();
+        let client = crate::TokenFactoryClient::new(&env, &contract_id);
 
-        // Create batch at max size
         let mut tokens = Vec::new(&env);
-        for i in 0..MAX_BATCH_SIZE {
-            let name = format!("Token{}", i);
-            let symbol = format!("T{}", i);
-            tokens.push_back(create_token_params(&env, &name, &symbol));
+        for _ in 0..MAX_BATCH_SIZE {
+            tokens.push_back(TokenCreationParams {
+                name: SorobanString::from_str(&env, "Token"),
+                symbol: SorobanString::from_str(&env, "TK0"),
+                decimals: 7,
+                initial_supply: 1_000_000_000_000,
+                max_supply: None,
+                metadata_uri: None,
+            });
         }
 
-        let base_fee = storage::get_base_fee(&env);
+        let base_fee = client.get_state().base_fee;
         let required_fee = base_fee * (MAX_BATCH_SIZE as i128);
 
-        let result = batch_reveal(&env, creator, tokens, required_fee);
-        assert!(result.is_ok());
-
-        let indices = result.unwrap();
+        let indices = client.batch_reveal(&creator, &tokens, &required_fee);
         assert_eq!(indices.len() as u32, MAX_BATCH_SIZE);
     }
 
     #[test]
     fn test_batch_atomicity_exceeds_max_size() {
-        let (env, creator) = setup_env();
+        let (env, contract_id, creator) = setup_env();
+        let client = crate::TokenFactoryClient::new(&env, &contract_id);
 
-        // Create batch exceeding max size
         let mut tokens = Vec::new(&env);
-        for i in 0..=MAX_BATCH_SIZE {
-            let name = format!("Token{}", i);
-            let symbol = format!("T{}", i);
-            tokens.push_back(create_token_params(&env, &name, &symbol));
+        for _ in 0..=MAX_BATCH_SIZE {
+            tokens.push_back(TokenCreationParams {
+                name: SorobanString::from_str(&env, "Token"),
+                symbol: SorobanString::from_str(&env, "TK0"),
+                decimals: 7,
+                initial_supply: 1_000_000_000_000,
+                max_supply: None,
+                metadata_uri: None,
+            });
         }
 
-        let base_fee = storage::get_base_fee(&env);
+        let base_fee = client.get_state().base_fee;
         let required_fee = base_fee * ((MAX_BATCH_SIZE + 1) as i128);
 
-        let result = batch_reveal(&env, creator, tokens, required_fee);
+        let result = client.try_batch_reveal(&creator, &tokens, &required_fee);
         assert!(result.is_err());
-        assert_eq!(result.unwrap_err(), Error::BatchTooLarge);
+        assert_eq!(result.unwrap_err().unwrap(), Error::BatchTooLarge);
     }
 
     #[test]
     fn test_batch_atomicity_state_consistency_after_failure() {
-        let (env, creator) = setup_env();
+        let (env, contract_id, creator) = setup_env();
+        let client = crate::TokenFactoryClient::new(&env, &contract_id);
 
-        // First successful batch
+        // First successful batch.
         let mut tokens1 = Vec::new(&env);
         tokens1.push_back(create_token_params(&env, "Token1", "T1"));
-        let base_fee = storage::get_base_fee(&env);
-        let result1 = batch_reveal(&env, creator.clone(), tokens1, base_fee);
-        assert!(result1.is_ok());
+        let base_fee = client.get_state().base_fee;
+        let indices1 = client.batch_reveal(&creator, &tokens1, &base_fee);
+        assert_eq!(indices1.len(), 1);
 
-        let count_after_first = storage::get_token_count(&env);
-
-        // Second batch with invalid element
+        // Second batch with an invalid element must fail and change nothing.
         let mut tokens2 = Vec::new(&env);
         tokens2.push_back(create_token_params(&env, "Token2", "T2"));
         tokens2.push_back(TokenCreationParams {
-            name: SorobanString::from_slice(&env, ""),  // Invalid
-            symbol: SorobanString::from_slice(&env, "INVALID"),
+            name: SorobanString::from_str(&env, ""), // Invalid
+            symbol: SorobanString::from_str(&env, "INVALID"),
             decimals: 7,
             initial_supply: 1_000_000_000_000,
+            max_supply: None,
             metadata_uri: None,
         });
 
-        let result2 = batch_reveal(&env, creator, tokens2, base_fee * 2);
-        assert!(result2.is_err());
+        let result = client.try_batch_reveal(&creator, &tokens2, &(base_fee * 2));
+        assert!(result.is_err());
 
-        // Verify state is consistent with first batch
-        let count_after_second = storage::get_token_count(&env);
-        assert_eq!(count_after_first, count_after_second, "State should not change after failed batch");
+        // Token index 1 (the would-be "Token2") must not exist.
+        assert!(client.try_get_token_info(&1_u32).is_err());
+        // Token index 0 (from the first batch) must be unaffected.
+        assert!(client.try_get_token_info(&0_u32).is_ok());
+    }
+
+    // ── pre-flight: catches failures before any execution ──────────────────
+
+    #[test]
+    fn test_preflight_catches_invalid_element_with_no_side_effects() {
+        let (env, contract_id, _creator) = setup_env();
+        let client = crate::TokenFactoryClient::new(&env, &contract_id);
+
+        let mut tokens = Vec::new(&env);
+        tokens.push_back(create_token_params(&env, "Token1", "T1"));
+        tokens.push_back(TokenCreationParams {
+            name: SorobanString::from_str(&env, ""), // Invalid: empty name
+            symbol: SorobanString::from_str(&env, "INVALID"),
+            decimals: 7,
+            initial_supply: 1_000_000_000_000,
+            max_supply: None,
+            metadata_uri: None,
+        });
+
+        let base_fee = client.get_state().base_fee;
+        let results = client.preflight_batch_reveal(&tokens, &(base_fee * 2));
+
+        assert_eq!(results.len(), 2);
+        assert_eq!(results.get(0).unwrap().error_code, 0);
+        assert_eq!(results.get(1).unwrap().error_code, Error::InvalidTokenParams.0);
+
+        // The dry-run must not have created anything.
+        assert!(client.try_get_token_info(&0_u32).is_err());
+    }
+
+    #[test]
+    fn test_preflight_reports_all_valid_for_clean_batch() {
+        let (env, contract_id, _creator) = setup_env();
+        let client = crate::TokenFactoryClient::new(&env, &contract_id);
+
+        let tokens = {
+            let mut v = Vec::new(&env);
+            v.push_back(create_token_params(&env, "Token1", "T1"));
+            v.push_back(create_token_params(&env, "Token2", "T2"));
+            v
+        };
+
+        let base_fee = client.get_state().base_fee;
+        let results = client.preflight_batch_reveal(&tokens, &(base_fee * 2));
+
+        assert_eq!(results.len(), 2);
+        for r in results.iter() {
+            assert_eq!(r.error_code, 0);
+        }
+        assert!(client.try_get_token_info(&0_u32).is_err());
     }
 }

--- a/contracts/token-factory/src/batch_operations.rs
+++ b/contracts/token-factory/src/batch_operations.rs
@@ -3,10 +3,26 @@
 /// Provides `batch_reveal` (batch token creation) and `batch_settle` (batch mint)
 /// with atomic execution, storage-access optimization, and a hard batch-size cap
 /// to bound gas consumption.
-use soroban_sdk::{Address, Env, Vec};
+///
+/// ## Atomicity model
+/// Every batch operation is split into two phases:
+/// 1. **Stage** – validate every item and compute the exact value that will be
+///    written for it. Nothing is written to storage in this phase, so any
+///    failure here (returned as `Err`) leaves the ledger byte-for-byte
+///    unchanged.
+/// 2. **Commit** – write the values staged in phase 1. Every value committed
+///    here was already validated, so this phase cannot fail: there is no
+///    operator in the commit loop that can return `Err`. This holds even
+///    when the function is called directly (bypassing the host's contract
+///    invocation boundary, as unit tests do), not just when atomicity is
+///    provided implicitly by the host rolling back a failed invocation.
+///
+/// `preflight_batch_reveal` / `preflight_batch_settle` expose phase 1 standalone
+/// so callers can validate a batch without paying for (or risking) execution.
+use soroban_sdk::{Address, Env, Map, Vec};
 
 use crate::storage;
-use crate::types::{Error, TokenCreationParams};
+use crate::types::{Error, PreflightItemResult, TokenCreationParams};
 
 /// Maximum number of items allowed in a single batch call.
 pub const MAX_BATCH_SIZE: u32 = 50;
@@ -54,13 +70,17 @@ pub fn batch_reveal(
         return Err(Error::BatchTooLarge);
     }
 
-    // ── Phase 1: validate all params and accumulate required fee ──────────
+    // ── Phase 1 (stage): validate every item and compute its final token
+    // index. Nothing is written to storage here. ───────────────────────────
     let base_fee = storage::get_base_fee(env);
     let metadata_fee = storage::get_metadata_fee(env);
+    let start_index = storage::get_token_count(env);
 
     let mut required_fee: i128 = 0;
-    for token in tokens.iter() {
+    let mut staged_indices: Vec<u32> = Vec::new(env);
+    for (i, token) in tokens.iter().enumerate() {
         validate_token_params(env, &token)?;
+
         let token_fee = if token.metadata_uri.is_some() {
             base_fee
                 .checked_add(metadata_fee)
@@ -71,23 +91,26 @@ pub fn batch_reveal(
         required_fee = required_fee
             .checked_add(token_fee)
             .ok_or(Error::ArithmeticError)?;
+
+        let token_index = start_index
+            .checked_add(i as u32)
+            .ok_or(Error::ArithmeticError)?;
+        staged_indices.push_back(token_index);
     }
 
     if total_fee_payment < required_fee {
         return Err(Error::InsufficientFee);
     }
 
-    // ── Phase 2: write state (all validations passed) ─────────────────────
-    // Read token count once to avoid N storage reads.
-    let start_index = storage::get_token_count(env);
+    // ── Phase 2 (commit): write every staged token. Every index/value here
+    // was already validated above, so this loop is infallible — no item can
+    // be left partially applied. A failure would indicate a phase-1/phase-2
+    // mismatch, so we panic (triggering a full host-level rollback) rather
+    // than risk silently committing a partial batch. ───────────────────────
     let mut indices = Vec::new(env);
-
-    for (i, token) in tokens.iter().enumerate() {
-        let token_index = start_index
-            .checked_add(i as u32)
-            .ok_or(Error::ArithmeticError)?;
-
-        crate::token_creation::create_token_internal(env, &creator, &token, token_index)?;
+    for (token, token_index) in tokens.iter().zip(staged_indices.iter()) {
+        crate::token_creation::create_token_internal(env, &creator, &token, token_index)
+            .unwrap_or_else(|e| panic!("batch_reveal: phase 2 commit failed after phase 1 validation passed: {:?}", e));
         indices.push_back(token_index);
     }
 
@@ -104,11 +127,76 @@ pub fn batch_reveal(
     Ok(indices)
 }
 
+/// Dry-run `batch_reveal`'s validation phase without writing any state.
+///
+/// Returns one [`PreflightItemResult`] per input token (`error_code == 0`
+/// means that item would succeed), plus an extra entry at `index ==
+/// tokens.len()` with `Error::InsufficientFee` if `total_fee_payment` would
+/// be too low for the items that do pass validation. Does not require
+/// `creator` authorization since nothing is mutated or spent.
+///
+/// # Errors
+/// * `ContractPaused`    – Factory is paused.
+/// * `InvalidParameters` – Empty batch.
+/// * `BatchTooLarge`     – `tokens.len() > MAX_BATCH_SIZE`.
+pub fn preflight_batch_reveal(
+    env: &Env,
+    tokens: Vec<TokenCreationParams>,
+    total_fee_payment: i128,
+) -> Result<Vec<PreflightItemResult>, Error> {
+    if storage::is_paused(env) {
+        return Err(Error::ContractPaused);
+    }
+
+    let batch_len = tokens.len();
+    if batch_len == 0 {
+        return Err(Error::InvalidParameters);
+    }
+    if batch_len > MAX_BATCH_SIZE {
+        return Err(Error::BatchTooLarge);
+    }
+
+    let base_fee = storage::get_base_fee(env);
+    let metadata_fee = storage::get_metadata_fee(env);
+
+    let mut results = Vec::new(env);
+    let mut required_fee: i128 = 0;
+    for (i, token) in tokens.iter().enumerate() {
+        let error_code = match validate_token_params(env, &token) {
+            Ok(()) => 0,
+            Err(e) => e.0,
+        };
+        results.push_back(PreflightItemResult {
+            index: i as u32,
+            error_code,
+        });
+
+        if error_code == 0 {
+            let token_fee = if token.metadata_uri.is_some() {
+                base_fee.checked_add(metadata_fee).unwrap_or(i128::MAX)
+            } else {
+                base_fee
+            };
+            required_fee = required_fee.checked_add(token_fee).unwrap_or(i128::MAX);
+        }
+    }
+
+    if total_fee_payment < required_fee {
+        results.push_back(PreflightItemResult {
+            index: batch_len,
+            error_code: Error::InsufficientFee.0,
+        });
+    }
+
+    Ok(results)
+}
+
 /// Batch-mint tokens to multiple recipients in a single atomic transaction.
 ///
 /// All recipients receive tokens from the same `token_index`. The caller must
-/// be the token creator. Validation of every (recipient, amount) pair is done
-/// before any balance is updated.
+/// be the token creator. Validation of every (recipient, amount) pair — and
+/// the resulting per-recipient balance — is done before any balance is
+/// updated. Duplicate recipients in the same batch are accumulated correctly.
 ///
 /// # Gas optimisation
 /// Token info is loaded once and reused across all mint operations.
@@ -128,6 +216,7 @@ pub fn batch_reveal(
 /// * `TokenPaused`       – Token is paused.
 /// * `BatchTooLarge`     – More than `MAX_BATCH_SIZE` recipients.
 /// * `InvalidParameters` – Empty recipients list or any amount ≤ 0.
+/// * `ArithmeticError`   – Aggregate or per-recipient balance would overflow.
 /// * `MaxSupplyExceeded` – Batch would exceed the token's max supply.
 pub fn batch_settle(
     env: &Env,
@@ -159,36 +248,157 @@ pub fn batch_settle(
         return Err(Error::TokenPaused);
     }
 
-    // ── Phase 1: validate all amounts and compute total ───────────────────
+    // ── Phase 1 (stage): validate every recipient and compute the final
+    // balance each unique address will hold. Nothing is written to storage
+    // here. Recipient deltas are accumulated per-address first so duplicate
+    // recipients in the same batch are handled correctly. ──────────────────
     let mut total_mint: i128 = 0;
-    for (_, amount) in recipients.iter() {
+    let mut deltas: Map<Address, i128> = Map::new(env);
+    for (recipient, amount) in recipients.iter() {
         if amount <= 0 {
             return Err(Error::InvalidParameters);
         }
         total_mint = total_mint
             .checked_add(amount)
             .ok_or(Error::ArithmeticError)?;
+
+        let prior = deltas.get(recipient.clone()).unwrap_or(0);
+        let combined = prior.checked_add(amount).ok_or(Error::ArithmeticError)?;
+        deltas.set(recipient.clone(), combined);
     }
 
     // Check max supply once using the aggregated total.
+    let new_supply = token_info
+        .total_supply
+        .checked_add(total_mint)
+        .ok_or(Error::ArithmeticError)?;
     if let Some(max) = token_info.max_supply {
-        let new_supply = token_info
-            .total_supply
-            .checked_add(total_mint)
-            .ok_or(Error::ArithmeticError)?;
         if new_supply > max {
             return Err(Error::MaxSupplyExceeded);
         }
     }
 
-    // ── Phase 2: apply mints ──────────────────────────────────────────────
+    // Resolve each unique recipient's final balance against current storage,
+    // catching any per-recipient overflow before committing anything.
+    let mut staged_balances: Map<Address, i128> = Map::new(env);
+    for (recipient, delta) in deltas.iter() {
+        let current_balance = storage::get_balance(env, token_index, &recipient);
+        let new_balance = current_balance
+            .checked_add(delta)
+            .ok_or(Error::ArithmeticError)?;
+        staged_balances.set(recipient, new_balance);
+    }
+
+    // ── Phase 2 (commit): write every staged balance and the new total
+    // supply. Every value here was already validated above, so this phase
+    // is infallible. ─────────────────────────────────────────────────────
+    let mut updated_info = token_info;
+    updated_info.total_supply = new_supply;
+    storage::set_token_info(env, token_index, &updated_info);
+
+    for (recipient, _) in deltas.iter() {
+        let new_balance = staged_balances
+            .get(recipient.clone())
+            .unwrap_or_else(|| panic!("batch_settle: phase 2 commit missing staged balance"));
+        storage::set_balance(env, token_index, &recipient, new_balance);
+        let _ = crate::snapshot::record_balance_snapshot(env, token_index, &recipient, new_balance);
+    }
+    let _ = crate::snapshot::record_supply_snapshot(env, token_index, new_supply);
+
+    // Emit one `mint` event per input entry, in input order, matching the
+    // documented event-ordering contract (duplicates emit once each).
     for (recipient, amount) in recipients.iter() {
-        crate::mint::mint(env, token_index, &recipient, amount)?;
+        crate::events::emit_mint(env, token_index, &recipient, amount);
     }
 
     crate::events::emit_batch_settle(env, token_index, &creator, batch_len, total_mint);
 
     Ok(total_mint)
+}
+
+/// Dry-run `batch_settle`'s validation phase without writing any state.
+///
+/// Returns one [`PreflightItemResult`] per `(recipient, amount)` pair
+/// (`error_code == 0` means that item would succeed), plus an extra entry at
+/// `index == recipients.len()` with `Error::MaxSupplyExceeded` if the
+/// aggregate mint would exceed the token's max supply.
+///
+/// # Errors
+/// * `ContractPaused`    – Factory is paused.
+/// * `InvalidParameters` – Empty recipients list.
+/// * `BatchTooLarge`     – More than `MAX_BATCH_SIZE` recipients.
+/// * `TokenNotFound`     – `token_index` does not exist.
+/// * `Unauthorized`      – Caller is not the token creator.
+/// * `TokenPaused`       – Token is paused.
+pub fn preflight_batch_settle(
+    env: &Env,
+    creator: Address,
+    token_index: u32,
+    recipients: Vec<(Address, i128)>,
+) -> Result<Vec<PreflightItemResult>, Error> {
+    if storage::is_paused(env) {
+        return Err(Error::ContractPaused);
+    }
+
+    let batch_len = recipients.len();
+    if batch_len == 0 {
+        return Err(Error::InvalidParameters);
+    }
+    if batch_len > MAX_BATCH_SIZE {
+        return Err(Error::BatchTooLarge);
+    }
+
+    let token_info = storage::get_token_info(env, token_index).ok_or(Error::TokenNotFound)?;
+    if token_info.creator != creator {
+        return Err(Error::Unauthorized);
+    }
+    if storage::is_token_paused(env, token_index) {
+        return Err(Error::TokenPaused);
+    }
+
+    let mut results = Vec::new(env);
+    let mut total_mint: i128 = 0;
+    let mut any_item_failed = false;
+
+    for (i, (_recipient, amount)) in recipients.iter().enumerate() {
+        if amount <= 0 {
+            results.push_back(PreflightItemResult {
+                index: i as u32,
+                error_code: Error::InvalidParameters.0,
+            });
+            any_item_failed = true;
+            continue;
+        }
+        match total_mint.checked_add(amount) {
+            Some(v) => total_mint = v,
+            None => {
+                results.push_back(PreflightItemResult {
+                    index: i as u32,
+                    error_code: Error::ArithmeticError.0,
+                });
+                any_item_failed = true;
+                continue;
+            }
+        }
+        results.push_back(PreflightItemResult {
+            index: i as u32,
+            error_code: 0,
+        });
+    }
+
+    if !any_item_failed {
+        if let Some(max) = token_info.max_supply {
+            let new_supply = token_info.total_supply.checked_add(total_mint).unwrap_or(i128::MAX);
+            if new_supply > max {
+                results.push_back(PreflightItemResult {
+                    index: batch_len,
+                    error_code: Error::MaxSupplyExceeded.0,
+                });
+            }
+        }
+    }
+
+    Ok(results)
 }
 
 // ── helpers ───────────────────────────────────────────────────────────────────
@@ -215,6 +425,8 @@ fn validate_token_params(env: &Env, params: &TokenCreationParams) -> Result<(), 
 
 #[cfg(test)]
 mod tests {
+    extern crate std;
+
     use super::*;
     use soroban_sdk::{testutils::Address as _, vec, Env, String};
 
@@ -258,7 +470,7 @@ mod tests {
             make_params(&env, "Gamma", "GAM"),
         ];
         // 3 tokens × base_fee (1_000_000 each, no metadata)
-        let indices = client.batch_reveal(&admin, &tokens, &3_000_000_i128).unwrap();
+        let indices = client.batch_reveal(&admin, &tokens, &3_000_000_i128);
 
         assert_eq!(indices.len(), 3);
         assert_eq!(indices.get(0).unwrap(), 0);
@@ -272,7 +484,7 @@ mod tests {
         let client = crate::TokenFactoryClient::new(&env, &contract_id);
 
         let tokens: Vec<TokenCreationParams> = vec![&env];
-        let err = client.batch_reveal(&admin, &tokens, &0_i128).unwrap_err();
+        let err = client.try_batch_reveal(&admin, &tokens, &0_i128).unwrap_err().unwrap();
         assert_eq!(err, crate::types::Error::InvalidParameters.into());
     }
 
@@ -282,7 +494,7 @@ mod tests {
         let client = crate::TokenFactoryClient::new(&env, &contract_id);
 
         let tokens = vec![&env, make_params(&env, "Alpha", "ALP")];
-        let err = client.batch_reveal(&admin, &tokens, &0_i128).unwrap_err();
+        let err = client.try_batch_reveal(&admin, &tokens, &0_i128).unwrap_err().unwrap();
         assert_eq!(err, crate::types::Error::InsufficientFee.into());
     }
 
@@ -300,121 +512,14 @@ mod tests {
             metadata_uri: None,
         };
         let tokens = vec![&env, make_params(&env, "Good", "GD"), bad];
-        let err = client.batch_reveal(&admin, &tokens, &2_000_000_i128).unwrap_err();
+        let err = client.try_batch_reveal(&admin, &tokens, &2_000_000_i128).unwrap_err().unwrap();
         assert_eq!(err, crate::types::Error::InvalidTokenParams.into());
 
         // Token count must remain 0 — no partial writes.
         let state = client.get_state();
         let _ = state; // state is accessible; token count checked via get_token_info
-        let info = client.get_token_info(&0_u32);
+        let info = client.try_get_token_info(&0_u32);
         assert!(info.is_err(), "no token should have been created");
-    }
-
-    // ── batch_settle ──────────────────────────────────────────────────────
-
-    #[test]
-    fn batch_settle_mints_to_multiple_recipients() {
-        let (env, contract_id, admin, _treasury) = setup();
-        let client = crate::TokenFactoryClient::new(&env, &contract_id);
-
-        // Create a token first.
-        client
-            .create_token(
-                &admin,
-                &String::from_str(&env, "MyToken"),
-                &String::from_str(&env, "MTK"),
-                &7_u32,
-                &1_000_000_i128,
-                &None,
-                &1_000_000_i128,
-            )
-            .unwrap();
-
-        let r1 = Address::generate(&env);
-        let r2 = Address::generate(&env);
-        let r3 = Address::generate(&env);
-
-        let recipients = vec![
-            &env,
-            (r1.clone(), 100_i128),
-            (r2.clone(), 200_i128),
-            (r3.clone(), 300_i128),
-        ];
-
-        let total = client.batch_settle(&admin, &0_u32, &recipients).unwrap();
-        assert_eq!(total, 600_i128);
-    }
-
-    #[test]
-    fn batch_settle_rejects_zero_amount() {
-        let (env, contract_id, admin, _treasury) = setup();
-        let client = crate::TokenFactoryClient::new(&env, &contract_id);
-
-        client
-            .create_token(
-                &admin,
-                &String::from_str(&env, "MyToken"),
-                &String::from_str(&env, "MTK"),
-                &7_u32,
-                &1_000_000_i128,
-                &None,
-                &1_000_000_i128,
-            )
-            .unwrap();
-
-        let r1 = Address::generate(&env);
-        let recipients = vec![&env, (r1, 0_i128)];
-        let err = client.batch_settle(&admin, &0_u32, &recipients).unwrap_err();
-        assert_eq!(err, crate::types::Error::InvalidParameters.into());
-    }
-
-    #[test]
-    fn batch_settle_rejects_non_creator() {
-        let (env, contract_id, admin, _treasury) = setup();
-        let client = crate::TokenFactoryClient::new(&env, &contract_id);
-
-        client
-            .create_token(
-                &admin,
-                &String::from_str(&env, "MyToken"),
-                &String::from_str(&env, "MTK"),
-                &7_u32,
-                &1_000_000_i128,
-                &None,
-                &1_000_000_i128,
-            )
-            .unwrap();
-
-        let impostor = Address::generate(&env);
-        let r1 = Address::generate(&env);
-        let recipients = vec![&env, (r1, 100_i128)];
-        let err = client.batch_settle(&impostor, &0_u32, &recipients).unwrap_err();
-        assert_eq!(err, crate::types::Error::Unauthorized.into());
-    }
-
-    #[test]
-    fn batch_settle_respects_max_supply() {
-        let (env, contract_id, admin, _treasury) = setup();
-        let client = crate::TokenFactoryClient::new(&env, &contract_id);
-
-        // Create token with max_supply = 1_000_000 (already at cap from initial supply).
-        let params = vec![
-            &env,
-            TokenCreationParams {
-                name: String::from_str(&env, "Capped"),
-                symbol: String::from_str(&env, "CAP"),
-                decimals: 7,
-                initial_supply: 1_000_000,
-                max_supply: Some(1_000_000),
-                metadata_uri: None,
-            },
-        ];
-        client.batch_reveal(&admin, &params, &1_000_000_i128).unwrap();
-
-        let r1 = Address::generate(&env);
-        let recipients = vec![&env, (r1, 1_i128)];
-        let err = client.batch_settle(&admin, &0_u32, &recipients).unwrap_err();
-        assert_eq!(err, crate::types::Error::MaxSupplyExceeded.into());
     }
 
     #[test]
@@ -440,7 +545,7 @@ mod tests {
             });
         }
 
-        let indices = client.batch_reveal(&admin, &tokens, &10_000_000_i128).unwrap();
+        let indices = client.batch_reveal(&admin, &tokens, &10_000_000_i128);
         assert_eq!(indices.len(), 10);
     }
 
@@ -464,9 +569,331 @@ mod tests {
             bad,
             make_params(&env, "Good2", "GD2"),
         ];
-        let err = client.batch_reveal(&admin, &tokens, &3_000_000_i128).unwrap_err();
+        let err = client.try_batch_reveal(&admin, &tokens, &3_000_000_i128).unwrap_err().unwrap();
         assert_eq!(err, crate::types::Error::InvalidTokenParams.into());
         // No token should have been created.
-        assert!(client.get_token_info(&0_u32).is_err());
+        assert!(client.try_get_token_info(&0_u32).is_err());
+    }
+
+    // ── preflight_batch_reveal ────────────────────────────────────────────
+
+    #[test]
+    fn preflight_batch_reveal_reports_all_valid_with_no_side_effects() {
+        let (env, contract_id, _admin, _treasury) = setup();
+        let client = crate::TokenFactoryClient::new(&env, &contract_id);
+
+        let tokens = vec![
+            &env,
+            make_params(&env, "Alpha", "ALP"),
+            make_params(&env, "Beta", "BET"),
+        ];
+        let results = client
+            .preflight_batch_reveal(&tokens, &2_000_000_i128);
+
+        assert_eq!(results.len(), 2);
+        for r in results.iter() {
+            assert_eq!(r.error_code, 0);
+        }
+        // Pure dry-run: no token should exist afterwards.
+        assert!(client.try_get_token_info(&0_u32).is_err());
+    }
+
+    #[test]
+    fn preflight_batch_reveal_catches_invalid_item_before_execution() {
+        let (env, contract_id, _admin, _treasury) = setup();
+        let client = crate::TokenFactoryClient::new(&env, &contract_id);
+
+        let bad = TokenCreationParams {
+            name: String::from_str(&env, ""), // invalid: empty name
+            symbol: String::from_str(&env, "BAD"),
+            decimals: 7,
+            initial_supply: 1_000_000,
+            max_supply: None,
+            metadata_uri: None,
+        };
+        let tokens = vec![&env, make_params(&env, "Good", "GD"), bad];
+        let results = client
+            .preflight_batch_reveal(&tokens, &2_000_000_i128);
+
+        assert_eq!(results.len(), 2);
+        assert_eq!(results.get(0).unwrap().error_code, 0);
+        assert_eq!(
+            results.get(1).unwrap().error_code,
+            crate::types::Error::InvalidTokenParams.0
+        );
+        // No side effects from the dry-run.
+        assert!(client.try_get_token_info(&0_u32).is_err());
+    }
+
+    #[test]
+    fn preflight_batch_reveal_flags_insufficient_fee_as_aggregate_entry() {
+        let (env, contract_id, _admin, _treasury) = setup();
+        let client = crate::TokenFactoryClient::new(&env, &contract_id);
+
+        let tokens = vec![&env, make_params(&env, "Alpha", "ALP")];
+        let results = client.preflight_batch_reveal(&tokens, &0_i128);
+
+        assert_eq!(results.len(), 2); // 1 item result + 1 aggregate fee result
+        assert_eq!(results.get(0).unwrap().error_code, 0);
+        assert_eq!(
+            results.get(1).unwrap().error_code,
+            crate::types::Error::InsufficientFee.0
+        );
+    }
+
+    // ── batch_settle ──────────────────────────────────────────────────────
+
+    fn create_simple_token(env: &Env, client: &crate::TokenFactoryClient, admin: &Address) {
+        client.create_token(
+            admin,
+            &String::from_str(env, "MyToken"),
+            &String::from_str(env, "MTK"),
+            &7_u32,
+            &1_000_000_i128,
+            &None,
+            &1_000_000_i128,
+        );
+    }
+
+    #[test]
+    fn batch_settle_mints_to_multiple_recipients() {
+        let (env, contract_id, admin, _treasury) = setup();
+        let client = crate::TokenFactoryClient::new(&env, &contract_id);
+        create_simple_token(&env, &client, &admin);
+
+        let r1 = Address::generate(&env);
+        let r2 = Address::generate(&env);
+        let r3 = Address::generate(&env);
+
+        let recipients = vec![
+            &env,
+            (r1.clone(), 100_i128),
+            (r2.clone(), 200_i128),
+            (r3.clone(), 300_i128),
+        ];
+
+        let total = client.batch_settle(&admin, &0_u32, &recipients);
+        assert_eq!(total, 600_i128);
+    }
+
+    #[test]
+    fn batch_settle_accumulates_duplicate_recipients() {
+        let (env, contract_id, admin, _treasury) = setup();
+        let client = crate::TokenFactoryClient::new(&env, &contract_id);
+        create_simple_token(&env, &client, &admin);
+
+        let r1 = Address::generate(&env);
+        let recipients = vec![&env, (r1.clone(), 100_i128), (r1.clone(), 50_i128)];
+
+        let total = client.batch_settle(&admin, &0_u32, &recipients);
+        assert_eq!(total, 150_i128);
+
+        let balance = env.as_contract(&contract_id, || storage::get_balance(&env, 0, &r1));
+        assert_eq!(balance, 150_i128);
+    }
+
+    #[test]
+    fn batch_settle_rejects_zero_amount() {
+        let (env, contract_id, admin, _treasury) = setup();
+        let client = crate::TokenFactoryClient::new(&env, &contract_id);
+        create_simple_token(&env, &client, &admin);
+
+        let r1 = Address::generate(&env);
+        let recipients = vec![&env, (r1, 0_i128)];
+        let err = client.try_batch_settle(&admin, &0_u32, &recipients).unwrap_err().unwrap();
+        assert_eq!(err, crate::types::Error::InvalidParameters.into());
+    }
+
+    #[test]
+    fn batch_settle_rejects_non_creator() {
+        let (env, contract_id, admin, _treasury) = setup();
+        let client = crate::TokenFactoryClient::new(&env, &contract_id);
+        create_simple_token(&env, &client, &admin);
+
+        let impostor = Address::generate(&env);
+        let r1 = Address::generate(&env);
+        let recipients = vec![&env, (r1, 100_i128)];
+        let err = client.try_batch_settle(&impostor, &0_u32, &recipients).unwrap_err().unwrap();
+        assert_eq!(err, crate::types::Error::Unauthorized.into());
+    }
+
+    #[test]
+    fn batch_settle_respects_max_supply() {
+        let (env, contract_id, admin, _treasury) = setup();
+        let client = crate::TokenFactoryClient::new(&env, &contract_id);
+
+        // Create token with max_supply = 1_000_000 (already at cap from initial supply).
+        let params = vec![
+            &env,
+            TokenCreationParams {
+                name: String::from_str(&env, "Capped"),
+                symbol: String::from_str(&env, "CAP"),
+                decimals: 7,
+                initial_supply: 1_000_000,
+                max_supply: Some(1_000_000),
+                metadata_uri: None,
+            },
+        ];
+        client.batch_reveal(&admin, &params, &1_000_000_i128);
+
+        let r1 = Address::generate(&env);
+        let recipients = vec![&env, (r1, 1_i128)];
+        let err = client.try_batch_settle(&admin, &0_u32, &recipients).unwrap_err().unwrap();
+        assert_eq!(err, crate::types::Error::MaxSupplyExceeded.into());
+    }
+
+    #[test]
+    fn batch_settle_rolls_back_fully_on_per_recipient_overflow() {
+        let (env, contract_id, admin, _treasury) = setup();
+        let client = crate::TokenFactoryClient::new(&env, &contract_id);
+        create_simple_token(&env, &client, &admin);
+
+        let near_max = Address::generate(&env);
+        let untouched = Address::generate(&env);
+
+        // Push near_max's balance right up against i128::MAX so the batch
+        // overflows on their entry, after `untouched` would already have
+        // been written under the old direct-write-per-item approach.
+        env.as_contract(&contract_id, || {
+            storage::set_balance(&env, 0, &near_max, i128::MAX - 10);
+        });
+
+        let recipients = vec![
+            &env,
+            (untouched.clone(), 500_i128),
+            (near_max.clone(), 100_i128),
+        ];
+        let err = client.try_batch_settle(&admin, &0_u32, &recipients).unwrap_err().unwrap();
+        assert_eq!(err, crate::types::Error::ArithmeticError.into());
+
+        // Full rollback: neither recipient's balance changed.
+        assert_eq!(env.as_contract(&contract_id, || storage::get_balance(&env, 0, &untouched)), 0_i128);
+        assert_eq!(env.as_contract(&contract_id, || storage::get_balance(&env, 0, &near_max)), i128::MAX - 10);
+    }
+
+    // ── preflight_batch_settle ────────────────────────────────────────────
+
+    #[test]
+    fn preflight_batch_settle_reports_all_valid_with_no_side_effects() {
+        let (env, contract_id, admin, _treasury) = setup();
+        let client = crate::TokenFactoryClient::new(&env, &contract_id);
+        create_simple_token(&env, &client, &admin);
+
+        let r1 = Address::generate(&env);
+        let r2 = Address::generate(&env);
+        let recipients = vec![&env, (r1.clone(), 100_i128), (r2.clone(), 200_i128)];
+
+        let results = client
+            .preflight_batch_settle(&admin, &0_u32, &recipients);
+
+        assert_eq!(results.len(), 2);
+        for r in results.iter() {
+            assert_eq!(r.error_code, 0);
+        }
+        // Pure dry-run: balances must remain zero.
+        assert_eq!(env.as_contract(&contract_id, || storage::get_balance(&env, 0, &r1)), 0_i128);
+        assert_eq!(env.as_contract(&contract_id, || storage::get_balance(&env, 0, &r2)), 0_i128);
+    }
+
+    #[test]
+    fn preflight_batch_settle_catches_invalid_item_before_execution() {
+        let (env, contract_id, admin, _treasury) = setup();
+        let client = crate::TokenFactoryClient::new(&env, &contract_id);
+        create_simple_token(&env, &client, &admin);
+
+        let r1 = Address::generate(&env);
+        let r2 = Address::generate(&env);
+        let recipients = vec![&env, (r1, 100_i128), (r2, 0_i128)];
+
+        let results = client
+            .preflight_batch_settle(&admin, &0_u32, &recipients);
+
+        assert_eq!(results.len(), 2);
+        assert_eq!(results.get(0).unwrap().error_code, 0);
+        assert_eq!(
+            results.get(1).unwrap().error_code,
+            crate::types::Error::InvalidParameters.0
+        );
+    }
+
+    #[test]
+    fn preflight_batch_settle_flags_max_supply_as_aggregate_entry() {
+        let (env, contract_id, admin, _treasury) = setup();
+        let client = crate::TokenFactoryClient::new(&env, &contract_id);
+
+        let params = vec![
+            &env,
+            TokenCreationParams {
+                name: String::from_str(&env, "Capped"),
+                symbol: String::from_str(&env, "CAP"),
+                decimals: 7,
+                initial_supply: 1_000_000,
+                max_supply: Some(1_000_000),
+                metadata_uri: None,
+            },
+        ];
+        client.batch_reveal(&admin, &params, &1_000_000_i128);
+
+        let r1 = Address::generate(&env);
+        let recipients = vec![&env, (r1, 1_i128)];
+        let results = client
+            .preflight_batch_settle(&admin, &0_u32, &recipients);
+
+        assert_eq!(results.len(), 2); // 1 item result + 1 aggregate max-supply result
+        assert_eq!(results.get(0).unwrap().error_code, 0);
+        assert_eq!(
+            results.get(1).unwrap().error_code,
+            crate::types::Error::MaxSupplyExceeded.0
+        );
+    }
+
+    // ── gas overhead: staged batch_reveal vs preflight + batch_reveal ──────
+
+    #[test]
+    fn bench_preflight_plus_reveal_overhead_vs_reveal_alone() {
+        // Quantifies the CPU cost a careful client pays for calling
+        // preflight_batch_reveal before submitting the real batch_reveal,
+        // versus calling batch_reveal directly (which performs the same
+        // staging internally as part of its own atomicity guarantee).
+        let tokens_for = |env: &Env| {
+            vec![
+                env,
+                make_params(env, "Alpha", "ALP"),
+                make_params(env, "Beta", "BET"),
+                make_params(env, "Gamma", "GAM"),
+            ]
+        };
+
+        let (env_direct, contract_id, admin, _treasury) = setup();
+        let client_direct = crate::TokenFactoryClient::new(&env_direct, &contract_id);
+        let tokens = tokens_for(&env_direct);
+        env_direct.budget().reset_unlimited();
+        env_direct.budget().reset_default();
+        client_direct
+            .batch_reveal(&admin, &tokens, &3_000_000_i128);
+        let direct_cpu = env_direct.budget().cpu_instruction_cost();
+
+        let (env_staged, contract_id2, admin2, _treasury2) = setup();
+        let client_staged = crate::TokenFactoryClient::new(&env_staged, &contract_id2);
+        let tokens2 = tokens_for(&env_staged);
+        env_staged.budget().reset_unlimited();
+        env_staged.budget().reset_default();
+        client_staged
+            .preflight_batch_reveal(&tokens2, &3_000_000_i128);
+        client_staged
+            .batch_reveal(&admin2, &tokens2, &3_000_000_i128);
+        let preflight_then_reveal_cpu = env_staged.budget().cpu_instruction_cost();
+
+        std::println!(
+            "batch_reveal alone: {} CPU instructions; preflight_batch_reveal + batch_reveal: {} CPU instructions (overhead: {} CPU)",
+            direct_cpu,
+            preflight_then_reveal_cpu,
+            preflight_then_reveal_cpu.saturating_sub(direct_cpu)
+        );
+
+        // The extra dry-run pass must add a bounded, non-zero overhead — it
+        // should never be cheaper than skipping it, and should not blow up
+        // disproportionately to the batch size.
+        assert!(preflight_then_reveal_cpu >= direct_cpu);
     }
 }

--- a/contracts/token-factory/src/lib.rs
+++ b/contracts/token-factory/src/lib.rs
@@ -157,8 +157,8 @@ mod vault_deposit_withdraw_test;
 use soroban_sdk::{contract, contractimpl, symbol_short, Address, Bytes, BytesN, Env, String, Symbol, Vec};
 use types::{
     AuctionStatus, BurnAuction, BuybackCampaign, CampaignStatus, ContractMetadata,
-    DynamicQuorumConfig, Error, FactoryState, PaginationCursor, StreamInfo, StreamPage,
-    StreamParams, TokenCreationParams, TokenInfo, TokenStats, Vault, VaultStatus,
+    DynamicQuorumConfig, Error, FactoryState, PaginationCursor, PreflightItemResult, StreamInfo,
+    StreamPage, StreamParams, TokenCreationParams, TokenInfo, TokenStats, Vault, VaultStatus,
 };
 use crate::milestone_verification::MilestoneVerifier;
 use crate::snapshot;
@@ -1330,6 +1330,45 @@ impl TokenFactory {
         let result = batch_operations::batch_settle(&env, creator, token_index, recipients);
         storage::release_reentrancy_lock(&env);
         result
+    }
+
+    /// Dry-run `batch_reveal`'s validation without writing any state.
+    ///
+    /// Lets a caller check which items in a batch would fail — and why —
+    /// before spending gas (or fee payment) on the real call. Performs no
+    /// authorization check and mutates nothing, so it is safe to call
+    /// speculatively.
+    ///
+    /// # Returns
+    /// One [`PreflightItemResult`] per input token (`error_code == 0` means
+    /// that item would succeed), plus an extra entry at `index ==
+    /// tokens.len()` carrying `Error::InsufficientFee` if the fee for the
+    /// valid items would not be covered by `total_fee_payment`.
+    pub fn preflight_batch_reveal(
+        env: Env,
+        tokens: Vec<TokenCreationParams>,
+        total_fee_payment: i128,
+    ) -> Result<Vec<PreflightItemResult>, Error> {
+        batch_operations::preflight_batch_reveal(&env, tokens, total_fee_payment)
+    }
+
+    /// Dry-run `batch_settle`'s validation without writing any state.
+    ///
+    /// Lets a caller check which `(recipient, amount)` pairs would fail —
+    /// and why — before spending gas on the real call. Mutates nothing.
+    ///
+    /// # Returns
+    /// One [`PreflightItemResult`] per input recipient (`error_code == 0`
+    /// means that item would succeed), plus an extra entry at `index ==
+    /// recipients.len()` carrying `Error::MaxSupplyExceeded` if the
+    /// aggregate mint would exceed the token's max supply.
+    pub fn preflight_batch_settle(
+        env: Env,
+        creator: Address,
+        token_index: u32,
+        recipients: Vec<(Address, i128)>,
+    ) -> Result<Vec<PreflightItemResult>, Error> {
+        batch_operations::preflight_batch_settle(&env, creator, token_index, recipients)
     }
 
     /// Set metadata URI for a token by index (creator-only convenience function)

--- a/contracts/token-factory/src/types.rs
+++ b/contracts/token-factory/src/types.rs
@@ -148,6 +148,18 @@ pub struct TokenCreationParams {
     pub metadata_uri: Option<String>,
 }
 
+/// Outcome of validating a single item during a batch pre-flight dry-run.
+///
+/// `index` matches the item's position in the batch input vector.
+/// `error_code` is `0` when the item is valid, otherwise the `Error` code
+/// (see `Error`'s associated constants) it would fail with if executed.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct PreflightItemResult {
+    pub index: u32,
+    pub error_code: u32,
+}
+
 /// Timelock configuration
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]


### PR DESCRIPTION
## Summary
- Refactors `batch_reveal` and `batch_settle` (`contracts/token-factory/src/batch_operations.rs`) into a strict stage-then-commit model: phase 1 validates every item and precomputes the exact value to be written (including index/balance arithmetic), so phase 2 only commits already-validated values and cannot fail partway through a batch — even when called directly, bypassing the host's automatic invocation-level rollback.
- `batch_settle` now aggregates per-recipient deltas via a local map before touching storage, so duplicate recipients in the same batch are accumulated correctly and a per-recipient overflow can never leave some recipients already minted to.
- Adds `preflight_batch_reveal` and `preflight_batch_settle`, exposing phase 1 standalone (both as internal functions and as new contract methods) so callers can see exactly which items in a batch would fail — and why — without spending gas or risking a partial execution.
- Rewrites `batch_atomicity_test.rs`, which had drifted from the current `soroban-sdk` contract-client API (`Address::random`, `TokenCreationParams` missing `max_supply`, etc.) and would not compile, against the current API, and adds coverage for the new pre-flight entry points alongside the existing full-rollback scenarios.

## Test plan
- [x] Verified `batch_operations.rs`, `batch_atomicity_test.rs`, `lib.rs`, and `types.rs` compile and the new/updated unit tests pass, isolated from this crate's pre-existing, unrelated compile breakage (see note below) using a sandboxed build.
- [ ] `cargo test batch_atomicity` (blocked in this environment — see note)

**Note on verification:** `contracts/token-factory` does not currently compile on `main` independent of this change (~75 errors via `cargo build`, ~600+ via `cargo test`) — duplicate function definitions, `DataKey` variants referenced by `storage.rs` but never added to the enum, event-emitter functions called but never defined, and several files written against an older `soroban-sdk` API (e.g. `Address::random`, panicking-vs-`try_` client method split). This spans modules unrelated to batch operations (multisig, fractionalization, burn scheduling, RBAC, streaming) and is out of scope for this PR. I validated this change in isolation by stubbing out the unrelated breakage in a throwaway local build, confirming zero compile errors trace back to the files touched here, then reverted those stubs before pushing — none of that workaround is part of this diff.

Closes #1387