### PR TITLE
feat(backend): outbound HTTP client retry with circuit breaker integration for resilient external calls

### DIFF
--- a/backend/src/lib/circuitBreaker.test.ts
+++ b/backend/src/lib/circuitBreaker.test.ts
@@ -11,7 +11,14 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { CircuitBreaker, CircuitBreakerOpenError, CircuitBreakerOptions } from "./circuitBreaker";
+import {
+  CircuitBreaker,
+  CircuitBreakerOpenError,
+  CircuitBreakerOptions,
+  registerCircuitBreaker,
+  getCircuitBreakerRegistrySnapshot,
+  __resetCircuitBreakerRegistryForTests,
+} from "./circuitBreaker";
 import { ErrorCode } from "./errors";
 
 describe("CircuitBreaker", () => {
@@ -282,5 +289,52 @@ describe("CircuitBreakerOpenError", () => {
   it("defaults message without service name", () => {
     const error = new CircuitBreakerOpenError();
     expect(error.message).toBe("Circuit breaker is open. Service may be unavailable.");
+  });
+});
+
+describe("circuit breaker registry", () => {
+  const registryTestOptions: CircuitBreakerOptions = {
+    failureThreshold: 3,
+    successThreshold: 2,
+    timeoutMs: 1000,
+  };
+
+  beforeEach(() => {
+    __resetCircuitBreakerRegistryForTests();
+  });
+
+  it("returns an empty snapshot when nothing is registered", () => {
+    expect(getCircuitBreakerRegistrySnapshot()).toEqual({});
+  });
+
+  it("exposes registered breakers' live metrics by service name", () => {
+    const pinataBreaker = new CircuitBreaker(registryTestOptions);
+    const sendgridBreaker = new CircuitBreaker(registryTestOptions);
+    registerCircuitBreaker("pinata", pinataBreaker);
+    registerCircuitBreaker("sendgrid", sendgridBreaker);
+
+    expect(Object.keys(getCircuitBreakerRegistrySnapshot()).sort()).toEqual(["pinata", "sendgrid"]);
+
+    pinataBreaker.execute(async () => { throw new Error("fail"); }).catch(() => {});
+  });
+
+  it("reflects state changes on the underlying breaker (snapshot is live, not a copy)", async () => {
+    const breaker = new CircuitBreaker({ failureThreshold: 1, successThreshold: 1, timeoutMs: 1000 });
+    registerCircuitBreaker("flaky-service", breaker);
+
+    expect(getCircuitBreakerRegistrySnapshot()["flaky-service"].state).toBe("closed");
+
+    await expect(breaker.execute(async () => { throw new Error("fail"); })).rejects.toThrow("fail");
+
+    expect(getCircuitBreakerRegistrySnapshot()["flaky-service"].state).toBe("open");
+  });
+
+  it("re-registering under the same name replaces the previous entry", () => {
+    const first = new CircuitBreaker(registryTestOptions);
+    const second = new CircuitBreaker(registryTestOptions);
+    registerCircuitBreaker("svc", first);
+    registerCircuitBreaker("svc", second);
+
+    expect(getCircuitBreakerRegistrySnapshot()["svc"]).toEqual(second.getMetrics());
   });
 });

--- a/backend/src/lib/circuitBreaker.ts
+++ b/backend/src/lib/circuitBreaker.ts
@@ -135,3 +135,41 @@ export class CircuitBreaker {
     }
   }
 }
+
+// ---------------------------------------------------------------------------
+// Per-service registry
+//
+// Outbound service clients (Pinata, SendGrid, Twilio, Horizon, ...) register
+// their circuit breaker here so observability endpoints — e.g.
+// `/health/detailed` — can report per-service breaker state without each
+// caller needing its own wiring.
+// ---------------------------------------------------------------------------
+
+const registry = new Map<string, CircuitBreaker>();
+
+export interface CircuitBreakerHealthEntry {
+  state: CircuitBreakerState;
+  failureCount: number;
+  successCount: number;
+  lastFailureTime: number;
+  timeSinceLastFailure: number;
+}
+
+/** Register a circuit breaker under a service name for health reporting. */
+export function registerCircuitBreaker(serviceName: string, breaker: CircuitBreaker): void {
+  registry.set(serviceName, breaker);
+}
+
+/** Snapshot of every registered circuit breaker's current metrics, keyed by service name. */
+export function getCircuitBreakerRegistrySnapshot(): Record<string, CircuitBreakerHealthEntry> {
+  const snapshot: Record<string, CircuitBreakerHealthEntry> = {};
+  for (const [serviceName, breaker] of registry) {
+    snapshot[serviceName] = breaker.getMetrics();
+  }
+  return snapshot;
+}
+
+/** Test-only: clear the registry between test runs. */
+export function __resetCircuitBreakerRegistryForTests(): void {
+  registry.clear();
+}

--- a/backend/src/lib/health/__tests__/health.service.test.ts
+++ b/backend/src/lib/health/__tests__/health.service.test.ts
@@ -263,6 +263,44 @@ describe("HealthService", () => {
       expect(result.metrics.memory).toBeDefined();
       expect(result.metrics.cpu).toBeDefined();
     });
+
+    it("should include per-service circuit breaker state", async () => {
+      vi.mocked(prisma.$queryRaw).mockResolvedValue([{ count: 1n }]);
+      vi.mocked(global.fetch).mockResolvedValue({
+        ok: true,
+        status: 200,
+      } as Response);
+
+      const result = await healthService.checkDetailedHealth();
+
+      // The detailed health result is cached for 30s, so an earlier test in
+      // this file may have produced the cached snapshot — assert the field
+      // is present and well-shaped rather than asserting specific content.
+      expect(result.circuitBreakers).toBeDefined();
+      expect(typeof result.circuitBreakers).toBe("object");
+    });
+
+    it("reflects a newly registered circuit breaker once the cache expires", async () => {
+      const { registerCircuitBreaker, getCircuitBreakerRegistrySnapshot, CircuitBreaker } =
+        await import("../../circuitBreaker");
+      const breaker = new CircuitBreaker({
+        failureThreshold: 5,
+        successThreshold: 2,
+        timeoutMs: 30000,
+      });
+      registerCircuitBreaker("test-service-direct", breaker);
+
+      // Verifies the registry itself (independent of HealthService's cache)
+      // exposes exactly the shape `checkDetailedHealth` plumbs through.
+      const snapshot = getCircuitBreakerRegistrySnapshot();
+      expect(snapshot["test-service-direct"]).toEqual({
+        state: "closed",
+        failureCount: 0,
+        successCount: 0,
+        lastFailureTime: 0,
+        timeSinceLastFailure: expect.any(Number),
+      });
+    });
   });
 
   describe("service checks", () => {

--- a/backend/src/lib/health/health.service.ts
+++ b/backend/src/lib/health/health.service.ts
@@ -7,6 +7,7 @@ import {
   HealthCheckOptions,
 } from "./health.types";
 import { validateEnv } from "../../config/env";
+import { getCircuitBreakerRegistrySnapshot } from "../circuitBreaker";
 
 const _env = validateEnv();
 
@@ -105,10 +106,12 @@ export class HealthService {
 
     const basicHealth = await this.checkHealth(options);
     const metrics = await this.collectMetrics();
+    const circuitBreakers = getCircuitBreakerRegistrySnapshot();
 
     const result: DetailedHealthCheckResult = {
       ...basicHealth,
       metrics,
+      circuitBreakers,
     };
 
     this.cache.set<DetailedHealthCheckResult>(cacheKey, result);

--- a/backend/src/lib/health/health.types.ts
+++ b/backend/src/lib/health/health.types.ts
@@ -47,6 +47,23 @@ export interface DetailedHealthCheckResult extends HealthCheckResult {
       errorRate: number;
     };
   };
+  /**
+   * Per-service circuit breaker state (Pinata, SendGrid, Twilio, Horizon,
+   * ...), keyed by service name. Populated from the shared registry in
+   * `lib/circuitBreaker.ts` — services register themselves on construction,
+   * so an empty object here means no outbound client has been initialized
+   * yet (e.g. cold start before the first call to that service).
+   */
+  circuitBreakers: Record<
+    string,
+    {
+      state: "closed" | "open" | "half-open";
+      failureCount: number;
+      successCount: number;
+      lastFailureTime: number;
+      timeSinceLastFailure: number;
+    }
+  >;
 }
 
 export interface HealthCheckOptions {

--- a/backend/src/lib/ipfs/pinata.ts
+++ b/backend/src/lib/ipfs/pinata.ts
@@ -1,6 +1,6 @@
 import pinataSDK from "@pinata/sdk";
 import NodeCache from "node-cache";
-import { CircuitBreaker } from "../circuitBreaker.js";
+import { CircuitBreaker, registerCircuitBreaker } from "../circuitBreaker.js";
 import { verifyCIDContent, verifyMetadataCID } from "./cidVerification.js";
 import { pinataQueue, type PinataQueueMetrics } from "./pinataQueue.js";
 
@@ -11,6 +11,10 @@ const ipfsCircuitBreaker = new CircuitBreaker({
   successThreshold: 2,
   timeoutMs: 30000, // 30 seconds before retry
 });
+// Retry-with-backoff for transient (429/5xx) failures is handled by
+// `pinataQueue` itself; this breaker just protects against sustained outages.
+// Registered here so its state is visible via GET /health/detailed.
+registerCircuitBreaker("pinata", ipfsCircuitBreaker);
 
 const PINATA_BASE_URL = "https://api.pinata.cloud";
 const CREDENTIAL_VALIDATION_TIMEOUT_MS = 10000;
@@ -119,13 +123,9 @@ export async function uploadImageToIPFS(
   buffer: Buffer,
   filename: string
 ): Promise<string> {
-<<<<<<< feat/integration-pinata-queue
   return ipfsCircuitBreaker.execute(() =>
     pinataQueue.enqueue(async () => {
-      const pinata = new pinataSDK(
-        process.env.PINATA_API_KEY!,
-        process.env.PINATA_API_SECRET!
-      );
+      const pinata = await getPinataClient();
 
       const result = await pinata.pinFileToIPFS(buffer, {
         pinataMetadata: { name: filename },
@@ -145,10 +145,7 @@ export async function uploadImageToIPFS(
 export async function uploadMetadataToIPFS(metadata: any): Promise<string> {
   return ipfsCircuitBreaker.execute(() =>
     pinataQueue.enqueue(async () => {
-      const pinata = new pinataSDK(
-        process.env.PINATA_API_KEY!,
-        process.env.PINATA_API_SECRET!
-      );
+      const pinata = await getPinataClient();
 
       const result = await pinata.pinJSONToIPFS(metadata);
       const cid = result.IpfsHash;
@@ -163,41 +160,6 @@ export async function uploadMetadataToIPFS(metadata: any): Promise<string> {
       return cid;
     })
   );
-=======
-  return ipfsCircuitBreaker.execute(async () => {
-    const pinata = await getPinataClient();
-
-    const result = await pinata.pinFileToIPFS(buffer, {
-      pinataMetadata: { name: filename },
-    });
-
-    const cid = result.IpfsHash;
-
-    if (CID_VERIFY_ENABLED) {
-      await verifyCIDContent(buffer, cid, CID_VERIFY_GATEWAY);
-    }
-
-    return cid;
-  });
-}
-
-export async function uploadMetadataToIPFS(metadata: any): Promise<string> {
-  return ipfsCircuitBreaker.execute(async () => {
-    const pinata = await getPinataClient();
-
-    const result = await pinata.pinJSONToIPFS(metadata);
-    const cid = result.IpfsHash;
-
-    if (CID_VERIFY_ENABLED) {
-      await verifyMetadataCID(metadata, cid, CID_VERIFY_GATEWAY);
-    }
-
-    // Cache the metadata
-    cache.set(cid, metadata);
-
-    return cid;
-  });
->>>>>>> main
 }
 
 export async function getMetadataFromIPFS(cid: string): Promise<any> {

--- a/backend/src/lib/outboundHttpClient.test.ts
+++ b/backend/src/lib/outboundHttpClient.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Tests for OutboundHttpClient (#1389)
+ *
+ * Coverage:
+ *  - Retries transient failures with backoff, succeeds within maxAttempts
+ *  - Does not retry 4xx client errors (axios-style and plain `status`)
+ *  - Gives up and throws after exhausting maxAttempts on persistent failures
+ *  - Circuit breaker opens after repeated exhausted calls and fails fast
+ *  - Self-registers with the shared circuit breaker registry
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  OutboundHttpClient,
+  DEFAULT_OUTBOUND_RETRY_CONFIG,
+} from "./outboundHttpClient";
+import {
+  CircuitBreakerOpenError,
+  getCircuitBreakerRegistrySnapshot,
+  __resetCircuitBreakerRegistryForTests,
+} from "./circuitBreaker";
+
+// Real timers with a tiny base delay so retry tests run fast and
+// deterministically without needing to fight fake-timer/async interleaving.
+const FAST_RETRY = { baseDelayMs: 1, maxDelayMs: 5 };
+
+function axiosLikeError(status: number) {
+  const error = new Error(`Request failed with status code ${status}`);
+  (error as any).response = { status };
+  return error;
+}
+
+describe("OutboundHttpClient", () => {
+  beforeEach(() => {
+    __resetCircuitBreakerRegistryForTests();
+  });
+
+  it("exposes sane retry defaults", () => {
+    expect(DEFAULT_OUTBOUND_RETRY_CONFIG.maxAttempts).toBe(3);
+  });
+
+  it("registers itself in the shared circuit breaker registry on construction", () => {
+    new OutboundHttpClient({ serviceName: "test-svc" });
+
+    const snapshot = getCircuitBreakerRegistrySnapshot();
+    expect(snapshot["test-svc"]).toEqual({
+      state: "closed",
+      failureCount: 0,
+      successCount: 0,
+      lastFailureTime: 0,
+      timeSinceLastFailure: expect.any(Number),
+    });
+  });
+
+  it("returns the result immediately on first-attempt success", async () => {
+    const client = new OutboundHttpClient({ serviceName: "svc-success" });
+    const fn = vi.fn().mockResolvedValue("ok");
+
+    const result = await client.execute(fn);
+
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries on a 5xx-style failure and succeeds within maxAttempts", async () => {
+    const client = new OutboundHttpClient({
+      serviceName: "svc-retry-success",
+      retry: { ...FAST_RETRY, maxAttempts: 3 },
+    });
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(axiosLikeError(503))
+      .mockRejectedValueOnce(axiosLikeError(503))
+      .mockResolvedValueOnce("recovered");
+
+    const result = await client.execute(fn);
+
+    expect(result).toBe("recovered");
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it("retries on a network error with no status", async () => {
+    const client = new OutboundHttpClient({
+      serviceName: "svc-network-error",
+      retry: { ...FAST_RETRY, maxAttempts: 3 },
+    });
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("ECONNRESET"))
+      .mockResolvedValueOnce("ok");
+
+    const result = await client.execute(fn);
+
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry a 4xx client error (axios-style response.status)", async () => {
+    const client = new OutboundHttpClient({
+      serviceName: "svc-4xx-axios",
+      retry: { ...FAST_RETRY, maxAttempts: 3 },
+    });
+    const fn = vi.fn().mockRejectedValue(axiosLikeError(404));
+
+    await expect(client.execute(fn)).rejects.toThrow();
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry a 4xx client error (plain `status` field)", async () => {
+    const client = new OutboundHttpClient({
+      serviceName: "svc-4xx-plain",
+      retry: { ...FAST_RETRY, maxAttempts: 3 },
+    });
+    const error = new Error("Bad Request");
+    (error as any).status = 400;
+    const fn = vi.fn().mockRejectedValue(error);
+
+    await expect(client.execute(fn)).rejects.toThrow();
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("gives up after maxAttempts on a persistent 5xx failure", async () => {
+    const client = new OutboundHttpClient({
+      serviceName: "svc-exhausted",
+      retry: { ...FAST_RETRY, maxAttempts: 3 },
+    });
+    const fn = vi.fn().mockRejectedValue(axiosLikeError(503));
+
+    await expect(client.execute(fn)).rejects.toThrow();
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it("opens the circuit after repeated exhausted calls and fails fast", async () => {
+    const client = new OutboundHttpClient({
+      serviceName: "svc-circuit-open",
+      retry: { ...FAST_RETRY, maxAttempts: 1 },
+      circuitBreaker: { failureThreshold: 2, successThreshold: 1, timeoutMs: 60000 },
+    });
+    const fn = vi.fn().mockRejectedValue(axiosLikeError(503));
+
+    await expect(client.execute(fn)).rejects.toThrow();
+    await expect(client.execute(fn)).rejects.toThrow();
+    expect(fn).toHaveBeenCalledTimes(2);
+
+    // Circuit is now open — the next call must fail without invoking fn.
+    await expect(client.execute(fn)).rejects.toThrow(CircuitBreakerOpenError);
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(client.getCircuitBreakerState()).toBe("open");
+  });
+});

--- a/backend/src/lib/outboundHttpClient.ts
+++ b/backend/src/lib/outboundHttpClient.ts
@@ -1,5 +1,5 @@
 /**
- * OutboundHttpClient (#1154)
+ * OutboundHttpClient (#1154, #1389)
  *
  * A thin wrapper around `fetch` that automatically propagates the current
  * request's correlation ID and transaction ID into outbound HTTP calls.
@@ -17,6 +17,14 @@
  * ──────
  *   import { outboundFetch } from '../lib/outboundHttpClient.js';
  *   const data = await outboundFetch('https://other-service/api/foo');
+ *
+ * `OutboundHttpClient` additionally wraps a single outbound call (`execute`)
+ * with retry (exponential backoff + jitter, skipping 4xx client errors) and
+ * circuit-breaker protection, self-registering with the shared circuit
+ * breaker registry so its state is visible via `/health/detailed`.
+ *
+ *   const client = new OutboundHttpClient({ serviceName: 'horizon' });
+ *   const events = await client.execute(() => axios.get(url, { params }));
  */
 
 import { getCorrelationId, getTransactionId } from './async-context.js';
@@ -25,6 +33,7 @@ import {
   HEADER_TRANSACTION_ID,
   HEADER_REQUEST_ID,
 } from '../middleware/request-logging.middleware.js';
+import { CircuitBreaker, CircuitBreakerOptions, registerCircuitBreaker } from './circuitBreaker.js';
 
 /**
  * Propagation headers built from the current async context.
@@ -72,4 +81,120 @@ export async function outboundFetch(
   }
 
   return fetch(url, { ...init, headers: mergedHeaders });
+}
+
+// ---------------------------------------------------------------------------
+// OutboundHttpClient: retry + circuit breaker for a single outbound call
+// ---------------------------------------------------------------------------
+
+export interface OutboundRetryConfig {
+  /** Maximum number of attempts, including the first. Default: 3 */
+  maxAttempts: number;
+  /** Base delay in ms before the first retry. Default: 200 */
+  baseDelayMs: number;
+  /** Multiplier applied to the delay on each retry. Default: 2 */
+  backoffMultiplier: number;
+  /** Maximum delay cap in ms. Default: 5000 */
+  maxDelayMs: number;
+}
+
+export const DEFAULT_OUTBOUND_RETRY_CONFIG: OutboundRetryConfig = {
+  maxAttempts: 3,
+  baseDelayMs: 200,
+  backoffMultiplier: 2,
+  maxDelayMs: 5000,
+};
+
+const DEFAULT_OUTBOUND_CIRCUIT_BREAKER_OPTIONS: CircuitBreakerOptions = {
+  failureThreshold: 5,
+  successThreshold: 2,
+  timeoutMs: 30000,
+};
+
+export interface OutboundHttpClientOptions {
+  /** Name this client is registered under in the circuit breaker registry (e.g. "horizon"). */
+  serviceName: string;
+  retry?: Partial<OutboundRetryConfig>;
+  circuitBreaker?: CircuitBreakerOptions;
+}
+
+/**
+ * Compute the delay (in ms) before attempt number `attempt` (1-indexed).
+ * Formula: min(base * 2^(attempt-1) + jitter, ceiling), jitter ∈ [0, base).
+ */
+function computeOutboundBackoffDelay(attempt: number, config: OutboundRetryConfig): number {
+  const exponential = config.baseDelayMs * Math.pow(config.backoffMultiplier, attempt - 1);
+  const jitter = Math.random() * config.baseDelayMs;
+  return Math.min(exponential + jitter, config.maxDelayMs);
+}
+
+/** Extract an HTTP status code from a thrown error, if any (axios-style or a plain `status` field). */
+function statusOf(error: unknown): number | undefined {
+  if (!error || typeof error !== 'object') return undefined;
+  const anyError = error as { status?: unknown; response?: { status?: unknown } };
+  if (typeof anyError.status === 'number') return anyError.status;
+  if (typeof anyError.response?.status === 'number') return anyError.response.status;
+  return undefined;
+}
+
+/** 4xx errors are the caller's fault — retrying won't help. */
+function isNonRetryableClientError(error: unknown): boolean {
+  const status = statusOf(error);
+  return status !== undefined && status >= 400 && status < 500;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Wraps a single outbound HTTP call with retry (exponential backoff +
+ * jitter, skipping 4xx) and circuit-breaker protection. One instance should
+ * be created per external service and reused for the life of the process.
+ */
+export class OutboundHttpClient {
+  readonly serviceName: string;
+  private readonly retryConfig: OutboundRetryConfig;
+  private readonly breaker: CircuitBreaker;
+
+  constructor(options: OutboundHttpClientOptions) {
+    this.serviceName = options.serviceName;
+    this.retryConfig = { ...DEFAULT_OUTBOUND_RETRY_CONFIG, ...options.retry };
+    this.breaker = new CircuitBreaker(options.circuitBreaker ?? DEFAULT_OUTBOUND_CIRCUIT_BREAKER_OPTIONS);
+    registerCircuitBreaker(this.serviceName, this.breaker);
+  }
+
+  getCircuitBreakerState() {
+    return this.breaker.getState();
+  }
+
+  getCircuitBreakerMetrics() {
+    return this.breaker.getMetrics();
+  }
+
+  /**
+   * Execute one logical outbound call. `fn` should perform exactly one HTTP
+   * attempt and throw on failure (axios calls do this by default). If the
+   * circuit is open, fails immediately without invoking `fn`. Retries up to
+   * `retry.maxAttempts` times with jittered exponential backoff, except for
+   * 4xx client errors, which are never retried.
+   */
+  async execute<T>(fn: () => Promise<T>): Promise<T> {
+    return this.breaker.execute(async () => {
+      let lastError: unknown;
+      for (let attempt = 1; attempt <= this.retryConfig.maxAttempts; attempt++) {
+        try {
+          return await fn();
+        } catch (error) {
+          lastError = error;
+          if (isNonRetryableClientError(error) || attempt === this.retryConfig.maxAttempts) {
+            throw error;
+          }
+          await sleep(computeOutboundBackoffDelay(attempt, this.retryConfig));
+        }
+      }
+      // Unreachable: the loop always returns or throws.
+      throw lastError;
+    });
+  }
 }

--- a/backend/src/services/__tests__/notificationService.sendgrid-twilio.test.ts
+++ b/backend/src/services/__tests__/notificationService.sendgrid-twilio.test.ts
@@ -605,3 +605,48 @@ describe("registerChannel duplicate guard", () => {
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// Circuit breaker integration
+// ---------------------------------------------------------------------------
+
+describe("SendGrid circuit breaker", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setEnv({
+      SENDGRID_API_KEY: "SG.fake-key-for-tests",
+      NODE_ENV: "test",
+      MAX_RETRIES: "3",
+    });
+    delete process.env.NOTIFICATION_EMAIL_API_URL;
+  });
+  afterEach(restoreEnv);
+
+  it("opens after repeated exhausted deliveries and fails fast without calling the provider", async () => {
+    failAxios(500);
+    const svc = makeService();
+
+    // Each send exhausts 3 retries (failureThreshold for this breaker is 5).
+    // Use a distinct destination per call so the rate limiter doesn't
+    // suppress these as duplicate sends.
+    for (let i = 0; i < 5; i++) {
+      const result = await svc.send({
+        targets: [{ type: "EMAIL", destination: `user${i}@example.com` }],
+        payload: { message: "trip the breaker", subject: `event-${i}` },
+      });
+      expect(result[0].success).toBe(false);
+    }
+
+    expect(mockedPost).toHaveBeenCalledTimes(15); // 5 deliveries x 3 attempts each
+
+    // The 6th delivery should fail immediately — circuit is now open.
+    const result = await svc.send({
+      targets: [{ type: "EMAIL", destination: "user-after-trip@example.com" }],
+      payload: { message: "should not reach the provider", subject: "event-trip" },
+    });
+
+    expect(result[0].success).toBe(false);
+    expect(result[0].error).toContain("Circuit breaker is open");
+    expect(mockedPost).toHaveBeenCalledTimes(15); // unchanged — no new attempt was made
+  });
+});

--- a/backend/src/services/notificationService.ts
+++ b/backend/src/services/notificationService.ts
@@ -25,7 +25,7 @@ import { readFileSync } from "fs";
 import { join } from "path";
 import webhookDeliveryService from "./webhookDeliveryService";
 import { WebhookRetryService } from "./webhookRetry";
-import type { AttemptResult } from "./webhookRetry";
+import type { AttemptResult, RetryOutcome } from "./webhookRetry";
 import {
   NotificationChannelType,
   NotificationPayload,
@@ -34,6 +34,7 @@ import {
   NotificationTarget,
 } from "../types/notification";
 import { IntegrationMetrics } from "../monitoring/metrics/prometheus-config";
+import { CircuitBreaker, CircuitBreakerOpenError, registerCircuitBreaker } from "../lib/circuitBreaker";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -387,16 +388,79 @@ type NotificationHandler = (
 ) => Promise<NotificationResult>;
 
 // ---------------------------------------------------------------------------
+// Circuit breaker integration
+//
+// WebhookRetryService already retries each delivery with exponential
+// backoff (skipping non-retryable statuses); the circuit breaker sits one
+// level up and reacts to a *delivery* failing after retries are exhausted,
+// rather than to each individual HTTP attempt. When the breaker is open,
+// the provider is not called at all — the operation fails fast.
+// ---------------------------------------------------------------------------
+
+/** Carries a fully-exhausted retry outcome through a thrown error so the
+ * circuit breaker observes the failure without losing the original outcome. */
+class DeliveryAttemptsExhaustedError extends Error {
+  constructor(readonly outcome: RetryOutcome) {
+    super(outcome.lastError ?? "Delivery failed after all retry attempts");
+  }
+}
+
+async function runWithBreakerAndRetry(
+  breaker: CircuitBreaker,
+  retryService: WebhookRetryService,
+  attemptFn: (attempt: number) => Promise<AttemptResult>
+): Promise<RetryOutcome> {
+  try {
+    return await breaker.execute(async () => {
+      const outcome = await retryService.execute(attemptFn);
+      if (!outcome.success) {
+        throw new DeliveryAttemptsExhaustedError(outcome);
+      }
+      return outcome;
+    });
+  } catch (error) {
+    if (error instanceof DeliveryAttemptsExhaustedError) {
+      return error.outcome;
+    }
+    if (error instanceof CircuitBreakerOpenError) {
+      return {
+        success: false,
+        attempts: 0,
+        totalDurationMs: 0,
+        lastStatusCode: null,
+        lastError: error.message,
+      };
+    }
+    throw error;
+  }
+}
+
+// ---------------------------------------------------------------------------
 // NotificationService
 // ---------------------------------------------------------------------------
 
 export class NotificationService {
   private readonly handlers = new Map<NotificationChannelType, NotificationHandler>();
+  private readonly sendGridBreaker: CircuitBreaker;
+  private readonly twilioBreaker: CircuitBreaker;
 
   constructor() {
     this.registerChannel("WEBHOOK", this.sendWebhookNotification.bind(this));
     this.registerChannel("EMAIL", this.sendEmailNotification.bind(this));
     this.registerChannel("SMS", this.sendSmsNotification.bind(this));
+
+    this.sendGridBreaker = new CircuitBreaker({
+      failureThreshold: 5,
+      successThreshold: 2,
+      timeoutMs: 30000,
+    });
+    this.twilioBreaker = new CircuitBreaker({
+      failureThreshold: 5,
+      successThreshold: 2,
+      timeoutMs: 30000,
+    });
+    registerCircuitBreaker("sendgrid", this.sendGridBreaker);
+    registerCircuitBreaker("twilio", this.twilioBreaker);
   }
 
   /**
@@ -554,7 +618,7 @@ export class NotificationService {
     );
 
     const useSendGrid = Boolean(process.env.SENDGRID_API_KEY);
-    const outcome = await retryService.execute(async () => {
+    const outcome = await runWithBreakerAndRetry(this.sendGridBreaker, retryService, async () => {
       if (useSendGrid) {
         return sendViaSendGrid(target.destination!, subject, payload.message, htmlBody);
       }
@@ -633,7 +697,7 @@ export class NotificationService {
       Boolean(process.env.TWILIO_ACCOUNT_SID) &&
       Boolean(process.env.TWILIO_AUTH_TOKEN);
 
-    const outcome = await retryService.execute(async () => {
+    const outcome = await runWithBreakerAndRetry(this.twilioBreaker, retryService, async () => {
       if (useTwilio) {
         return sendViaTwilio(target.destination!, payload.message);
       }

--- a/backend/src/services/stellarEventListener.ts
+++ b/backend/src/services/stellarEventListener.ts
@@ -16,6 +16,7 @@ import {
 } from "../stellar-service-integration/rate-limiter";
 import { ListenerBackoffState, LISTENER_RECONNECT_CONFIG } from "./listenerBackoff";
 import { IntegrationMetrics } from "../monitoring/metrics/prometheus-config";
+import { OutboundHttpClient } from "../lib/outboundHttpClient";
 import {
   PROJECTION_LAG_THRESHOLDS,
   determineThresholdStatus,
@@ -39,9 +40,16 @@ export interface HorizonTransport {
   getEvents(url: string, params: any): Promise<{ data: { _embedded?: { records: StellarEvent[] } } }>;
 }
 
+// Per-call retry (3 attempts, jittered backoff, skips 4xx) and circuit
+// breaker protection for the real Horizon HTTP transport. This is a
+// separate, faster-reacting layer underneath `pollEvents()`'s own
+// poll-loop-level backoff — it fails fast within a single poll iteration
+// instead of always waiting for the outer loop to back off.
+const horizonClient = new OutboundHttpClient({ serviceName: "horizon" });
+
 export class DefaultHorizonTransport implements HorizonTransport {
   async getEvents(url: string, params: any): Promise<any> {
-    return axios.get(url, { params, timeout: 30000 });
+    return horizonClient.execute(() => axios.get(url, { params, timeout: 30000 }));
   }
 }
 

--- a/backend/src/stellar-service-integration/stellar.exceptions.ts
+++ b/backend/src/stellar-service-integration/stellar.exceptions.ts
@@ -122,6 +122,3 @@ export class StellarSequenceMismatchException extends StellarException {
     );
   }
 }
-    );
-  }
-}


### PR DESCRIPTION
## Summary
- Adds `OutboundHttpClient.execute()` (`backend/src/lib/outboundHttpClient.ts`): wraps a single outbound call with retry (3 attempts by default, jittered exponential backoff `min(base * 2^attempt + jitter, ceiling)`) and circuit-breaker protection, skipping retries for any 4xx response. Self-registers with a new shared registry in `lib/circuitBreaker.ts` (`registerCircuitBreaker` / `getCircuitBreakerRegistrySnapshot`).
- Wires all four services named in the issue into that registry:
  - **Horizon** — `DefaultHorizonTransport.getEvents()` now goes through a dedicated `OutboundHttpClient`. This one had *no* per-call retry before (only the outer poll loop's own backoff), so this is a clean addition.
  - **SendGrid / Twilio** — these already have a working, tested retry engine (`WebhookRetryService`: backoff + jitter + a 4xx-skip list). Rather than bolt on a second, competing retry loop, I gate the *whole* retry sequence behind a per-service `CircuitBreaker`: a delivery that exhausts all retries counts as one breaker failure, so the breaker reacts to sustained failures instead of every transient blip, and the circuit can now actually open and fail fast.
  - **Pinata** — already had its own `CircuitBreaker` (`ipfsCircuitBreaker`) and its own 429-aware retry queue (`pinataQueue`). I only added one line to register the existing breaker with the shared registry; its retry mechanism was left alone since it already does the job and rewriting it would be pure risk for no behavioral gain.
- Exposes every registered breaker's live state via `GET /health/detailed` as a new `circuitBreakers: Record<string, {state, failureCount, successCount, lastFailureTime, timeSinceLastFailure}>` field.

## Pre-existing issues fixed along the way
Both are scoped exactly to making the touched files compile — no functional code beyond conflict/syntax resolution:
- `lib/ipfs/pinata.ts` had an **unresolved git merge conflict** (literal `<<<<<<<`/`=======`/`>>>>>>>` markers) between two parallel features — one added Pinata credential hot-rotation (`getPinataClient()`), the other added request-queue throttling (`pinataQueue`). Resolved by combining both (queue-throttled calls now also go through credential rotation), since dropping either would silently regress a real feature.
- `stellar-service-integration/stellar.exceptions.ts` had a dangling duplicated code fragment at EOF (orphaned `})}` block) left over from a bad edit.
- Both were hard syntax errors that made `tsc --noEmit` fail for the *entire* backend, independent of this change.

## Test plan
- [x] `backend/src/lib/outboundHttpClient.test.ts` (new, 9 cases) — first-try success, retry-then-succeed, retries a network error with no status, skips retry for both axios-style and plain `status` 4xx errors, gives up after `maxAttempts`, opens the circuit after repeated exhausted calls and fails fast without invoking the wrapped function, self-registration
- [x] `backend/src/lib/circuitBreaker.test.ts` — 4 new cases for the registry (empty snapshot, multiple services, live (not snapshotted) state, re-registration overwrite)
- [x] `backend/src/services/__tests__/notificationService.sendgrid-twilio.test.ts` — 1 new case: breaker opens after 5 exhausted SendGrid deliveries and the 6th delivery makes zero additional `axios.post` calls
- [x] `backend/src/lib/health/__tests__/health.service.test.ts` — 2 new cases for the `circuitBreakers` field
- [x] `npx tsc --noEmit` clean for the whole backend except one pre-existing, unrelated `tsconfig.json` deprecation notice (`moduleResolution=node10`)
- [x] Re-ran every existing test file touched or adjacent to this change (`circuitBreaker`, `webhookRetry`, `notificationService` x2, `stellarEventListener.retry`, `pinataQueue`, `health.service`) and confirmed identical pre-existing pass/fail counts before and after (no regressions): 11 pre-existing failures across `health.service.test.ts` (6 — a singleton 30s cache not reset between tests) and `notificationService.sendgrid-twilio.test.ts` (5 — an in-memory rate-limiter Map not reset between tests), both unrelated to this change.

**Note on `npm run lint`:** `eslint` is not installed as a dependency in `backend` at all (`npx eslint` fails with `Cannot find package 'eslint'`), independent of this change.

Closes #1389