### PR TITLE
feat(integration): automated divergence alerting in stream reconciliation service

### DIFF
--- a/backend/src/__tests__/incidentResponse.pagerduty.test.ts
+++ b/backend/src/__tests__/incidentResponse.pagerduty.test.ts
@@ -14,6 +14,8 @@ import {
   alertDatabasePoolExhausted,
   resolveEventListenerDown,
   resolveHighApiErrorRate,
+  alertStreamDivergence,
+  resolveStreamDivergence,
 } from "/workspaces/nova-launch/monitoring/pagerduty/incident-response";
 
 // ---------------------------------------------------------------------------
@@ -421,6 +423,85 @@ describe("PagerDuty Incident Response", () => {
         const parsed = JSON.parse(capturedBody);
         expect(parsed.event_action).toBe("resolve");
         expect(parsed.dedup_key).toBe("nova-api-high-error-rate");
+      } finally {
+        process.env.PAGERDUTY_ROUTING_KEY = original;
+      }
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Stream divergence alerts
+  // -------------------------------------------------------------------------
+
+  describe("stream divergence alerts", () => {
+    it("alertStreamDivergence uses error severity (P2) and a per-stream/field dedup key", async () => {
+      let capturedBody = "";
+      vi.spyOn(https, "request").mockImplementation((_opts, callback) => {
+        const res = Object.assign(new EventEmitter(), { statusCode: 202 });
+        const req = Object.assign(new EventEmitter(), {
+          write: vi.fn((data: string) => {
+            capturedBody = data;
+          }),
+          end: vi.fn(() => {
+            if (callback) {
+              (callback as (res: any) => void)(res);
+              res.emit("data", JSON.stringify(SUCCESS_RESPONSE));
+              res.emit("end");
+            }
+          }),
+        });
+        return req as any;
+      });
+
+      const original = process.env.PAGERDUTY_ROUTING_KEY;
+      process.env.PAGERDUTY_ROUTING_KEY = ROUTING_KEY;
+      try {
+        await alertStreamDivergence({
+          streamId: 42,
+          field: "balance",
+          onChainValue: "100",
+          projectedValue: "150",
+        });
+        const parsed = JSON.parse(capturedBody);
+        expect(parsed.payload.severity).toBe("error");
+        expect(parsed.dedup_key).toBe("nova-stream-divergence-42-balance");
+        expect(parsed.payload.custom_details).toEqual({
+          streamId: 42,
+          field: "balance",
+          onChainValue: "100",
+          projectedValue: "150",
+        });
+      } finally {
+        process.env.PAGERDUTY_ROUTING_KEY = original;
+      }
+    });
+
+    it("resolveStreamDivergence sends resolve for the matching dedup key", async () => {
+      let capturedBody = "";
+      vi.spyOn(https, "request").mockImplementation((_opts, callback) => {
+        const res = Object.assign(new EventEmitter(), { statusCode: 202 });
+        const req = Object.assign(new EventEmitter(), {
+          write: vi.fn((data: string) => {
+            capturedBody = data;
+          }),
+          end: vi.fn(() => {
+            if (callback) {
+              (callback as (res: any) => void)(res);
+              res.emit("data", JSON.stringify(SUCCESS_RESPONSE));
+              res.emit("end");
+            }
+          }),
+        });
+        return req as any;
+      });
+
+      const original = process.env.PAGERDUTY_ROUTING_KEY;
+      process.env.PAGERDUTY_ROUTING_KEY = ROUTING_KEY;
+      try {
+        await resolveStreamDivergence(42, "balance");
+        const parsed = JSON.parse(capturedBody);
+        expect(parsed.event_action).toBe("resolve");
+        expect(parsed.dedup_key).toBe("nova-stream-divergence-42-balance");
       } finally {
         process.env.PAGERDUTY_ROUTING_KEY = original;
       }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -31,6 +31,9 @@ import { registerPoolMetrics } from "./lib/metrics/poolMetrics";
 import { prisma } from "./lib/prisma";
 import stellarEventListener from "./services/stellarEventListener";
 import websocketService from "./services/websocket";
+import jobQueue from "./services/jobQueue";
+import { streamReconciliationService } from "./services/streamReconciliation";
+import "./services/streamDivergenceAlerting";
 
 dotenv.config();
 
@@ -223,11 +226,9 @@ const server = app.listen(PORT, async () => {
   // Schedule periodic stream reconciliation if enabled
   if (process.env.ENABLE_STREAM_RECONCILIATION === "true") {
     const reconciliationInterval = parseInt(
-      process.env.STREAM_RECONCILIATION_INTERVAL_MS || "3600000"
+      process.env.STREAM_RECONCILIATION_INTERVAL_MS || "300000" // 5 minutes default
     );
-    setInterval(() => {
-      jobQueue.enqueue("stream_reconciliation", {}, {});
-    }, reconciliationInterval);
+    jobQueue.scheduleRecurring("stream_reconciliation", {}, reconciliationInterval);
     console.log(
       `📋 Stream reconciliation scheduled every ${reconciliationInterval}ms`
     );

--- a/backend/src/services/jobQueue.test.ts
+++ b/backend/src/services/jobQueue.test.ts
@@ -301,6 +301,53 @@ describe("JobQueue", () => {
     }, 5_000);
   });
 
+  // ── Recurring schedule ────────────────────────────────────────────────────
+
+  describe("scheduleRecurring", () => {
+    it("enqueues a job on each interval tick", async () => {
+      q.register("recur", async () => {});
+      q.scheduleRecurring("recur", { x: 1 }, 20);
+
+      await flush(70); // ~3 ticks
+
+      expect(q.stats().completed).toBeGreaterThanOrEqual(2);
+      q.stopRecurring("recur");
+    });
+
+    it("is a no-op when called twice for the same type", async () => {
+      let calls = 0;
+      q.register("recur.once", async () => {
+        calls++;
+      });
+
+      q.scheduleRecurring("recur.once", {}, 20);
+      q.scheduleRecurring("recur.once", {}, 20);
+
+      await flush(50);
+      const callsAfterFirstWindow = calls;
+      q.stopRecurring("recur.once");
+      await flush(50);
+
+      // A duplicate schedule would have doubled the calls in the same window.
+      expect(callsAfterFirstWindow).toBeLessThan(4);
+      expect(calls).toBe(callsAfterFirstWindow);
+    });
+  });
+
+  describe("stopRecurring", () => {
+    it("stops enqueuing further jobs once stopped", async () => {
+      q.register("recur.stop", async () => {});
+      q.scheduleRecurring("recur.stop", {}, 20);
+
+      await flush(50);
+      q.stopRecurring("recur.stop");
+      const completedAtStop = q.stats().completed;
+
+      await flush(60);
+      expect(q.stats().completed).toBe(completedAtStop);
+    });
+  });
+
   // ── Payload size guard ────────────────────────────────────────────────────
 
   describe("payload size guard", () => {

--- a/backend/src/services/jobQueue.ts
+++ b/backend/src/services/jobQueue.ts
@@ -115,6 +115,7 @@ export class JobQueue {
   private activeWorkers = 0;
   private tickTimer: ReturnType<typeof setTimeout> | null = null;
   private stopped = false;
+  private recurringTimers = new Map<string, ReturnType<typeof setInterval>>();
 
   /** Counts for completed/failed (kept separately to avoid unbounded arrays). */
   private completedCount = 0;
@@ -185,6 +186,35 @@ export class JobQueue {
     if (this.tickTimer) {
       clearTimeout(this.tickTimer);
       this.tickTimer = null;
+    }
+  }
+
+  /**
+   * Enqueue a job of `type` on a recurring `intervalMs` cadence.
+   * Calling this again for a `type` that's already scheduled is a no-op —
+   * use `stopRecurring` first to change the interval.
+   */
+  scheduleRecurring<T>(
+    type: string,
+    payload: T,
+    intervalMs: number,
+    opts: EnqueueOptions = {}
+  ): void {
+    if (this.recurringTimers.has(type)) return;
+
+    const timer = setInterval(() => {
+      this.enqueue(type, payload, opts);
+    }, intervalMs);
+    timer.unref?.();
+    this.recurringTimers.set(type, timer);
+  }
+
+  /** Stop a recurring schedule previously started with `scheduleRecurring`. */
+  stopRecurring(type: string): void {
+    const timer = this.recurringTimers.get(type);
+    if (timer) {
+      clearInterval(timer);
+      this.recurringTimers.delete(type);
     }
   }
 

--- a/backend/src/services/streamDivergenceAlerting.test.ts
+++ b/backend/src/services/streamDivergenceAlerting.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { EventBus } from "./eventBus";
+
+vi.mock("../../../monitoring/pagerduty/incident-response", () => ({
+  alertStreamDivergence: vi.fn().mockResolvedValue({
+    status: "success",
+    message: "Event processed",
+    dedup_key: "nova-stream-divergence-1-balance",
+  }),
+}));
+
+import { alertStreamDivergence } from "../../../monitoring/pagerduty/incident-response";
+import { registerStreamDivergenceAlerting } from "./streamDivergenceAlerting";
+
+describe("streamDivergenceAlerting", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("triggers a PagerDuty incident when a stream.divergence_detected event is published", async () => {
+    const bus = new EventBus();
+    registerStreamDivergenceAlerting(bus);
+
+    await bus.publish("stream.divergence_detected", {
+      streamId: 1,
+      field: "balance",
+      onChainValue: "0",
+      projectedValue: "1000",
+    });
+
+    expect(alertStreamDivergence).toHaveBeenCalledWith({
+      streamId: 1,
+      field: "balance",
+      onChainValue: "0",
+      projectedValue: "1000",
+    });
+  });
+
+  it("does not call PagerDuty for unrelated events", async () => {
+    const bus = new EventBus();
+    registerStreamDivergenceAlerting(bus);
+
+    await bus.publish("token.created", { symbol: "TKN" });
+
+    expect(alertStreamDivergence).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/services/streamDivergenceAlerting.ts
+++ b/backend/src/services/streamDivergenceAlerting.ts
@@ -1,0 +1,24 @@
+/**
+ * Bridges stream reconciliation divergence events to PagerDuty.
+ *
+ * streamReconciliation.ts publishes "stream.divergence_detected" on the
+ * eventBus without knowing about PagerDuty; this module is the sole
+ * subscriber that turns those events into P2 incidents.
+ */
+
+import { eventBus, EventBus, Subscription } from "./eventBus";
+import { alertStreamDivergence } from "../../../monitoring/pagerduty/incident-response";
+import type { StreamDivergenceDetectedPayload } from "./streamReconciliation";
+
+export function registerStreamDivergenceAlerting(
+  bus: EventBus = eventBus
+): Subscription {
+  return bus.subscribe<StreamDivergenceDetectedPayload>(
+    "stream.divergence_detected",
+    async (event) => {
+      await alertStreamDivergence(event.payload);
+    }
+  );
+}
+
+registerStreamDivergenceAlerting();

--- a/backend/src/services/streamReconciliation.test.ts
+++ b/backend/src/services/streamReconciliation.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { StreamStatus } from "@prisma/client";
+import { StreamReconciliationService } from "./streamReconciliation";
+import { eventBus } from "./eventBus";
+
+function mockPrisma(streams: unknown[]) {
+  return {
+    stream: {
+      findMany: vi.fn().mockResolvedValue(streams),
+    },
+  } as any;
+}
+
+describe("StreamReconciliationService", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("flags a divergence and publishes stream.divergence_detected when balances mismatch", async () => {
+    const publishSpy = vi.spyOn(eventBus, "publish");
+    const prisma = mockPrisma([
+      {
+        streamId: 1,
+        creator: "GCREATOR",
+        recipient: "GRECIPIENT",
+        amount: BigInt(1000),
+        claimedAt: null,
+        status: StreamStatus.CREATED,
+      },
+    ]);
+
+    const service = new StreamReconciliationService(prisma, 300_000);
+    const result = await service.reconcile();
+
+    expect(result.divergences).toHaveLength(1);
+    expect(result.divergences[0]).toMatchObject({
+      streamId: 1,
+      field: "balance",
+      projectedValue: "1000",
+      onChainValue: "0",
+    });
+
+    expect(publishSpy).toHaveBeenCalledWith("stream.divergence_detected", {
+      streamId: 1,
+      field: "balance",
+      onChainValue: "0",
+      projectedValue: "1000",
+    });
+  });
+
+  it("does not publish an event when the projected balance matches on-chain state", async () => {
+    const publishSpy = vi.spyOn(eventBus, "publish");
+    const prisma = mockPrisma([
+      {
+        streamId: 2,
+        creator: "GCREATOR",
+        recipient: "GRECIPIENT",
+        amount: BigInt(0),
+        claimedAt: new Date(),
+        status: StreamStatus.CLAIMED,
+      },
+    ]);
+
+    const service = new StreamReconciliationService(prisma, 300_000);
+    const result = await service.reconcile();
+
+    expect(result.divergences).toHaveLength(0);
+    expect(publishSpy).not.toHaveBeenCalled();
+  });
+
+  it("reports a divergence per mismatched stream across multiple streams", async () => {
+    const publishSpy = vi.spyOn(eventBus, "publish");
+    const prisma = mockPrisma([
+      {
+        streamId: 1,
+        creator: "GCREATOR",
+        recipient: "GRECIPIENT",
+        amount: BigInt(1000),
+        claimedAt: null,
+        status: StreamStatus.CREATED,
+      },
+      {
+        streamId: 2,
+        creator: "GCREATOR2",
+        recipient: "GRECIPIENT2",
+        amount: BigInt(0),
+        claimedAt: new Date(),
+        status: StreamStatus.CLAIMED,
+      },
+      {
+        streamId: 3,
+        creator: "GCREATOR3",
+        recipient: "GRECIPIENT3",
+        amount: BigInt(500),
+        claimedAt: null,
+        status: StreamStatus.CREATED,
+      },
+    ]);
+
+    const service = new StreamReconciliationService(prisma, 300_000);
+    const result = await service.reconcile();
+
+    expect(result.totalStreams).toBe(3);
+    expect(result.divergences.map((d) => d.streamId)).toEqual([1, 3]);
+    expect(publishSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("defaults to a 5-minute reconciliation interval", () => {
+    const original = process.env.STREAM_RECONCILIATION_INTERVAL_MS;
+    delete process.env.STREAM_RECONCILIATION_INTERVAL_MS;
+    try {
+      const prisma = mockPrisma([]);
+      const service = new StreamReconciliationService(prisma);
+
+      expect((service as any).reconciliationIntervalMs).toBe(300_000);
+    } finally {
+      process.env.STREAM_RECONCILIATION_INTERVAL_MS = original;
+    }
+  });
+});

--- a/backend/src/services/streamReconciliation.ts
+++ b/backend/src/services/streamReconciliation.ts
@@ -1,15 +1,26 @@
 import { PrismaClient, StreamStatus } from "@prisma/client";
-import { Logger } from "@nestjs/common";
+import { logger } from "../lib/logger";
+import { eventBus } from "./eventBus";
 
 export interface StreamDivergence {
   streamId: number;
   creator: string;
   recipient: string;
-  projectedBalance: string;
-  onChainBalance: string;
+  /** Name of the field that diverged, e.g. "balance" */
+  field: string;
+  projectedValue: string;
+  onChainValue: string;
   divergenceType: "mismatch" | "missing_onchain" | "missing_projected";
   severity: "error" | "warning";
   timestamp: Date;
+}
+
+/** Payload published on the eventBus when reconciliation finds a divergence */
+export interface StreamDivergenceDetectedPayload {
+  streamId: number;
+  field: string;
+  onChainValue: string;
+  projectedValue: string;
 }
 
 export interface StreamReconciliationResult {
@@ -22,7 +33,6 @@ export interface StreamReconciliationResult {
 }
 
 export class StreamReconciliationService {
-  private readonly logger = new Logger(StreamReconciliationService.name);
   private prisma: PrismaClient;
   private reconciliationIntervalMs: number;
   private lastReconciliation?: Date;
@@ -30,8 +40,8 @@ export class StreamReconciliationService {
   constructor(
     prisma: PrismaClient,
     reconciliationIntervalMs: number = parseInt(
-      process.env.STREAM_RECONCILIATION_INTERVAL_MS || "3600000"
-    ) // 1 hour default
+      process.env.STREAM_RECONCILIATION_INTERVAL_MS || "300000"
+    ) // 5 minutes default
   ) {
     this.prisma = prisma;
     this.reconciliationIntervalMs = reconciliationIntervalMs;
@@ -39,7 +49,7 @@ export class StreamReconciliationService {
 
   async reconcile(): Promise<StreamReconciliationResult> {
     const startTime = Date.now();
-    this.logger.debug("Starting stream settlement reconciliation");
+    logger.debug("Starting stream settlement reconciliation");
 
     const divergences: StreamDivergence[] = [];
     const errors: string[] = [];
@@ -73,16 +83,26 @@ export class StreamReconciliationService {
             onChainBalance !== null &&
             projectedBalance !== onChainBalance.toString()
           ) {
-            divergences.push({
+            const divergence: StreamDivergence = {
               streamId: stream.streamId,
               creator: stream.creator,
               recipient: stream.recipient,
-              projectedBalance,
-              onChainBalance: onChainBalance.toString(),
+              field: "balance",
+              projectedValue: projectedBalance,
+              onChainValue: onChainBalance.toString(),
               divergenceType: "mismatch",
               severity: "error",
               timestamp: new Date(),
-            });
+            };
+            divergences.push(divergence);
+
+            const eventPayload: StreamDivergenceDetectedPayload = {
+              streamId: divergence.streamId,
+              field: divergence.field,
+              onChainValue: divergence.onChainValue,
+              projectedValue: divergence.projectedValue,
+            };
+            await eventBus.publish("stream.divergence_detected", eventPayload);
           }
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
@@ -93,7 +113,7 @@ export class StreamReconciliationService {
       this.lastReconciliation = new Date();
 
       if (divergences.length > 0) {
-        this.logger.warn(
+        logger.warn(
           `Found ${divergences.length} stream divergences during reconciliation`
         );
       }
@@ -108,7 +128,7 @@ export class StreamReconciliationService {
       };
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      this.logger.error(`Reconciliation failed: ${msg}`);
+      logger.error(`Reconciliation failed: ${msg}`);
       errors.push(`Reconciliation failed: ${msg}`);
 
       return {
@@ -136,7 +156,7 @@ export class StreamReconciliationService {
       // In production, this would call a blockchain RPC or contract query
       return BigInt(0);
     } catch (err) {
-      this.logger.warn(`Failed to fetch on-chain balance for stream ${streamId}`);
+      logger.warn(`Failed to fetch on-chain balance for stream ${streamId}`);
       return null;
     }
   }
@@ -177,9 +197,9 @@ export class StreamReconciliationService {
     if (result.divergences.length > 0) {
       lines.push("  DIVERGENCES:");
       result.divergences.forEach((div) => {
-        lines.push(`    ❌ Stream ${div.streamId}`);
-        lines.push(`       Projected: ${div.projectedBalance}`);
-        lines.push(`       On-chain:  ${div.onChainBalance}`);
+        lines.push(`    ❌ Stream ${div.streamId} (${div.field})`);
+        lines.push(`       Projected: ${div.projectedValue}`);
+        lines.push(`       On-chain:  ${div.onChainValue}`);
       });
     } else {
       lines.push("  ✅ All streams reconciled successfully");

--- a/monitoring/pagerduty/incident-response.test.ts
+++ b/monitoring/pagerduty/incident-response.test.ts
@@ -14,6 +14,8 @@ import {
   alertDatabasePoolExhausted,
   resolveEventListenerDown,
   resolveHighApiErrorRate,
+  alertStreamDivergence,
+  resolveStreamDivergence,
 } from "./incident-response";
 
 // ---------------------------------------------------------------------------
@@ -421,6 +423,85 @@ describe("PagerDuty Incident Response", () => {
         const parsed = JSON.parse(capturedBody);
         expect(parsed.event_action).toBe("resolve");
         expect(parsed.dedup_key).toBe("nova-api-high-error-rate");
+      } finally {
+        process.env.PAGERDUTY_ROUTING_KEY = original;
+      }
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Stream divergence alerts
+  // -------------------------------------------------------------------------
+
+  describe("stream divergence alerts", () => {
+    it("alertStreamDivergence uses error severity (P2) and a per-stream/field dedup key", async () => {
+      let capturedBody = "";
+      vi.spyOn(https, "request").mockImplementation((_opts, callback) => {
+        const res = Object.assign(new EventEmitter(), { statusCode: 202 });
+        const req = Object.assign(new EventEmitter(), {
+          write: vi.fn((data: string) => {
+            capturedBody = data;
+          }),
+          end: vi.fn(() => {
+            if (callback) {
+              (callback as (res: any) => void)(res);
+              res.emit("data", JSON.stringify(SUCCESS_RESPONSE));
+              res.emit("end");
+            }
+          }),
+        });
+        return req as any;
+      });
+
+      const original = process.env.PAGERDUTY_ROUTING_KEY;
+      process.env.PAGERDUTY_ROUTING_KEY = ROUTING_KEY;
+      try {
+        await alertStreamDivergence({
+          streamId: 42,
+          field: "balance",
+          onChainValue: "100",
+          projectedValue: "150",
+        });
+        const parsed = JSON.parse(capturedBody);
+        expect(parsed.payload.severity).toBe("error");
+        expect(parsed.dedup_key).toBe("nova-stream-divergence-42-balance");
+        expect(parsed.payload.custom_details).toEqual({
+          streamId: 42,
+          field: "balance",
+          onChainValue: "100",
+          projectedValue: "150",
+        });
+      } finally {
+        process.env.PAGERDUTY_ROUTING_KEY = original;
+      }
+    });
+
+    it("resolveStreamDivergence sends resolve for the matching dedup key", async () => {
+      let capturedBody = "";
+      vi.spyOn(https, "request").mockImplementation((_opts, callback) => {
+        const res = Object.assign(new EventEmitter(), { statusCode: 202 });
+        const req = Object.assign(new EventEmitter(), {
+          write: vi.fn((data: string) => {
+            capturedBody = data;
+          }),
+          end: vi.fn(() => {
+            if (callback) {
+              (callback as (res: any) => void)(res);
+              res.emit("data", JSON.stringify(SUCCESS_RESPONSE));
+              res.emit("end");
+            }
+          }),
+        });
+        return req as any;
+      });
+
+      const original = process.env.PAGERDUTY_ROUTING_KEY;
+      process.env.PAGERDUTY_ROUTING_KEY = ROUTING_KEY;
+      try {
+        await resolveStreamDivergence(42, "balance");
+        const parsed = JSON.parse(capturedBody);
+        expect(parsed.event_action).toBe("resolve");
+        expect(parsed.dedup_key).toBe("nova-stream-divergence-42-balance");
       } finally {
         process.env.PAGERDUTY_ROUTING_KEY = original;
       }

--- a/monitoring/pagerduty/incident-response.ts
+++ b/monitoring/pagerduty/incident-response.ts
@@ -197,3 +197,31 @@ export function resolveEventListenerDown() {
 export function resolveHighApiErrorRate() {
   return resolveIncident("nova-api-high-error-rate");
 }
+
+export interface StreamDivergenceDetails {
+  streamId: number;
+  field: string;
+  onChainValue: string;
+  projectedValue: string;
+}
+
+/** Build the dedup key for a stream divergence so it can be resolved later */
+function streamDivergenceDedupKey(streamId: number, field: string): string {
+  return `nova-stream-divergence-${streamId}-${field}`;
+}
+
+/** Alert (P2) when stream reconciliation finds the projection diverging from on-chain state */
+export function alertStreamDivergence(details: StreamDivergenceDetails) {
+  return triggerIncident({
+    summary: `Nova Launch: Stream ${details.streamId} ${details.field} diverged from on-chain state`,
+    severity: "error",
+    dedupKey: streamDivergenceDedupKey(details.streamId, details.field),
+    source: "streamReconciliation",
+    customDetails: details,
+  });
+}
+
+/** Resolve a stream divergence incident once reconciliation confirms it cleared */
+export function resolveStreamDivergence(streamId: number, field: string) {
+  return resolveIncident(streamDivergenceDedupKey(streamId, field));
+}


### PR DESCRIPTION
## Summary
- `streamReconciliation` now emits a `stream.divergence_detected` event (with `streamId`, `field`, `onChainValue`, `projectedValue`) on the existing `eventBus` whenever the projection diverges from on-chain state, and defaults to a 5-minute reconciliation interval.
- `monitoring/pagerduty/incident-response` gains `alertStreamDivergence` / `resolveStreamDivergence`, raising/resolving a P2 PagerDuty incident deduplicated per stream + field.
- New `streamDivergenceAlerting` service subscribes to the event and calls the PagerDuty helper, keeping reconciliation decoupled from alerting (same pattern as `leaderboardService`'s eventBus subscriptions).
- `JobQueue` gains `scheduleRecurring` / `stopRecurring`, and `index.ts` now schedules reconciliation through the queue instead of an ad-hoc `setInterval`.

## Notable fixes found along the way
- `index.ts` referenced `jobQueue` and `streamReconciliationService` without importing them — the stream reconciliation registration/scheduling block would throw at server startup. Added the missing imports.
- `streamReconciliation.ts` imported `Logger` from `@nestjs/common`, which isn't a project dependency (not installed, not in `package.json`), so the module couldn't be loaded at all. Swapped to the app's existing `lib/logger`.

## Test plan
- [x] `vitest run` on `streamReconciliation.test.ts`, `streamDivergenceAlerting.test.ts`, `jobQueue.test.ts`, `incidentResponse.pagerduty.test.ts`, `eventBus.test.ts` — all green (77 tests)
- [x] Confirmed the pre-existing failures elsewhere in the suite (~100 unrelated files) are present on `main` as well, i.e. unaffected by this change

Closes #1390