### PR TITLE
test(services): mutation testing and concurrent write coverage for AuditRetentionJob

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -16,6 +16,8 @@ build/
 # Testing
 coverage/
 .nyc_output/
+.stryker-tmp*/
+reports/mutation/
 
 # IDE
 .vscode/

--- a/backend/package.json
+++ b/backend/package.json
@@ -20,6 +20,7 @@
     "test:security:scanning": "vitest run src/__tests__/security.dependency-scanning.test.ts",
     "test:txn-propagation": "vitest run src/__tests__/txn-id-propagation.test.ts src/__tests__/correlation-id-propagation.test.ts --reporter=verbose",
     "test:mutation": "vitest run src/__tests__/mutation-testing.framework.test.ts",
+    "test:mutation:audit": "stryker run stryker.audit.conf.json",
     "lint": "eslint src --ext .ts,.tsx",
     "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json}\"",
     "format:check": "prettier --check \"src/**/*.{ts,tsx,js,jsx,json}\"",
@@ -53,6 +54,8 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@stryker-mutator/core": "^8.7.1",
+    "@stryker-mutator/vitest-runner": "^8.7.1",
     "@types/bcryptjs": "^2.4.6",
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",

--- a/backend/src/__tests__/auditRetentionJob.concurrent.test.ts
+++ b/backend/src/__tests__/auditRetentionJob.concurrent.test.ts
@@ -1,0 +1,280 @@
+/**
+ * AuditRetentionJob: Boundary & Concurrent-Write Coverage
+ *
+ * `runAuditRetention(retentionDays)` computes `cutoff = now - retentionDays`
+ * and purges every audit log with `timestamp < cutoff`. The single most
+ * dangerous mutation here is flipping `<` to `<=` (or the mirrored `>=` to
+ * `>` inside `Database.purgeAuditLogs`), which would delete records sitting
+ * exactly ON the retention boundary one period too early.
+ *
+ * This suite:
+ *   1. Pins down the three boundary cases directly (1ms before cutoff is
+ *      purged, exactly-at-cutoff is kept, 1ms after cutoff is kept) using
+ *      fake system time for precise control over "now" vs. record timestamps.
+ *   2. Simulates concurrent writers racing against a single retention run
+ *      and asserts none of their freshly-written records are deleted.
+ *
+ * SEVERITY: HIGH — silent data loss with no test coverage previously.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { Database } from "../config/database";
+import { runAuditRetention } from "../services/auditRetentionJob";
+import { MetricsCollector } from "../lib/metrics";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function baseLogPayload() {
+  return {
+    adminId: "admin-1",
+    action: "test_action",
+    resource: "token",
+    resourceId: "res-1",
+    beforeState: null,
+    afterState: null,
+    ipAddress: "127.0.0.1",
+    userAgent: "vitest",
+  };
+}
+
+/**
+ * Insert an audit log with a precisely controlled timestamp.
+ * `Database.createAuditLog` always stamps `new Date()` at call time, so we
+ * drive the clock with fake timers, create the record, then restore "now".
+ */
+async function createLogAt(timestamp: Date) {
+  vi.setSystemTime(timestamp);
+  const log = await Database.createAuditLog(baseLogPayload());
+  return log;
+}
+
+describe("AuditRetentionJob: retention boundary semantics", () => {
+  const RETENTION_DAYS = 90;
+
+  beforeEach(() => {
+    Database.__resetAuditLogsForTests();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("purges a record exactly 1ms before the retention cutoff", async () => {
+    const now = new Date("2026-06-24T12:00:00.000Z");
+    const cutoff = new Date(now.getTime() - RETENTION_DAYS * DAY_MS);
+    const justBeforeCutoff = new Date(cutoff.getTime() - 1);
+
+    await createLogAt(justBeforeCutoff);
+
+    vi.setSystemTime(now);
+    const purgedCount = await runAuditRetention(RETENTION_DAYS);
+
+    expect(purgedCount).toBe(1);
+    const remaining = await Database.getAuditLogs();
+    expect(remaining).toHaveLength(0);
+  });
+
+  it("keeps a record exactly AT the retention cutoff (the < vs <= boundary)", async () => {
+    const now = new Date("2026-06-24T12:00:00.000Z");
+    const cutoff = new Date(now.getTime() - RETENTION_DAYS * DAY_MS);
+
+    await createLogAt(cutoff);
+
+    vi.setSystemTime(now);
+    const purgedCount = await runAuditRetention(RETENTION_DAYS);
+
+    // A `<` to `<=` mutation would purge this record (purgedCount === 1,
+    // remaining === 0). The correct behavior keeps it.
+    expect(purgedCount).toBe(0);
+    const remaining = await Database.getAuditLogs();
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].timestamp.getTime()).toBe(cutoff.getTime());
+  });
+
+  it("keeps a record exactly 1ms after the retention cutoff", async () => {
+    const now = new Date("2026-06-24T12:00:00.000Z");
+    const cutoff = new Date(now.getTime() - RETENTION_DAYS * DAY_MS);
+    const justAfterCutoff = new Date(cutoff.getTime() + 1);
+
+    await createLogAt(justAfterCutoff);
+
+    vi.setSystemTime(now);
+    const purgedCount = await runAuditRetention(RETENTION_DAYS);
+
+    expect(purgedCount).toBe(0);
+    const remaining = await Database.getAuditLogs();
+    expect(remaining).toHaveLength(1);
+  });
+
+  it("purges old records while keeping boundary and fresh records together", async () => {
+    const now = new Date("2026-06-24T12:00:00.000Z");
+    const cutoff = new Date(now.getTime() - RETENTION_DAYS * DAY_MS);
+
+    await createLogAt(new Date(cutoff.getTime() - 1)); // purge
+    await createLogAt(cutoff); // keep (boundary)
+    await createLogAt(new Date(cutoff.getTime() + 1)); // keep
+    await createLogAt(now); // keep (fresh)
+
+    vi.setSystemTime(now);
+    const purgedCount = await runAuditRetention(RETENTION_DAYS);
+
+    expect(purgedCount).toBe(1);
+    const remaining = await Database.getAuditLogs();
+    expect(remaining).toHaveLength(3);
+    expect(remaining.every((l) => l.timestamp.getTime() >= cutoff.getTime())).toBe(
+      true
+    );
+  });
+
+  it("records the background-job metric with the correct job name, status, and duration", async () => {
+    const recordSpy = vi.spyOn(MetricsCollector, "recordBackgroundJob");
+    const now = new Date("2026-06-24T12:00:00.000Z");
+    vi.setSystemTime(now);
+
+    await runAuditRetention(RETENTION_DAYS);
+
+    expect(recordSpy).toHaveBeenCalledTimes(1);
+    const [jobName, status, durationSeconds] = recordSpy.mock.calls[0];
+    expect(jobName).toBe("audit_retention");
+    expect(status).toBe("success");
+    // Duration must be a non-negative number of *seconds*, not milliseconds
+    // and not the result of an addition (Date.now() + start would be huge).
+    expect(durationSeconds).toBeGreaterThanOrEqual(0);
+    expect(durationSeconds).toBeLessThan(1);
+
+    recordSpy.mockRestore();
+  });
+
+  it("logs a structured completion event with the correct event name and cutoff", async () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const now = new Date("2026-06-24T12:00:00.000Z");
+    const cutoff = new Date(now.getTime() - RETENTION_DAYS * DAY_MS);
+    vi.setSystemTime(now);
+
+    await runAuditRetention(RETENTION_DAYS);
+
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const logged = JSON.parse(logSpy.mock.calls[0][0] as string);
+    expect(logged.event).toBe("audit_retention.complete");
+    expect(logged.cutoff).toBe(cutoff.toISOString());
+    expect(logged.retentionDays).toBe(RETENTION_DAYS);
+    expect(logged.purged).toBe(0);
+    expect(typeof logged.durationMs).toBe("number");
+    expect(logged.durationMs).toBeGreaterThanOrEqual(0);
+
+    logSpy.mockRestore();
+  });
+
+  it("is idempotent: running twice in a row purges nothing the second time", async () => {
+    const now = new Date("2026-06-24T12:00:00.000Z");
+    const cutoff = new Date(now.getTime() - RETENTION_DAYS * DAY_MS);
+
+    await createLogAt(new Date(cutoff.getTime() - 1));
+    await createLogAt(cutoff);
+
+    vi.setSystemTime(now);
+    const firstRun = await runAuditRetention(RETENTION_DAYS);
+    const secondRun = await runAuditRetention(RETENTION_DAYS);
+
+    expect(firstRun).toBe(1);
+    expect(secondRun).toBe(0);
+    const remaining = await Database.getAuditLogs();
+    expect(remaining).toHaveLength(1);
+  });
+});
+
+describe("AuditRetentionJob: concurrent writes during a deletion run", () => {
+  const RETENTION_DAYS = 90;
+
+  beforeEach(() => {
+    Database.__resetAuditLogsForTests();
+  });
+
+  it("does not delete fresh records written concurrently with a retention pass", async () => {
+    // Seed a stale record well outside the retention window so the
+    // retention pass has guaranteed work to do.
+    const staleTimestamp = new Date(
+      Date.now() - (RETENTION_DAYS + 10) * DAY_MS
+    );
+    vi.useFakeTimers();
+    vi.setSystemTime(staleTimestamp);
+    await Database.createAuditLog(baseLogPayload());
+    vi.useRealTimers();
+
+    // Race 10 concurrent "writer" operations (each stamped with the current
+    // real time) against a single concurrently-running retention pass.
+    const writerCount = 10;
+    const writers = Array.from({ length: writerCount }, (_, i) =>
+      Database.createAuditLog({
+        ...baseLogPayload(),
+        resourceId: `concurrent-${i}`,
+      })
+    );
+
+    const [retentionResult] = await Promise.all([
+      runAuditRetention(RETENTION_DAYS),
+      ...writers,
+    ]);
+
+    const remaining = await Database.getAuditLogs();
+
+    // The stale seed record should have been purged.
+    expect(retentionResult).toBeGreaterThanOrEqual(1);
+
+    // All 10 freshly-written concurrent records must survive — none of them
+    // are older than the retention cutoff.
+    const concurrentSurvivors = remaining.filter((l) =>
+      l.resourceId.startsWith("concurrent-")
+    );
+    expect(concurrentSurvivors).toHaveLength(writerCount);
+
+    // Sanity: every survivor's resourceId is represented exactly once.
+    const survivorIds = new Set(concurrentSurvivors.map((l) => l.resourceId));
+    expect(survivorIds.size).toBe(writerCount);
+  });
+
+  it("preserves a record written exactly at the retention boundary while writers race", async () => {
+    const now = new Date("2026-06-24T12:00:00.000Z");
+    const cutoff = new Date(now.getTime() - RETENTION_DAYS * DAY_MS);
+
+    // Keep fake time pinned at `now` for the entire scenario so that the
+    // cutoff `runAuditRetention` computes internally (via Date.now()) lines
+    // up exactly with the boundary record's timestamp. Real timers would let
+    // wall-clock time drift past `now` between setup and the retention call,
+    // which would make the boundary record legitimately stale instead of
+    // exactly-at-cutoff.
+    vi.useFakeTimers();
+    vi.setSystemTime(cutoff);
+    await Database.createAuditLog({
+      ...baseLogPayload(),
+      resourceId: "boundary-record",
+    });
+    vi.setSystemTime(now);
+
+    const writers = Array.from({ length: 10 }, (_, i) =>
+      Database.createAuditLog({
+        ...baseLogPayload(),
+        resourceId: `writer-${i}`,
+      })
+    );
+
+    await Promise.all([runAuditRetention(RETENTION_DAYS), ...writers]);
+
+    vi.useRealTimers();
+
+    const remaining = await Database.getAuditLogs();
+    const boundaryRecord = remaining.find(
+      (l) => l.resourceId === "boundary-record"
+    );
+
+    // This is the case a `<` -> `<=` mutant gets wrong: the boundary record
+    // must be preserved, not purged.
+    expect(boundaryRecord).toBeDefined();
+
+    const survivingWriters = remaining.filter((l) =>
+      l.resourceId.startsWith("writer-")
+    );
+    expect(survivingWriters).toHaveLength(10);
+  });
+});

--- a/backend/src/config/database.ts
+++ b/backend/src/config/database.ts
@@ -108,6 +108,15 @@ export class Database {
     return logs.sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime());
   }
 
+  /**
+   * Test-only helper: clear all in-memory audit logs.
+   * Not used by production code paths — exists so tests can reset state
+   * between cases without reaching into private static fields.
+   */
+  static __resetAuditLogsForTests(): void {
+    this.auditLogs = [];
+  }
+
   // Initialize with sample data
   static initialize() {
     // Add sample admin user

--- a/backend/stryker.audit.conf.json
+++ b/backend/stryker.audit.conf.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "./node_modules/@stryker-mutator/core/schema/stryker-schema.json",
+  "_comment": "Scoped mutation-testing config for backend/src/services/auditRetentionJob.ts (issue #1331). Mutates only the retention job so a single `npm run test:mutation:audit` run stays fast and focused on the < vs <= boundary regression this issue is about.",
+  "packageManager": "npm",
+  "testRunner": "vitest",
+  "vitest": {
+    "configFile": "vitest.config.mutation-audit.ts"
+  },
+  "mutate": [
+    "src/services/auditRetentionJob.ts:28-54"
+  ],
+  "testRunnerNodeArgs": [],
+  "ignoreStatic": true,
+  "disableTypeChecks": "src/services/auditRetentionJob.ts",
+  "mutator": {
+    "plugins": null
+  },
+  "reporters": [
+    "html",
+    "clear-text",
+    "progress"
+  ],
+  "htmlReporter": {
+    "fileName": "reports/mutation/audit-retention/index.html"
+  },
+  "coverageAnalysis": "perTest",
+  "thresholds": {
+    "high": 90,
+    "low": 70,
+    "break": 70
+  },
+  "tempDirName": ".stryker-tmp-audit"
+}

--- a/backend/vitest.config.mutation-audit.ts
+++ b/backend/vitest.config.mutation-audit.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    dedupe: ["graphql"],
+  },
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["src/__tests__/auditRetentionJob.concurrent.test.ts"],
+  },
+});


### PR DESCRIPTION
## Summary
- Adds boundary-case tests for `runAuditRetention` pinning the exact `<` semantics of the retention cutoff comparison (1ms before, exactly at, 1ms after) — a `<` → `<=` mutant would previously delete records on the boundary one period early without any test catching it.
- Adds a concurrent-write simulation (10 writers racing against a single retention pass, plus a variant with a record written exactly at the boundary) asserting freshly-written records are never deleted.
- Adds a scoped Stryker config (`stryker.audit.conf.json` + `vitest.config.mutation-audit.ts`) targeting only `auditRetentionJob.ts`'s `runAuditRetention` function, exposed via `npm run test:mutation:audit`.
- Adds `Database.__resetAuditLogsForTests()` test-only helper to reset in-memory audit state between cases.

## Test plan
- [x] `npx vitest run src/__tests__/auditRetentionJob.concurrent.test.ts` — 9/9 tests pass
- [x] `npm run test:mutation:audit` — mutation score 83.33% (≥80% target), all surviving mutants outside the retention/metrics/logging logic this issue targets

Closes #1331