### PR TITLE
feat: per-tenant token-bucket rate limiting for webhook delivery

### DIFF
--- a/backend/src/__tests__/chaos.webhook-fanout-storm.test.ts
+++ b/backend/src/__tests__/chaos.webhook-fanout-storm.test.ts
@@ -13,6 +13,11 @@
 process.env.WEBHOOK_MAX_RETRIES = '1';
 process.env.WEBHOOK_TIMEOUT_MS = '500';
 process.env.WEBHOOK_RETRY_DELAY_MS = '0';
+// This test fans out to 20+ subscribers sharing one createdBy/"tenant" —
+// raise the per-tenant rate-limit bucket so the storm volume here (which is
+// about fan-out correctness, not rate limiting) is never queued.
+process.env.WEBHOOK_RATE_LIMIT_PER_MINUTE = '100000';
+process.env.WEBHOOK_RATE_LIMIT_BURST = '10000';
 
 import nock from 'nock';
 import { describe, it, beforeEach, afterEach, vi, expect } from 'vitest';

--- a/backend/src/__tests__/chaos.webhook-network-failures.test.ts
+++ b/backend/src/__tests__/chaos.webhook-network-failures.test.ts
@@ -46,6 +46,12 @@
 process.env.WEBHOOK_MAX_RETRIES = '3'
 process.env.WEBHOOK_TIMEOUT_MS = '200'
 process.env.WEBHOOK_RETRY_DELAY_MS = '0'
+// Several property blocks below run 20+ fast-check iterations against a
+// single shared createdBy/"tenant" within one `it()`. Raise the per-tenant
+// rate-limit bucket so this network-failure chaos suite (which is not about
+// rate limiting) never queues a delivery.
+process.env.WEBHOOK_RATE_LIMIT_PER_MINUTE = '100000'
+process.env.WEBHOOK_RATE_LIMIT_BURST = '10000'
 
 import nock from 'nock'
 import { describe, it, beforeEach, afterEach, vi, expect } from 'vitest'

--- a/backend/src/__tests__/property.webhook-parallel-delivery.test.ts
+++ b/backend/src/__tests__/property.webhook-parallel-delivery.test.ts
@@ -28,6 +28,12 @@
 process.env.WEBHOOK_MAX_RETRIES = '1'
 process.env.WEBHOOK_TIMEOUT_MS = '2000'
 process.env.WEBHOOK_RETRY_DELAY_MS = '0'
+// This test measures wall-clock parallelism — per-tenant rate-limit queuing
+// would corrupt the timing assertions, and isn't what this test is about.
+// Raise the bucket far above this file's call volumes so deliveries are
+// never queued here (see TenantWebhookRateLimiter).
+process.env.WEBHOOK_RATE_LIMIT_PER_MINUTE = '100000'
+process.env.WEBHOOK_RATE_LIMIT_BURST = '10000'
 
 import nock from 'nock'
 import { describe, it, beforeEach, afterEach, vi, expect } from 'vitest'

--- a/backend/src/__tests__/tenantWebhookRateLimiter.test.ts
+++ b/backend/src/__tests__/tenantWebhookRateLimiter.test.ts
@@ -1,0 +1,351 @@
+/**
+ * Tests for TenantWebhookRateLimiter — the per-tenant token-bucket rate
+ * limiter gating outbound webhook delivery (Issue #1336).
+ *
+ * Covers:
+ *   - Default config (100/min, burst 20) is read from env vars at construction.
+ *   - Burst capacity is respected: the first `burstCapacity` acquisitions
+ *     resolve immediately; the next one is queued, not dropped.
+ *   - Queued acquisitions eventually resolve once tokens refill (using
+ *     vi.useFakeTimers() to advance time deterministically).
+ *   - Tenants are isolated: one tenant's exhausted bucket never blocks or
+ *     drains tokens from another tenant's bucket.
+ *   - Per-tenant overrides (setTenantOverride/clearTenantOverride) work as
+ *     the documented extension point for future settings-table integration.
+ *   - Metrics (webhook_delivery_queued_total / webhook_delivery_rate_limited_total)
+ *     are incremented per tenant exactly when deliveries are queued/rate-limited.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+describe("TenantWebhookRateLimiter", () => {
+  let TenantWebhookRateLimiter: typeof import("../services/tenantWebhookRateLimiter").TenantWebhookRateLimiter;
+  let webhookDeliveryQueuedTotal: typeof import("../services/tenantWebhookRateLimiter").webhookDeliveryQueuedTotal;
+  let webhookDeliveryRateLimitedTotal: typeof import("../services/tenantWebhookRateLimiter").webhookDeliveryRateLimitedTotal;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    const mod = await import("../services/tenantWebhookRateLimiter");
+    TenantWebhookRateLimiter = mod.TenantWebhookRateLimiter;
+    webhookDeliveryQueuedTotal = mod.webhookDeliveryQueuedTotal;
+    webhookDeliveryRateLimitedTotal = mod.webhookDeliveryRateLimitedTotal;
+    webhookDeliveryQueuedTotal.reset();
+    webhookDeliveryRateLimitedTotal.reset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // -------------------------------------------------------------------------
+  // Defaults / configuration
+  // -------------------------------------------------------------------------
+
+  describe("default configuration", () => {
+    it("defaults to 100/min and burst 20 when no env vars are set", () => {
+      delete process.env.WEBHOOK_RATE_LIMIT_PER_MINUTE;
+      delete process.env.WEBHOOK_RATE_LIMIT_BURST;
+      const limiter = new TenantWebhookRateLimiter();
+      const config = limiter.getConfigForTenant("tenant-a");
+      expect(config.ratePerMinute).toBe(100);
+      expect(config.burstCapacity).toBe(20);
+      limiter.destroy();
+    });
+
+    it("reads defaults from WEBHOOK_RATE_LIMIT_PER_MINUTE / WEBHOOK_RATE_LIMIT_BURST env vars", async () => {
+      process.env.WEBHOOK_RATE_LIMIT_PER_MINUTE = "240";
+      process.env.WEBHOOK_RATE_LIMIT_BURST = "5";
+      vi.resetModules();
+      const mod = await import("../services/tenantWebhookRateLimiter");
+      const limiter = new mod.TenantWebhookRateLimiter();
+      const config = limiter.getConfigForTenant("tenant-a");
+      expect(config.ratePerMinute).toBe(240);
+      expect(config.burstCapacity).toBe(5);
+      limiter.destroy();
+      delete process.env.WEBHOOK_RATE_LIMIT_PER_MINUTE;
+      delete process.env.WEBHOOK_RATE_LIMIT_BURST;
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Burst behavior — immediate vs queued
+  // -------------------------------------------------------------------------
+
+  describe("burst capacity", () => {
+    it("allows exactly burstCapacity immediate acquisitions before queuing", async () => {
+      const limiter = new TenantWebhookRateLimiter({
+        ratePerMinute: 100,
+        burstCapacity: 20,
+      });
+      const tenant = "tenant-burst";
+
+      const resolvedFlags: boolean[] = [];
+      const promises = Array.from({ length: 20 }, () => {
+        const p = limiter.acquire(tenant).then(() => {
+          resolvedFlags.push(true);
+        });
+        return p;
+      });
+
+      await Promise.all(promises);
+      expect(resolvedFlags).toHaveLength(20);
+      // Bucket should now be empty (0 tokens, modulo negligible elapsed-time refill)
+      expect(limiter.getAvailableTokens(tenant)).toBeLessThan(1);
+
+      limiter.destroy();
+    });
+
+    it("queues the (burstCapacity + 1)th acquisition instead of dropping it", async () => {
+      vi.useFakeTimers();
+      const limiter = new TenantWebhookRateLimiter({
+        ratePerMinute: 60, // 1 token/sec — easy to reason about
+        burstCapacity: 3,
+      });
+      const tenant = "tenant-overflow";
+
+      // Consume all 3 burst tokens immediately.
+      await limiter.acquire(tenant);
+      await limiter.acquire(tenant);
+      await limiter.acquire(tenant);
+      expect(limiter.getQueueLength(tenant)).toBe(0);
+
+      // The 4th acquisition must NOT resolve immediately — it should queue.
+      let fourthResolved = false;
+      const fourth = limiter.acquire(tenant).then(() => {
+        fourthResolved = true;
+      });
+
+      // Give pending microtasks a chance to run without advancing real time.
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(fourthResolved).toBe(false);
+      expect(limiter.getQueueLength(tenant)).toBe(1);
+
+      // Advance fake time by 1 token's worth (1000ms at 60/min) plus the
+      // drain-check interval so the queued caller is resolved, not dropped.
+      await vi.advanceTimersByTimeAsync(1100);
+
+      expect(fourthResolved).toBe(true);
+      expect(limiter.getQueueLength(tenant)).toBe(0);
+
+      limiter.destroy();
+    });
+
+    it("never drops excess deliveries — all queued callers eventually resolve", async () => {
+      vi.useFakeTimers();
+      const limiter = new TenantWebhookRateLimiter({
+        ratePerMinute: 60, // 1 token/sec
+        burstCapacity: 2,
+      });
+      const tenant = "tenant-no-drop";
+
+      const TOTAL_REQUESTS = 10;
+      let resolvedCount = 0;
+      const promises = Array.from({ length: TOTAL_REQUESTS }, () =>
+        limiter.acquire(tenant).then(() => {
+          resolvedCount++;
+        })
+      );
+
+      // Immediately, only burstCapacity (2) should be resolved; the rest queued.
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(resolvedCount).toBe(2);
+      expect(limiter.getQueueLength(tenant)).toBe(TOTAL_REQUESTS - 2);
+
+      // Advance time enough for all remaining tokens to refill (8 more
+      // tokens at 1/sec => ~8s, with margin for the drain check interval).
+      await vi.advanceTimersByTimeAsync(9000);
+
+      expect(resolvedCount).toBe(TOTAL_REQUESTS);
+      expect(limiter.getQueueLength(tenant)).toBe(0);
+
+      await Promise.all(promises);
+      limiter.destroy();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Tenant isolation
+  // -------------------------------------------------------------------------
+
+  describe("tenant isolation", () => {
+    it("one tenant exhausting its bucket does not affect another tenant", async () => {
+      vi.useFakeTimers();
+      const limiter = new TenantWebhookRateLimiter({
+        ratePerMinute: 60,
+        burstCapacity: 2,
+      });
+
+      // Exhaust tenant A's bucket and queue 3 more.
+      await limiter.acquire("tenant-a");
+      await limiter.acquire("tenant-a");
+      let aResolvedExtra = false;
+      limiter.acquire("tenant-a").then(() => {
+        aResolvedExtra = true;
+      });
+      await Promise.resolve();
+      expect(limiter.getQueueLength("tenant-a")).toBe(1);
+      expect(aResolvedExtra).toBe(false);
+
+      // Tenant B should still have its full burst capacity available.
+      expect(limiter.getAvailableTokens("tenant-b")).toBe(2);
+      let bResolved = false;
+      await limiter.acquire("tenant-b").then(() => {
+        bResolved = true;
+      });
+      expect(bResolved).toBe(true);
+      expect(limiter.getQueueLength("tenant-b")).toBe(0);
+
+      limiter.destroy();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Per-tenant overrides — the documented extension point
+  // -------------------------------------------------------------------------
+
+  describe("per-tenant overrides", () => {
+    it("setTenantOverride changes the effective config for that tenant only", () => {
+      const limiter = new TenantWebhookRateLimiter({
+        ratePerMinute: 100,
+        burstCapacity: 20,
+      });
+
+      limiter.setTenantOverride("vip-tenant", {
+        ratePerMinute: 1000,
+        burstCapacity: 100,
+      });
+
+      expect(limiter.getConfigForTenant("vip-tenant")).toEqual({
+        ratePerMinute: 1000,
+        burstCapacity: 100,
+      });
+      expect(limiter.getConfigForTenant("regular-tenant")).toEqual({
+        ratePerMinute: 100,
+        burstCapacity: 20,
+      });
+
+      limiter.destroy();
+    });
+
+    it("clearTenantOverride reverts a tenant back to the default config", async () => {
+      const limiter = new TenantWebhookRateLimiter({
+        ratePerMinute: 100,
+        burstCapacity: 20,
+      });
+
+      limiter.setTenantOverride("temp-tenant", {
+        ratePerMinute: 5,
+        burstCapacity: 1,
+      });
+      expect(limiter.getConfigForTenant("temp-tenant").burstCapacity).toBe(1);
+
+      limiter.clearTenantOverride("temp-tenant");
+      expect(limiter.getConfigForTenant("temp-tenant")).toEqual({
+        ratePerMinute: 100,
+        burstCapacity: 20,
+      });
+
+      limiter.destroy();
+    });
+
+    it("a lowered override clamps existing tokens down to the new burst capacity", async () => {
+      const limiter = new TenantWebhookRateLimiter({
+        ratePerMinute: 100,
+        burstCapacity: 20,
+      });
+      const tenant = "shrinking-tenant";
+
+      // Touch the bucket so it's created with the default 20-token capacity.
+      expect(limiter.getAvailableTokens(tenant)).toBe(20);
+
+      limiter.setTenantOverride(tenant, { ratePerMinute: 100, burstCapacity: 3 });
+      expect(limiter.getAvailableTokens(tenant)).toBeLessThanOrEqual(3);
+
+      limiter.destroy();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Metrics
+  // -------------------------------------------------------------------------
+
+  describe("metrics", () => {
+    it("does NOT increment queued/rate_limited metrics while under budget", async () => {
+      const limiter = new TenantWebhookRateLimiter({
+        ratePerMinute: 100,
+        burstCapacity: 20,
+      });
+
+      await limiter.acquire("metrics-tenant-ok");
+      await limiter.acquire("metrics-tenant-ok");
+
+      const queuedMetric = await webhookDeliveryQueuedTotal.get();
+      const rateLimitedMetric = await webhookDeliveryRateLimitedTotal.get();
+      expect(
+        queuedMetric.values.some((v) => v.labels.tenant_id === "metrics-tenant-ok")
+      ).toBe(false);
+      expect(
+        rateLimitedMetric.values.some((v) => v.labels.tenant_id === "metrics-tenant-ok")
+      ).toBe(false);
+
+      limiter.destroy();
+    });
+
+    it("increments webhook_delivery_queued_total and webhook_delivery_rate_limited_total exactly once per over-budget acquisition", async () => {
+      vi.useFakeTimers();
+      const limiter = new TenantWebhookRateLimiter({
+        ratePerMinute: 60,
+        burstCapacity: 1,
+      });
+      const tenant = "metrics-tenant-overflow";
+
+      await limiter.acquire(tenant); // consumes the only token, no metric yet
+
+      const pending = limiter.acquire(tenant); // over budget -> queued + metrics incremented synchronously
+      await Promise.resolve();
+
+      const queuedMetric = await webhookDeliveryQueuedTotal.get();
+      const rateLimitedMetric = await webhookDeliveryRateLimitedTotal.get();
+      const queuedEntry = queuedMetric.values.find((v) => v.labels.tenant_id === tenant);
+      const rateLimitedEntry = rateLimitedMetric.values.find(
+        (v) => v.labels.tenant_id === tenant
+      );
+
+      expect(queuedEntry?.value).toBe(1);
+      expect(rateLimitedEntry?.value).toBe(1);
+
+      await vi.advanceTimersByTimeAsync(1100);
+      await pending;
+
+      limiter.destroy();
+    });
+
+    it("uses separate metric label values per tenant", async () => {
+      vi.useFakeTimers();
+      const limiter = new TenantWebhookRateLimiter({
+        ratePerMinute: 60,
+        burstCapacity: 1,
+      });
+
+      await limiter.acquire("tenant-x");
+      const p1 = limiter.acquire("tenant-x"); // over budget
+
+      await limiter.acquire("tenant-y");
+      const p2 = limiter.acquire("tenant-y"); // over budget
+
+      await Promise.resolve();
+
+      const queuedMetric = await webhookDeliveryQueuedTotal.get();
+      const xEntry = queuedMetric.values.find((v) => v.labels.tenant_id === "tenant-x");
+      const yEntry = queuedMetric.values.find((v) => v.labels.tenant_id === "tenant-y");
+      expect(xEntry?.value).toBe(1);
+      expect(yEntry?.value).toBe(1);
+
+      await vi.advanceTimersByTimeAsync(1100);
+      await Promise.all([p1, p2]);
+      limiter.destroy();
+    });
+  });
+});

--- a/backend/src/__tests__/webhook-network-failures.integration.test.ts
+++ b/backend/src/__tests__/webhook-network-failures.integration.test.ts
@@ -11,6 +11,14 @@
  *   - Verify delivery records/metrics are updated correctly
  */
 
+// Set BEFORE importing webhookDeliveryService so the per-tenant rate
+// limiter singleton (created at module load) picks up a large bucket. This
+// file's fixtures share one createdBy/"tenant" across many `it()` blocks
+// with no module reset, and is about network-failure handling, not rate
+// limiting — raise the bucket so deliveries here are never queued.
+process.env.WEBHOOK_RATE_LIMIT_PER_MINUTE = "100000";
+process.env.WEBHOOK_RATE_LIMIT_BURST = "10000";
+
 import { describe, it, beforeEach, afterEach, vi, expect } from "vitest";
 import nock from "nock";
 import { v4 as uuidv4 } from "uuid";

--- a/backend/src/__tests__/webhook-subscription-filtering.integration.test.ts
+++ b/backend/src/__tests__/webhook-subscription-filtering.integration.test.ts
@@ -13,6 +13,10 @@
 
 // Set env vars BEFORE any imports so module-level constants pick them up
 process.env.WEBHOOK_RETRY_DELAY_MS = '0'
+// This file is about subscription filtering, not rate limiting — raise the
+// per-tenant bucket so none of these calls are ever queued.
+process.env.WEBHOOK_RATE_LIMIT_PER_MINUTE = '100000'
+process.env.WEBHOOK_RATE_LIMIT_BURST = '10000'
 
 import nock from 'nock'
 import { describe, it, beforeEach, afterEach, vi, expect } from 'vitest'

--- a/backend/src/__tests__/webhookCompression.test.ts
+++ b/backend/src/__tests__/webhookCompression.test.ts
@@ -6,6 +6,14 @@
  * uncompressed when the consumer responds with 415.
  */
 
+// Set BEFORE importing webhookDeliveryService so the per-tenant rate
+// limiter singleton (created at module load) picks up a large bucket. This
+// file's fixtures share one createdBy/"tenant" across all `it()` blocks
+// with no module reset, and is about compression behavior, not rate
+// limiting — raise the bucket so deliveries here are never queued.
+process.env.WEBHOOK_RATE_LIMIT_PER_MINUTE = "100000";
+process.env.WEBHOOK_RATE_LIMIT_BURST = "10000";
+
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import nock from "nock";
 import { v4 as uuidv4 } from "uuid";

--- a/backend/src/__tests__/webhookDeliveryLogging.integration.test.ts
+++ b/backend/src/__tests__/webhookDeliveryLogging.integration.test.ts
@@ -32,6 +32,10 @@
 process.env.WEBHOOK_MAX_RETRIES = "3"
 process.env.WEBHOOK_TIMEOUT_MS = "200"
 process.env.WEBHOOK_RETRY_DELAY_MS = "0" // keep tests fast
+// This file is about delivery logging, not rate limiting — raise the
+// per-tenant bucket so none of these calls are ever queued.
+process.env.WEBHOOK_RATE_LIMIT_PER_MINUTE = "100000"
+process.env.WEBHOOK_RATE_LIMIT_BURST = "10000"
 
 import nock from "nock";
 import { describe, it, beforeEach, afterEach, vi, expect } from "vitest";

--- a/backend/src/__tests__/webhookDeliveryService.chaos.test.ts
+++ b/backend/src/__tests__/webhookDeliveryService.chaos.test.ts
@@ -2,6 +2,12 @@
 process.env.WEBHOOK_MAX_RETRIES = '3'
 process.env.WEBHOOK_TIMEOUT_MS = '200'
 process.env.WEBHOOK_RETRY_DELAY_MS = '0'
+// Several property blocks below run 10-20 fast-check iterations against a
+// single shared createdBy/"tenant" within one `it()`. Raise the per-tenant
+// rate-limit bucket so this chaos suite (which is not about rate limiting)
+// never queues a delivery.
+process.env.WEBHOOK_RATE_LIMIT_PER_MINUTE = '100000'
+process.env.WEBHOOK_RATE_LIMIT_BURST = '10000'
 
 import nock from 'nock'
 import { describe, it, beforeEach, afterEach, vi, expect } from 'vitest'

--- a/backend/src/__tests__/webhookDeliveryService.rateLimiting.test.ts
+++ b/backend/src/__tests__/webhookDeliveryService.rateLimiting.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Integration tests: per-tenant rate limiting wired into
+ * WebhookDeliveryService (Issue #1336).
+ *
+ * Verifies the TenantWebhookRateLimiter is actually applied BEFORE the
+ * outbound HTTP call in `deliverWebhook`, keyed by `subscription.createdBy`
+ * ("tenant" — see comment on `WebhookDeliveryService.getTenantId`):
+ *   - A tenant within its burst budget delivers immediately.
+ *   - A tenant exceeding burst has the excess QUEUED (delivered later, once
+ *     tokens refill) rather than dropped — every subscription still ends up
+ *     delivered and logged exactly once.
+ *   - One busy tenant does not starve a different tenant's delivery.
+ *
+ * Uses vi.useFakeTimers() to advance the token-bucket refill loop
+ * deterministically instead of real sleeps.
+ */
+
+// Set env vars BEFORE any imports so module-level constants pick them up.
+process.env.WEBHOOK_MAX_RETRIES = "1";
+process.env.WEBHOOK_RETRY_DELAY_MS = "0";
+process.env.WEBHOOK_TIMEOUT_MS = "5000";
+// Small, easy-to-reason-about rate limit for this file's assertions:
+// 1 token/sec sustained, burst of 3.
+process.env.WEBHOOK_RATE_LIMIT_PER_MINUTE = "60";
+process.env.WEBHOOK_RATE_LIMIT_BURST = "3";
+
+import nock from "nock";
+import { describe, it, beforeEach, afterEach, vi, expect } from "vitest";
+import { v4 as uuidv4 } from "uuid";
+import {
+  WebhookEventType,
+  WebhookSubscription,
+  TokenCreatedEventData,
+} from "../types/webhook";
+
+const BASE_URL = "http://rate-limit-test.local";
+
+function makeSubscription(tenant: string, path: string): WebhookSubscription {
+  return {
+    id: `sub-${uuidv4()}`,
+    url: `${BASE_URL}${path}`,
+    events: [WebhookEventType.TOKEN_CREATED],
+    secret: "rate-limit-test-secret",
+    active: true,
+    createdBy: tenant,
+    createdAt: new Date(),
+    lastTriggered: null,
+    tokenAddress: null,
+  };
+}
+
+const eventData: TokenCreatedEventData = {
+  tokenAddress: "GTOKEN_RATE_LIMIT_TEST",
+  creator: "GCREATOR_RATE_LIMIT_TEST",
+  name: "Rate Limit Token",
+  symbol: "RLT",
+  decimals: 7,
+  initialSupply: "1000000",
+  transactionHash: "rate-limit-tx-hash",
+  ledger: 77777,
+};
+
+let service: import("../services/webhookDeliveryService").WebhookDeliveryService;
+let webhookServiceMod: typeof import("../services/webhookService").default;
+let rateLimiterMod: typeof import("../services/tenantWebhookRateLimiter").default;
+let deliveredOrder: string[] = [];
+
+beforeEach(async () => {
+  vi.resetModules();
+  deliveredOrder = [];
+
+  const wsMod = await import("../services/webhookService");
+  webhookServiceMod = wsMod.default;
+  vi.spyOn(webhookServiceMod, "logDelivery").mockResolvedValue(undefined);
+  vi.spyOn(webhookServiceMod, "updateLastTriggered").mockResolvedValue(undefined);
+
+  const rlMod = await import("../services/tenantWebhookRateLimiter");
+  rateLimiterMod = rlMod.default;
+
+  const mod = await import("../services/webhookDeliveryService");
+  service = mod.default;
+});
+
+afterEach(() => {
+  nock.cleanAll();
+  vi.clearAllMocks();
+  vi.useRealTimers();
+});
+
+describe("WebhookDeliveryService — per-tenant rate limiting", () => {
+  it("delivers immediately while a tenant is within its burst budget", async () => {
+    const tenant = "tenant-within-budget";
+    const sub1 = makeSubscription(tenant, "/hook-1");
+    const sub2 = makeSubscription(tenant, "/hook-2");
+    const sub3 = makeSubscription(tenant, "/hook-3");
+
+    nock(BASE_URL).post("/hook-1").reply(200, () => {
+      deliveredOrder.push(sub1.id);
+      return {};
+    });
+    nock(BASE_URL).post("/hook-2").reply(200, () => {
+      deliveredOrder.push(sub2.id);
+      return {};
+    });
+    nock(BASE_URL).post("/hook-3").reply(200, () => {
+      deliveredOrder.push(sub3.id);
+      return {};
+    });
+
+    // Burst capacity is 3 — exactly these 3 deliveries must succeed
+    // without any artificial delay.
+    await Promise.all([
+      service.deliverWebhook(sub1, WebhookEventType.TOKEN_CREATED, eventData),
+      service.deliverWebhook(sub2, WebhookEventType.TOKEN_CREATED, eventData),
+      service.deliverWebhook(sub3, WebhookEventType.TOKEN_CREATED, eventData),
+    ]);
+
+    expect(deliveredOrder.sort()).toEqual([sub1.id, sub2.id, sub3.id].sort());
+    expect(webhookServiceMod.logDelivery).toHaveBeenCalledTimes(3);
+    expect(nock.isDone()).toBe(true);
+  });
+
+  it("queues excess deliveries beyond burst capacity instead of dropping them", async () => {
+    vi.useFakeTimers();
+    const tenant = "tenant-over-budget";
+
+    const subs = Array.from({ length: 5 }, (_, i) =>
+      makeSubscription(tenant, `/hook-${i}`)
+    );
+    subs.forEach((sub, i) => {
+      nock(BASE_URL)
+        .post(`/hook-${i}`)
+        .reply(200, () => {
+          deliveredOrder.push(sub.id);
+          return {};
+        });
+    });
+
+    // Fire all 5 deliveries "at once" for one tenant. Burst capacity is 3,
+    // so the other 2 must be queued, not dropped.
+    const deliveryPromises = subs.map((sub) =>
+      service.deliverWebhook(sub, WebhookEventType.TOKEN_CREATED, eventData)
+    );
+
+    // Let the first wave (immediate, within-burst) settle. Two ticks are
+    // needed: the first lets the rate limiter's immediately-resolved
+    // `acquire()` promise settle, the second lets the now-unblocked
+    // axios/nock request-response microtask chain resolve.
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(deliveredOrder.length).toBe(3);
+    expect(rateLimiterMod.getQueueLength(tenant)).toBe(2);
+
+    // Advance fake time enough for the remaining 2 tokens to refill
+    // (1 token/sec at our configured rate) and the queue to drain.
+    await vi.advanceTimersByTimeAsync(2200);
+
+    await Promise.all(deliveryPromises);
+
+    // Crucially: ALL 5 subscriptions were eventually delivered — none
+    // silently dropped because the tenant was over budget.
+    expect(deliveredOrder.length).toBe(5);
+    expect(new Set(deliveredOrder).size).toBe(5);
+    expect(webhookServiceMod.logDelivery).toHaveBeenCalledTimes(5);
+    expect(rateLimiterMod.getQueueLength(tenant)).toBe(0);
+    expect(nock.isDone()).toBe(true);
+  });
+
+  it("does not let a busy tenant starve a different tenant's deliveries", async () => {
+    vi.useFakeTimers();
+    const busyTenant = "tenant-busy";
+    const quietTenant = "tenant-quiet";
+
+    // Busy tenant fires 6 deliveries — well beyond its burst of 3.
+    const busySubs = Array.from({ length: 6 }, (_, i) =>
+      makeSubscription(busyTenant, `/busy-${i}`)
+    );
+    busySubs.forEach((sub, i) => {
+      nock(BASE_URL)
+        .post(`/busy-${i}`)
+        .reply(200, () => {
+          deliveredOrder.push(sub.id);
+          return {};
+        });
+    });
+
+    // Quiet tenant fires a single delivery — comfortably within its own budget.
+    const quietSub = makeSubscription(quietTenant, "/quiet-0");
+    nock(BASE_URL)
+      .post("/quiet-0")
+      .reply(200, () => {
+        deliveredOrder.push(quietSub.id);
+        return {};
+      });
+
+    const busyPromises = busySubs.map((sub) =>
+      service.deliverWebhook(sub, WebhookEventType.TOKEN_CREATED, eventData)
+    );
+    const quietPromise = service.deliverWebhook(
+      quietSub,
+      WebhookEventType.TOKEN_CREATED,
+      eventData
+    );
+
+    // Two ticks: one for `acquire()` to settle, one for the unblocked
+    // axios/nock request-response microtask chain to resolve.
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(0);
+
+    // The quiet tenant's single delivery must succeed immediately,
+    // regardless of how backed up the busy tenant's queue is.
+    expect(deliveredOrder).toContain(quietSub.id);
+    expect(rateLimiterMod.getQueueLength(quietTenant)).toBe(0);
+
+    // The busy tenant should have exactly 3 delivered immediately and 3 queued.
+    const busyDeliveredSoFar = deliveredOrder.filter((id) =>
+      busySubs.some((s) => s.id === id)
+    );
+    expect(busyDeliveredSoFar.length).toBe(3);
+    expect(rateLimiterMod.getQueueLength(busyTenant)).toBe(3);
+
+    // Drain the busy tenant's queue.
+    await vi.advanceTimersByTimeAsync(3200);
+    await Promise.all(busyPromises);
+    await quietPromise;
+
+    expect(deliveredOrder.length).toBe(7);
+    expect(rateLimiterMod.getQueueLength(busyTenant)).toBe(0);
+  });
+});

--- a/backend/src/services/tenantWebhookRateLimiter.ts
+++ b/backend/src/services/tenantWebhookRateLimiter.ts
@@ -1,0 +1,272 @@
+/**
+ * Per-tenant webhook delivery rate limiter (token-bucket algorithm).
+ *
+ * Problem: `webhookDeliveryService` dispatches webhook deliveries for all
+ * matching subscriptions with no notion of fairness between tenants. A
+ * single tenant that triggers a burst of events (e.g. a large batch token
+ * deployment) can flood outbound HTTP delivery, starving other tenants'
+ * webhooks of timely delivery and putting unnecessary load on downstream
+ * endpoints.
+ *
+ * What is a "tenant" here?
+ *   This codebase's webhook layer (see `types/webhook.ts` /
+ *   `services/webhookService.ts`) has no dedicated tenant/org table —
+ *   `WebhookSubscription.createdBy` (the address that registered the
+ *   subscription) is the closest existing identifier that scopes a
+ *   subscription to a single account. We use `createdBy` as the tenant key.
+ *   If a real multi-tenant/organization concept is introduced later, swap
+ *   the key extraction in `webhookDeliveryService.ts` (search for
+ *   `getTenantId`) to use that identifier instead — no changes are needed
+ *   here in the limiter itself, which is keyed by an opaque string.
+ *
+ * Algorithm: classic token bucket per tenant.
+ *   - Each tenant has a bucket holding up to `burstCapacity` tokens.
+ *   - Tokens refill continuously at `ratePerMinute / 60` tokens/sec.
+ *   - A delivery costs 1 token. If a token is available, it is consumed and
+ *     the delivery proceeds immediately (`acquire()` resolves immediately).
+ *   - If no token is available, the request is queued (FIFO) and resolved
+ *     later, once enough time has passed for a token to refill — it is
+ *     NEVER dropped.
+ *
+ * Why in-memory and not Redis-backed?
+ *   `backend/src/middleware/rateLimiter.ts` shows this codebase already has
+ *   a Redis-backed limiter for HTTP ingress when distributed correctness
+ *   matters (rate limits shared across multiple API instances). Outbound
+ *   webhook delivery is driven by a single delivery worker process per
+ *   deployment today (there is no multi-instance fan-out of
+ *   `WebhookDeliveryService`), so an in-memory `Map`-based bucket (the same
+ *   pattern as `services/cache.ts`'s `CacheService`) is sufficient, avoids
+ *   adding a Redis round-trip to the hot delivery path, and keeps the
+ *   queue/drain logic trivially testable with fake timers. If delivery is
+ *   ever sharded across processes, swap the storage in this class for a
+ *   Redis Lua-script token bucket (e.g. reusing `createRedisClient()` from
+ *   `middleware/rateLimiter.ts`) while keeping the same public API.
+ *
+ * Configuration / extension point:
+ *   - Defaults come from env vars: `WEBHOOK_RATE_LIMIT_PER_MINUTE` (default
+ *     100) and `WEBHOOK_RATE_LIMIT_BURST` (default 20).
+ *   - Per-tenant overrides can be registered at runtime via
+ *     `setTenantOverride(tenantId, config)` / `clearTenantOverride(tenantId)`.
+ *     This is an in-memory map for now. If a tenant/settings table is added
+ *     to the Prisma schema later, load overrides from that table on
+ *     startup (or lazily on first lookup) and call `setTenantOverride` —
+ *     the rest of the rate limiter requires no changes.
+ */
+
+import { Counter } from "prom-client";
+import { register } from "../lib/metrics";
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+export interface TenantRateLimitConfig {
+  /** Sustained delivery rate, in deliveries per minute. */
+  ratePerMinute: number;
+  /** Maximum burst size — the bucket's token capacity. */
+  burstCapacity: number;
+}
+
+function readDefaultConfig(): TenantRateLimitConfig {
+  return {
+    ratePerMinute: parseInt(process.env.WEBHOOK_RATE_LIMIT_PER_MINUTE || "100", 10),
+    burstCapacity: parseInt(process.env.WEBHOOK_RATE_LIMIT_BURST || "20", 10),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Metrics
+//
+// Named to match the issue's logical event names (webhook.delivery.queued /
+// webhook.delivery.rate_limited) while following this codebase's existing
+// Prometheus naming convention of `snake_case_total` counters (see
+// `webhook_deliveries_total` etc. in `lib/metrics/index.ts`).
+// ---------------------------------------------------------------------------
+
+export const webhookDeliveryQueuedTotal = new Counter({
+  name: "webhook_delivery_queued_total",
+  help: "Total number of webhook deliveries queued because the tenant's rate-limit token bucket was empty (webhook.delivery.queued)",
+  labelNames: ["tenant_id"],
+  registers: [register],
+});
+
+export const webhookDeliveryRateLimitedTotal = new Counter({
+  name: "webhook_delivery_rate_limited_total",
+  help: "Total number of webhook delivery requests that exceeded the tenant's immediate token budget (webhook.delivery.rate_limited)",
+  labelNames: ["tenant_id"],
+  registers: [register],
+});
+
+/** Logical metric names referenced by the issue, kept alongside the Prometheus counters above for log/metric correlation. */
+export const WEBHOOK_RATE_LIMIT_METRIC_NAMES = {
+  QUEUED: "webhook.delivery.queued",
+  RATE_LIMITED: "webhook.delivery.rate_limited",
+} as const;
+
+// ---------------------------------------------------------------------------
+// Token bucket state
+// ---------------------------------------------------------------------------
+
+interface TokenBucket {
+  tokens: number;
+  lastRefill: number; // epoch ms
+  config: TenantRateLimitConfig;
+  /** FIFO queue of deliveries waiting for a token. */
+  queue: Array<() => void>;
+  /** Handle for the scheduled drain check, if one is pending. */
+  drainTimer: NodeJS.Timeout | null;
+}
+
+/**
+ * Per-tenant token-bucket rate limiter gating outbound webhook delivery.
+ *
+ * Usage: call `await limiter.acquire(tenantId)` immediately before the
+ * outbound HTTP call. It resolves as soon as a token is available for that
+ * tenant — immediately if the bucket has capacity, or after enough time has
+ * elapsed for the bucket to refill if the tenant is currently over budget.
+ * Callers are queued (never dropped) while waiting.
+ */
+export class TenantWebhookRateLimiter {
+  private readonly buckets: Map<string, TokenBucket> = new Map();
+  private readonly defaultConfig: TenantRateLimitConfig;
+  private readonly overrides: Map<string, TenantRateLimitConfig> = new Map();
+
+  constructor(defaultConfig: TenantRateLimitConfig = readDefaultConfig()) {
+    this.defaultConfig = defaultConfig;
+  }
+
+  /**
+   * Register a per-tenant override. Extension point for a future
+   * settings/tenant-config table — load rows at startup (or on demand) and
+   * call this for each tenant.
+   */
+  setTenantOverride(tenantId: string, config: TenantRateLimitConfig): void {
+    this.overrides.set(tenantId, config);
+    // If a bucket already exists, re-clamp its tokens to the new capacity
+    // and remember the new config for future refills.
+    const bucket = this.buckets.get(tenantId);
+    if (bucket) {
+      bucket.config = config;
+      bucket.tokens = Math.min(bucket.tokens, config.burstCapacity);
+    }
+  }
+
+  clearTenantOverride(tenantId: string): void {
+    this.overrides.delete(tenantId);
+    const bucket = this.buckets.get(tenantId);
+    if (bucket) bucket.config = this.defaultConfig;
+  }
+
+  getConfigForTenant(tenantId: string): TenantRateLimitConfig {
+    return this.overrides.get(tenantId) || this.defaultConfig;
+  }
+
+  /**
+   * Resolve once a token is available for `tenantId`, consuming it.
+   * Resolves synchronously-soon (next microtask) when capacity is
+   * immediately available; otherwise the caller is queued and resolved
+   * later by the drain loop as tokens refill. Never rejects, never drops.
+   */
+  acquire(tenantId: string): Promise<void> {
+    const bucket = this.getOrCreateBucket(tenantId);
+    this.refill(bucket);
+
+    if (bucket.tokens >= 1) {
+      bucket.tokens -= 1;
+      return Promise.resolve();
+    }
+
+    // Over budget: queue the request and emit rate-limit/queued metrics.
+    webhookDeliveryRateLimitedTotal.inc({ tenant_id: tenantId });
+    webhookDeliveryQueuedTotal.inc({ tenant_id: tenantId });
+
+    return new Promise<void>((resolve) => {
+      bucket.queue.push(resolve);
+      this.scheduleDrain(tenantId, bucket);
+    });
+  }
+
+  /** Number of deliveries currently queued (waiting for a token) for a tenant. */
+  getQueueLength(tenantId: string): number {
+    return this.buckets.get(tenantId)?.queue.length ?? 0;
+  }
+
+  /** Current available tokens for a tenant (after lazily applying refill). */
+  getAvailableTokens(tenantId: string): number {
+    const bucket = this.getOrCreateBucket(tenantId);
+    this.refill(bucket);
+    return bucket.tokens;
+  }
+
+  /** Tear down any pending timers — call in tests / on shutdown. */
+  destroy(): void {
+    for (const bucket of this.buckets.values()) {
+      if (bucket.drainTimer) clearTimeout(bucket.drainTimer);
+    }
+    this.buckets.clear();
+  }
+
+  // -- internals -----------------------------------------------------------
+
+  private getOrCreateBucket(tenantId: string): TokenBucket {
+    let bucket = this.buckets.get(tenantId);
+    if (!bucket) {
+      const config = this.overrides.get(tenantId) || this.defaultConfig;
+      bucket = {
+        tokens: config.burstCapacity,
+        lastRefill: Date.now(),
+        config,
+        queue: [],
+        drainTimer: null,
+      };
+      this.buckets.set(tenantId, bucket);
+    }
+    return bucket;
+  }
+
+  /** Add tokens proportional to elapsed time since the last refill, capped at burst capacity. */
+  private refill(bucket: TokenBucket): void {
+    const now = Date.now();
+    const elapsedMs = now - bucket.lastRefill;
+    if (elapsedMs <= 0) return;
+
+    const tokensPerMs = bucket.config.ratePerMinute / 60_000;
+    const refillAmount = elapsedMs * tokensPerMs;
+
+    if (refillAmount > 0) {
+      bucket.tokens = Math.min(bucket.config.burstCapacity, bucket.tokens + refillAmount);
+      bucket.lastRefill = now;
+    }
+  }
+
+  /**
+   * Ensure a drain check is scheduled for a tenant with a non-empty queue.
+   * Drains as many queued deliveries as current tokens allow, then
+   * reschedules itself if the queue is still non-empty.
+   */
+  private scheduleDrain(tenantId: string, bucket: TokenBucket): void {
+    if (bucket.drainTimer) return; // already scheduled
+
+    const msPerToken = 60_000 / bucket.config.ratePerMinute;
+    // Check slightly more often than one token's worth of time to keep
+    // queued callers' wait times tight without busy-looping.
+    const intervalMs = Math.max(10, Math.ceil(msPerToken));
+
+    bucket.drainTimer = setInterval(() => {
+      this.refill(bucket);
+
+      while (bucket.tokens >= 1 && bucket.queue.length > 0) {
+        bucket.tokens -= 1;
+        const resolve = bucket.queue.shift()!;
+        resolve();
+      }
+
+      if (bucket.queue.length === 0 && bucket.drainTimer) {
+        clearInterval(bucket.drainTimer);
+        bucket.drainTimer = null;
+      }
+    }, intervalMs);
+  }
+}
+
+export default new TenantWebhookRateLimiter();

--- a/backend/src/services/webhookDeliveryService.ts
+++ b/backend/src/services/webhookDeliveryService.ts
@@ -12,6 +12,9 @@ import webhookDeadLetterService from "./webhookDeadLetterService";
 import { IntegrationMetrics } from "../monitoring/metrics/prometheus-config";
 import { webhookDeliveryLatency } from "../lib/metrics";
 import { CircuitBreaker } from "../lib/circuitBreaker";
+import tenantWebhookRateLimiter, {
+  TenantWebhookRateLimiter,
+} from "./tenantWebhookRateLimiter";
 
 const gzipAsync = promisify(gzip);
 
@@ -23,8 +26,12 @@ export class WebhookDeliveryService {
   private circuitBreaker: CircuitBreaker;
   // Read at construction time so tests can override via process.env before new WebhookDeliveryService()
   private readonly compressionThresholdBytes: number;
+  // Per-tenant token-bucket rate limiter gating outbound delivery. Defaults
+  // to the shared singleton so all callers in the process share state, but
+  // can be overridden (e.g. in tests) via the constructor.
+  private readonly rateLimiter: TenantWebhookRateLimiter;
 
-  constructor() {
+  constructor(rateLimiter: TenantWebhookRateLimiter = tenantWebhookRateLimiter) {
     this.circuitBreaker = new CircuitBreaker({
       failureThreshold: parseInt(process.env.WEBHOOK_CIRCUIT_BREAKER_FAILURE_THRESHOLD || "5"),
       successThreshold: parseInt(process.env.WEBHOOK_CIRCUIT_BREAKER_SUCCESS_THRESHOLD || "2"),
@@ -34,6 +41,21 @@ export class WebhookDeliveryService {
     this.compressionThresholdBytes = parseInt(
       process.env.WEBHOOK_COMPRESSION_THRESHOLD_BYTES || "1024"
     );
+    this.rateLimiter = rateLimiter;
+  }
+
+  /**
+   * Resolve the rate-limiter "tenant" key for a subscription.
+   *
+   * There is no dedicated tenant/org column on webhook subscriptions in
+   * this codebase (see `types/webhook.ts` / `services/webhookService.ts`) —
+   * `createdBy` (the address that registered the subscription) is the
+   * closest existing identifier scoping a subscription to one account, so
+   * it is used as the tenant key. Centralizing the lookup here means a
+   * future real tenant/org concept only requires changing this one method.
+   */
+  private getTenantId(subscription: WebhookSubscription): string {
+    return subscription.createdBy;
   }
   /**
    * Trigger webhooks for an event
@@ -86,6 +108,13 @@ export class WebhookDeliveryService {
     // Include originating tx hash if present in data
     const txHash = (data as unknown as Record<string, unknown>).transactionHash as string | undefined;
     if (txHash) extraHeaders['X-Tx-Hash'] = txHash;
+
+    // Per-tenant token-bucket rate limiting gate — applied BEFORE any
+    // outbound HTTP call. If the tenant is within budget this resolves
+    // immediately; otherwise the delivery is queued (never dropped) and
+    // resolves once a token refills (see TenantWebhookRateLimiter).
+    const tenantId = this.getTenantId(subscription);
+    await this.rateLimiter.acquire(tenantId);
 
     return this.circuitBreaker.execute(async () => {
       let lastError: string | null = null;


### PR DESCRIPTION
closes #1336 
## Summary
- Adds `TenantWebhookRateLimiter`, a per-tenant token-bucket limiter (keyed by `WebhookSubscription.createdBy`) so one tenant's burst of events can't starve outbound webhook delivery for other tenants.
- Wires it into `WebhookDeliveryService.deliverWebhook`, applied immediately before the outbound HTTP call; over-budget deliveries are queued (never dropped) and drained as tokens refill.
- Configurable via `WEBHOOK_RATE_LIMIT_PER_MINUTE` / `WEBHOOK_RATE_LIMIT_BURST` env vars, with a per-tenant override API (`setTenantOverride`/`clearTenantOverride`) for future use.
- Emits Prometheus counters (`webhook_delivery_queued_total`, `webhook_delivery_rate_limited_total`) labeled by tenant.
- Existing chaos/integration/property webhook tests that fan out many deliveries under one shared tenant now raise their rate-limit env vars so they remain unaffected (they're testing other behavior, not rate limiting).

## Test plan
- [x] `tenantWebhookRateLimiter.test.ts` — 12 unit tests covering defaults, burst capacity, tenant isolation, overrides, and metrics
- [x] `webhookDeliveryService.rateLimiting.test.ts` — 3 integration tests verifying the limiter gates real delivery, queues excess instead of dropping, and doesn't let a busy tenant starve a quiet one
- [x] Full webhook test suite (9 files, 97 tests) passes
- [x] `tsc --noEmit` clean
