### PR TITLE
feat(api): cursor-based pagination for /api/tokens replacing offset pagination

### DIFF
--- a/backend/src/app/api/tokens/route.ts
+++ b/backend/src/app/api/tokens/route.ts
@@ -1,6 +1,57 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
+import { Database } from "@/config/database";
+import { CursorPagination } from "@/lib/pagination";
 
-export async function GET() {
-  // Placeholder: token-related API
-  return NextResponse.json({ message: "Tokens API" });
+export async function GET(request: NextRequest) {
+  try {
+    const searchParams = request.nextUrl.searchParams;
+
+    const cursor = searchParams.get("cursor") || undefined;
+    const rawLimit = searchParams.get("limit");
+    const rawOffset = searchParams.get("offset");
+
+    const limit = CursorPagination.validateLimit(
+      rawLimit !== null ? Number(rawLimit) : undefined
+    );
+
+    let offset: number | undefined;
+    if (!cursor && rawOffset !== null) {
+      const parsedOffset = Number(rawOffset);
+      if (Number.isNaN(parsedOffset) || parsedOffset < 0) {
+        return NextResponse.json(
+          { error: "Invalid offset parameter" },
+          { status: 400 }
+        );
+      }
+      offset = parsedOffset;
+    }
+
+    const tokens = await Database.getAllTokens();
+
+    const result = CursorPagination.paginateByCreatedAt(tokens, {
+      cursor,
+      limit,
+      offset,
+    });
+
+    return NextResponse.json({
+      tokens: result.items,
+      nextCursor: result.nextCursor ?? null,
+      hasMore: result.hasMore,
+      total: result.total,
+    });
+  } catch (error) {
+    if (error instanceof Error && error.message === "Invalid cursor format") {
+      return NextResponse.json(
+        { error: "Invalid cursor parameter" },
+        { status: 400 }
+      );
+    }
+
+    console.error("Tokens list error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
 }

--- a/backend/src/contracts/apiSchemas.ts
+++ b/backend/src/contracts/apiSchemas.ts
@@ -41,12 +41,20 @@ export interface TokenRecord {
 }
 
 export interface TokenPagination {
+  /** @deprecated offset-based page number — prefer `cursor`/`nextCursor` */
   page: number;
   limit: number;
   total: number;
+  /** @deprecated offset-based page count — prefer `hasMore` */
   totalPages: number;
+  /** @deprecated prefer `hasMore` */
   hasNext: boolean;
+  /** @deprecated offset-based pagination is deprecated */
   hasPrev: boolean;
+  /** Opaque keyset cursor for the next page; `null` when there are no more results. */
+  nextCursor: string | null;
+  /** Whether another page is available via `nextCursor`. */
+  hasMore: boolean;
 }
 
 export interface TokenFilters {
@@ -59,6 +67,8 @@ export interface TokenFilters {
   hasBurns?: string;
   sortBy: "created" | "burned" | "supply" | "name";
   sortOrder: "asc" | "desc";
+  /** Echoes back the `cursor` query param when one was supplied. */
+  cursor?: string;
 }
 
 export interface TokenSearchResponse {

--- a/backend/src/lib/openapi/spec.ts
+++ b/backend/src/lib/openapi/spec.ts
@@ -23,12 +23,14 @@ const schemas = {
   Pagination: {
     type: "object",
     properties: {
-      page: { type: "integer", example: 1 },
+      page: { type: "integer", example: 1, deprecated: true, description: "Offset-based page number. Deprecated — prefer `cursor`/`nextCursor`." },
       limit: { type: "integer", example: 20 },
       total: { type: "integer", example: 100 },
-      totalPages: { type: "integer", example: 5 },
-      hasNext: { type: "boolean" },
-      hasPrev: { type: "boolean" },
+      totalPages: { type: "integer", example: 5, deprecated: true },
+      hasNext: { type: "boolean", deprecated: true, description: "Deprecated — prefer `hasMore`." },
+      hasPrev: { type: "boolean", deprecated: true },
+      nextCursor: { type: "string", nullable: true, description: "Opaque cursor for the next page; null when there are no more results." },
+      hasMore: { type: "boolean", description: "Whether another page is available via `nextCursor`." },
     },
   },
 
@@ -292,7 +294,8 @@ const paths: OpenAPIObject["paths"] = {
         { name: "hasBurns", in: "query", schema: { type: "string", enum: ["true", "false"] } },
         { name: "sortBy", in: "query", schema: { type: "string", enum: ["created", "burned", "supply", "name"], default: "created" } },
         { name: "sortOrder", in: "query", schema: { type: "string", enum: ["asc", "desc"], default: "desc" } },
-        { name: "page", in: "query", schema: { type: "integer", default: 1 } },
+        { name: "cursor", in: "query", schema: { type: "string" }, description: "Opaque keyset cursor from a previous response's `pagination.nextCursor`. Only supported when sortBy=created; takes precedence over `page`." },
+        { name: "page", in: "query", schema: { type: "integer", default: 1 }, deprecated: true, description: "Offset-based page number. Deprecated in favor of `cursor` — inconsistent results may occur when new tokens are deployed between page fetches." },
         { name: "limit", in: "query", schema: { type: "integer", default: 20, maximum: 50 } },
       ],
       responses: {

--- a/backend/src/lib/pagination.ts
+++ b/backend/src/lib/pagination.ts
@@ -14,11 +14,31 @@ export interface PaginatedResult<T> {
   total?: number;
 }
 
+/**
+ * Composite keyset cursor position used for stable `createdAt`+`id` ordered
+ * pagination (so two rows with an identical `createdAt` never collide/skip).
+ */
+export interface CreatedAtCursor {
+  createdAt: string;
+  id: string;
+}
+
+export interface CreatedAtPaginationParams {
+  cursor?: string;
+  limit?: number;
+  offset?: number;
+}
+
 export class CursorPagination {
   private static readonly DEFAULT_LIMIT = 20;
   private static readonly MAX_LIMIT = 100;
 
-  static encodeCursor(value: string | number): string {
+  static encodeCursor(value: string | number): string;
+  static encodeCursor(value: CreatedAtCursor): string;
+  static encodeCursor(value: string | number | CreatedAtCursor): string {
+    if (typeof value === 'object' && value !== null) {
+      return Buffer.from(JSON.stringify(value)).toString('base64');
+    }
     return Buffer.from(String(value)).toString('base64');
   }
 
@@ -28,6 +48,33 @@ export class CursorPagination {
     } catch {
       throw new Error('Invalid cursor format');
     }
+  }
+
+  /**
+   * Decodes a composite `createdAt`+`id` keyset cursor produced by
+   * {@link encodeCursor} (object form). Throws on malformed input so callers
+   * can surface a 400 to the client instead of silently mis-paginating.
+   */
+  static decodeCreatedAtCursor(cursor: string): CreatedAtCursor {
+    const decoded = this.decodeCursor(cursor);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(decoded);
+    } catch {
+      throw new Error('Invalid cursor format');
+    }
+
+    if (
+      typeof parsed !== 'object' ||
+      parsed === null ||
+      typeof (parsed as CreatedAtCursor).createdAt !== 'string' ||
+      typeof (parsed as CreatedAtCursor).id !== 'string' ||
+      Number.isNaN(Date.parse((parsed as CreatedAtCursor).createdAt))
+    ) {
+      throw new Error('Invalid cursor format');
+    }
+
+    return parsed as CreatedAtCursor;
   }
 
   static validateLimit(limit?: number): number {
@@ -118,6 +165,67 @@ export class CursorPagination {
       nextCursor,
       prevCursor,
       hasMore,
+    };
+  }
+
+  /**
+   * Keyset-paginates `items` by a stable `(createdAt desc, id asc)` order
+   * using an opaque cursor that encodes the last-seen `(createdAt, id)`
+   * pair. Unlike {@link paginate} (which locates a row by `id` alone and can
+   * collide when several rows share the same `createdAt`), this compares the
+   * full tuple so ties are resolved deterministically.
+   *
+   * Falls back to plain offset-based slicing of the same sorted list when no
+   * `cursor` is supplied but an `offset` is (deprecated, kept for backward
+   * compatibility with existing offset-based clients).
+   */
+  static paginateByCreatedAt<T extends { id: string | number; createdAt: Date | string }>(
+    items: T[],
+    params: CreatedAtPaginationParams
+  ): PaginatedResult<T> {
+    const limit = this.validateLimit(params.limit);
+
+    const sorted = [...items].sort((a, b) => {
+      const timeDiff =
+        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+      if (timeDiff !== 0) return timeDiff;
+      return String(a.id) < String(b.id) ? -1 : String(a.id) > String(b.id) ? 1 : 0;
+    });
+
+    let startIndex = 0;
+
+    if (params.cursor) {
+      const { createdAt, id } = this.decodeCreatedAtCursor(params.cursor);
+      const cursorTime = new Date(createdAt).getTime();
+      // First index strictly "after" the cursor position in (createdAt desc, id asc) order.
+      startIndex = sorted.findIndex((item) => {
+        const itemTime = new Date(item.createdAt).getTime();
+        if (itemTime !== cursorTime) return itemTime < cursorTime;
+        return String(item.id) > id;
+      });
+      if (startIndex === -1) startIndex = sorted.length;
+    } else if (params.offset !== undefined && params.offset > 0) {
+      // Deprecated offset fallback.
+      startIndex = params.offset;
+    }
+
+    const endIndex = startIndex + limit;
+    const paginatedItems = sorted.slice(startIndex, endIndex);
+    const hasMore = endIndex < sorted.length;
+
+    const lastItem = paginatedItems[paginatedItems.length - 1];
+    const nextCursor = hasMore && lastItem
+      ? this.encodeCursor({
+          createdAt: new Date(lastItem.createdAt).toISOString(),
+          id: String(lastItem.id),
+        })
+      : undefined;
+
+    return {
+      items: paginatedItems,
+      nextCursor,
+      hasMore,
+      total: sorted.length,
     };
   }
 }

--- a/backend/src/routes/tokens.test.ts
+++ b/backend/src/routes/tokens.test.ts
@@ -84,6 +84,8 @@ describe("GET /api/tokens/search", () => {
       totalPages: 1,
       hasNext: false,
       hasPrev: false,
+      nextCursor: null,
+      hasMore: false,
     });
   });
 
@@ -95,9 +97,7 @@ describe("GET /api/tokens/search", () => {
 
     expect(prisma.token.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: expect.objectContaining({
-          creator: TENANT_ID,
-        }),
+        where: { AND: expect.arrayContaining([{ creator: TENANT_ID }]) },
       })
     );
   });
@@ -116,13 +116,17 @@ describe("GET /api/tokens/search", () => {
     expect(response.body.data[0].name).toBe("Test Token");
     expect(prisma.token.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: expect.objectContaining({
-          creator: TENANT_ID,
-          OR: [
-            { name: { contains: "test", mode: "insensitive" } },
-            { symbol: { contains: "test", mode: "insensitive" } },
-          ],
-        }),
+        where: {
+          AND: expect.arrayContaining([
+            { creator: TENANT_ID },
+            {
+              OR: [
+                { name: { contains: "test", mode: "insensitive" } },
+                { symbol: { contains: "test", mode: "insensitive" } },
+              ],
+            },
+          ]),
+        },
       })
     );
   });
@@ -141,13 +145,17 @@ describe("GET /api/tokens/search", () => {
     expect(response.body.success).toBe(true);
     expect(prisma.token.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: expect.objectContaining({
-          creator: TENANT_ID,
-          createdAt: {
-            gte: new Date("2024-01-01T00:00:00.000Z"),
-            lte: new Date("2024-01-31T23:59:59.999Z"),
-          },
-        }),
+        where: {
+          AND: expect.arrayContaining([
+            { creator: TENANT_ID },
+            {
+              createdAt: {
+                gte: new Date("2024-01-01T00:00:00.000Z"),
+                lte: new Date("2024-01-31T23:59:59.999Z"),
+              },
+            },
+          ]),
+        },
       })
     );
   });
@@ -164,13 +172,17 @@ describe("GET /api/tokens/search", () => {
     expect(response.body.success).toBe(true);
     expect(prisma.token.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: expect.objectContaining({
-          creator: TENANT_ID,
-          totalSupply: {
-            gte: BigInt(100000),
-            lte: BigInt(600000),
-          },
-        }),
+        where: {
+          AND: expect.arrayContaining([
+            { creator: TENANT_ID },
+            {
+              totalSupply: {
+                gte: BigInt(100000),
+                lte: BigInt(600000),
+              },
+            },
+          ]),
+        },
       })
     );
   });
@@ -187,10 +199,12 @@ describe("GET /api/tokens/search", () => {
     expect(response.body.success).toBe(true);
     expect(prisma.token.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: expect.objectContaining({
-          creator: TENANT_ID,
-          burnCount: { gt: 0 },
-        }),
+        where: {
+          AND: expect.arrayContaining([
+            { creator: TENANT_ID },
+            { burnCount: { gt: 0 } },
+          ]),
+        },
       })
     );
   });
@@ -207,15 +221,17 @@ describe("GET /api/tokens/search", () => {
     expect(response.body.success).toBe(true);
     expect(prisma.token.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: expect.objectContaining({
-          creator: TENANT_ID,
-          burnCount: 0,
-        }),
+        where: {
+          AND: expect.arrayContaining([
+            { creator: TENANT_ID },
+            { burnCount: 0 },
+          ]),
+        },
       })
     );
   });
 
-  it("should sort by created date descending (default)", async () => {
+  it("should sort by created date descending (default), with id as tie-breaker", async () => {
     vi.mocked(prisma.token.findMany).mockResolvedValue(mockTokens);
     vi.mocked(prisma.token.count).mockResolvedValue(2);
 
@@ -223,7 +239,7 @@ describe("GET /api/tokens/search", () => {
 
     expect(prisma.token.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        orderBy: { createdAt: "desc" },
+        orderBy: [{ createdAt: "desc" }, { id: "asc" }],
       })
     );
   });
@@ -238,7 +254,7 @@ describe("GET /api/tokens/search", () => {
 
     expect(prisma.token.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        orderBy: { totalBurned: "asc" },
+        orderBy: [{ totalBurned: "asc" }],
       })
     );
   });
@@ -253,7 +269,7 @@ describe("GET /api/tokens/search", () => {
 
     expect(prisma.token.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        orderBy: { totalSupply: "desc" },
+        orderBy: [{ totalSupply: "desc" }],
       })
     );
   });
@@ -268,12 +284,12 @@ describe("GET /api/tokens/search", () => {
 
     expect(prisma.token.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        orderBy: { name: "asc" },
+        orderBy: [{ name: "asc" }],
       })
     );
   });
 
-  it("should handle pagination correctly", async () => {
+  it("should handle pagination correctly (deprecated page/offset flow)", async () => {
     vi.mocked(prisma.token.findMany).mockResolvedValue([mockTokens[1]]);
     vi.mocked(prisma.token.count).mockResolvedValue(50);
 
@@ -288,11 +304,13 @@ describe("GET /api/tokens/search", () => {
       totalPages: 5,
       hasNext: true,
       hasPrev: true,
+      nextCursor: null,
+      hasMore: false,
     });
     expect(prisma.token.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
         skip: 10,
-        take: 10,
+        take: 11,
       })
     );
   });
@@ -305,9 +323,96 @@ describe("GET /api/tokens/search", () => {
 
     expect(prisma.token.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        take: 50,
+        take: 51,
       })
     );
+  });
+
+  it("should paginate by cursor on the created sort, returning a nextCursor when more results exist", async () => {
+    // Service returns limit+1 rows so the route can detect hasMore.
+    vi.mocked(prisma.token.findMany).mockResolvedValue([
+      mockTokens[0],
+      mockTokens[1],
+    ]);
+    vi.mocked(prisma.token.count).mockResolvedValue(5);
+
+    const response = await withTenant(
+      request(app).get("/api/tokens/search?limit=1")
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.data).toHaveLength(1);
+    expect(response.body.pagination.hasMore).toBe(true);
+    expect(typeof response.body.pagination.nextCursor).toBe("string");
+
+    const decoded = JSON.parse(
+      Buffer.from(response.body.pagination.nextCursor, "base64").toString(
+        "utf-8"
+      )
+    );
+    expect(decoded).toEqual({
+      createdAt: mockTokens[0].createdAt.toISOString(),
+      id: mockTokens[0].id,
+    });
+  });
+
+  it("should apply the keyset WHERE condition when a cursor is supplied", async () => {
+    vi.mocked(prisma.token.findMany).mockResolvedValue([mockTokens[1]]);
+    vi.mocked(prisma.token.count).mockResolvedValue(2);
+
+    const cursor = Buffer.from(
+      JSON.stringify({ createdAt: "2024-01-01T00:00:00.000Z", id: "1" })
+    ).toString("base64");
+
+    const response = await withTenant(
+      request(app).get(`/api/tokens/search?cursor=${cursor}`)
+    );
+
+    expect(response.status).toBe(200);
+    expect(prisma.token.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          AND: expect.arrayContaining([
+            { creator: TENANT_ID },
+            {
+              OR: [
+                { createdAt: { lt: new Date("2024-01-01T00:00:00.000Z") } },
+                {
+                  createdAt: new Date("2024-01-01T00:00:00.000Z"),
+                  id: { gt: "1" },
+                },
+              ],
+            },
+          ]),
+        },
+      })
+    );
+    // Cursor mode bypasses `skip` entirely.
+    expect(prisma.token.findMany).not.toHaveBeenCalledWith(
+      expect.objectContaining({ skip: expect.anything() })
+    );
+  });
+
+  it("should reject a cursor combined with a non-created sortBy", async () => {
+    const cursor = Buffer.from(
+      JSON.stringify({ createdAt: "2024-01-01T00:00:00.000Z", id: "1" })
+    ).toString("base64");
+
+    const response = await withTenant(
+      request(app).get(`/api/tokens/search?cursor=${cursor}&sortBy=name`)
+    );
+
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+  });
+
+  it("should reject a malformed cursor", async () => {
+    const response = await withTenant(
+      request(app).get("/api/tokens/search?cursor=not-valid-base64-json")
+    );
+
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
   });
 
   it("should convert BigInt to string in response", async () => {
@@ -364,14 +469,14 @@ describe("GET /api/tokens/search", () => {
     expect(response.body.success).toBe(true);
     expect(prisma.token.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: expect.objectContaining({
-          creator: TENANT_ID,
-          OR: expect.any(Array),
-          burnCount: { gt: 0 },
-          totalSupply: expect.objectContaining({
-            gte: BigInt(100000),
-          }),
-        }),
+        where: {
+          AND: expect.arrayContaining([
+            { creator: TENANT_ID },
+            { OR: expect.any(Array) },
+            { burnCount: { gt: 0 } },
+            { totalSupply: expect.objectContaining({ gte: BigInt(100000) }) },
+          ]),
+        },
       })
     );
   });
@@ -408,6 +513,7 @@ describe("GET /api/tokens/search", () => {
       hasBurns: undefined,
       sortBy: "burned",
       sortOrder: "desc",
+      cursor: undefined,
     });
   });
 

--- a/backend/src/routes/tokens.ts
+++ b/backend/src/routes/tokens.ts
@@ -13,6 +13,7 @@ import {
   batchDeployTokens,
   type TokenDeployInput,
 } from "../services/batchTokenDeployService";
+import { CursorPagination } from "../lib/pagination";
 
 const router = Router();
 
@@ -30,6 +31,9 @@ const searchParamsSchema = z.object({
   hasBurns: z.enum(["true", "false"]).optional(),
   sortBy: z.enum(["created", "burned", "supply", "name"]).default("created"),
   sortOrder: z.enum(["asc", "desc"]).default("desc"),
+  // Keyset cursor (preferred) — see CursorPagination.decodeCreatedAtCursor.
+  cursor: z.string().optional(),
+  // Offset-based page number — deprecated, kept for backward compatibility.
   page: z.string().regex(/^\d+$/).default("1"),
   limit: z.string().regex(/^\d+$/).default("20"),
 });
@@ -97,81 +101,120 @@ router.get("/search", async (req: TenantRequest & Request, res: Response) => {
       });
     }
 
+    // Cursor pagination is only well-defined against the `createdAt`+`id`
+    // keyset this endpoint sorts other fields independently of — reject the
+    // combination explicitly rather than silently falling back to offset.
+    if (params.cursor && params.sortBy !== "created") {
+      return res.status(400).json({
+        success: false,
+        error: "cursor pagination is only supported with sortBy=created",
+      });
+    }
+
     // Parse pagination
     const page = parseInt(params.page);
     const limit = Math.min(parseInt(params.limit), 50); // Max 50 per page
     const skip = (page - 1) * limit;
 
-    // Build where clause — always scoped to the requesting tenant.
+    // Base filters — always scoped to the requesting tenant.
     // The explicit `creator` query param is intentionally ignored: tenants may
     // only query their own tokens, so the scope is always `creator = tenantId`.
-    const where: Prisma.TokenWhereInput = {
-      creator: tenantId,
-    };
+    const baseConditions: Prisma.TokenWhereInput[] = [{ creator: tenantId }];
 
     // Full-text search by name or symbol
     if (params.q) {
-      where.OR = [
-        { name: { contains: params.q, mode: "insensitive" } },
-        { symbol: { contains: params.q, mode: "insensitive" } },
-      ];
+      baseConditions.push({
+        OR: [
+          { name: { contains: params.q, mode: "insensitive" } },
+          { symbol: { contains: params.q, mode: "insensitive" } },
+        ],
+      });
     }
 
     // Filter by creation date range
     if (params.startDate || params.endDate) {
-      where.createdAt = {};
-      if (params.startDate) {
-        where.createdAt.gte = new Date(params.startDate);
-      }
-      if (params.endDate) {
-        where.createdAt.lte = new Date(params.endDate);
-      }
+      const createdAt: Prisma.DateTimeFilter = {};
+      if (params.startDate) createdAt.gte = new Date(params.startDate);
+      if (params.endDate) createdAt.lte = new Date(params.endDate);
+      baseConditions.push({ createdAt });
     }
 
     // Filter by supply range
     if (params.minSupply || params.maxSupply) {
-      where.totalSupply = {};
-      if (params.minSupply) {
-        where.totalSupply.gte = BigInt(params.minSupply);
-      }
-      if (params.maxSupply) {
-        where.totalSupply.lte = BigInt(params.maxSupply);
-      }
+      const totalSupply: Prisma.BigIntFilter = {};
+      if (params.minSupply) totalSupply.gte = BigInt(params.minSupply);
+      if (params.maxSupply) totalSupply.lte = BigInt(params.maxSupply);
+      baseConditions.push({ totalSupply });
     }
 
     // Filter by burn status
     if (params.hasBurns === "true") {
-      where.burnCount = { gt: 0 };
+      baseConditions.push({ burnCount: { gt: 0 } });
     } else if (params.hasBurns === "false") {
-      where.burnCount = 0;
+      baseConditions.push({ burnCount: 0 });
     }
 
-    // Build orderBy clause
-    let orderBy: Prisma.TokenOrderByWithRelationInput = {};
+    // Keyset cursor condition — `(createdAt, id) > (cursor.createdAt, cursor.id)`
+    // (or `<` for descending order), comparing the full tuple so rows with an
+    // identical `createdAt` never collide or get skipped/duplicated across
+    // pages the way plain offset pagination can when rows are inserted
+    // between fetches.
+    const andConditions = [...baseConditions];
+    let decodedCursor: { createdAt: string; id: string } | undefined;
 
-    switch (params.sortBy) {
-      case "created":
-        orderBy = { createdAt: params.sortOrder };
-        break;
-      case "burned":
-        orderBy = { totalBurned: params.sortOrder };
-        break;
-      case "supply":
-        orderBy = { totalSupply: params.sortOrder };
-        break;
-      case "name":
-        orderBy = { name: params.sortOrder };
-        break;
+    if (params.cursor) {
+      try {
+        decodedCursor = CursorPagination.decodeCreatedAtCursor(params.cursor);
+      } catch {
+        return res.status(400).json({
+          success: false,
+          error: "Invalid cursor parameter",
+        });
+      }
+
+      const cursorTime = new Date(decodedCursor.createdAt);
+      andConditions.push(
+        params.sortOrder === "asc"
+          ? {
+              OR: [
+                { createdAt: { gt: cursorTime } },
+                { createdAt: cursorTime, id: { gt: decodedCursor.id } },
+              ],
+            }
+          : {
+              OR: [
+                { createdAt: { lt: cursorTime } },
+                { createdAt: cursorTime, id: { gt: decodedCursor.id } },
+              ],
+            }
+      );
     }
 
-    // Execute queries in parallel
+    const where: Prisma.TokenWhereInput = { AND: andConditions };
+    // `total`/`totalPages` describe all matching rows regardless of cursor
+    // position, so the count query excludes the cursor condition.
+    const countWhere: Prisma.TokenWhereInput = { AND: baseConditions };
+
+    // Build orderBy clause. `created` always includes `id` as a tie-breaker
+    // so the keyset cursor above has a stable, total order to walk.
+    const orderBy: Prisma.TokenOrderByWithRelationInput[] =
+      params.sortBy === "created"
+        ? [{ createdAt: params.sortOrder }, { id: "asc" }]
+        : params.sortBy === "burned"
+        ? [{ totalBurned: params.sortOrder }]
+        : params.sortBy === "supply"
+        ? [{ totalSupply: params.sortOrder }]
+        : [{ name: params.sortOrder }];
+
+    // Fetch one extra row beyond `limit` so `hasMore`/`nextCursor` can be
+    // computed without a second count-from-cursor query.
     const start = performance.now();
-    const [tokens, total] = await Promise.all([
+    const [rawTokens, total] = await Promise.all([
       prisma.token.findMany({
         where,
         orderBy,
-        skip,
-        take: limit,
+        ...(params.cursor ? {} : { skip }),
+        take: limit + 1,
         select: {
           id: true,
           address: true,
@@ -188,13 +231,26 @@ router.get("/search", async (req: TenantRequest & Request, res: Response) => {
           updatedAt: true,
         },
       }),
-      prisma.token.count({ where }),
+      prisma.token.count({ where: countWhere }),
     ]);
     const duration = performance.now() - start;
     if (duration > 150) {
       console.warn(`[PERF] Token search took ${duration.toFixed(2)}ms`);
     }
 
+    const hasMore = rawTokens.length > limit;
+    const tokens = hasMore ? rawTokens.slice(0, limit) : rawTokens;
+    const lastToken = tokens[tokens.length - 1];
+
+    // Keyset cursor navigation is only offered for the `created` sort —
+    // other sort modes keep the deprecated page/offset flow exclusively.
+    const nextCursor =
+      params.sortBy === "created" && hasMore && lastToken
+        ? CursorPagination.encodeCursor({
+            createdAt: lastToken.createdAt.toISOString(),
+            id: String(lastToken.id),
+          })
+        : null;
 
     // Convert BigInt to string for JSON serialization
     const serializedTokens = tokens.map((token) => ({
@@ -216,6 +272,8 @@ router.get("/search", async (req: TenantRequest & Request, res: Response) => {
         totalPages,
         hasNext: page < totalPages,
         hasPrev: page > 1,
+        nextCursor,
+        hasMore,
       },
       filters: {
         q: params.q,
@@ -227,6 +285,7 @@ router.get("/search", async (req: TenantRequest & Request, res: Response) => {
         hasBurns: params.hasBurns,
         sortBy: params.sortBy,
         sortOrder: params.sortOrder,
+        cursor: params.cursor,
       },
     };
 


### PR DESCRIPTION
## Summary

The issue's referenced file (`backend/src/app/api/tokens/route.ts`) is a Next.js App-Router stub — this backend is actually an Express app (`npm run dev`/`start` → `tsx watch src/index.ts` / `node dist/index.js`), and there is no `next dev`/`build`/`start` script anywhere, so that file is never served. The real, live token-listing endpoint clients hit is `GET /api/tokens/search` in `backend/src/routes/tokens.ts` (mounted via `v1Router.use("/tokens", ...)` in `index.ts`), which used Prisma `skip`/`take` (page-based) pagination. This PR implements true keyset pagination on **that** live endpoint, and additionally fills in the literal stub the issue named so it isn't left inert.

- `backend/src/routes/tokens.ts` (the live endpoint): adds a `cursor` query param. When supplied (only valid with the default `sortBy=created`), builds a Prisma `WHERE (createdAt, id) > (cursor.createdAt, cursor.id)` tuple comparison (mirrored for `desc`/`asc`) instead of `skip`. `orderBy` for the `created` sort now includes `id` as a tie-breaker so the keyset has a stable total order. Fetches `limit + 1` rows to derive `hasMore`/`nextCursor` without an extra query. `page`/`offset` keep working unchanged (deprecated) when no `cursor` is given or when sorting by a field other than `created`.
- `backend/src/lib/pagination.ts`: adds `CreatedAtCursor`, `encodeCursor`/`decodeCreatedAtCursor` (base64 JSON of `{createdAt, id}`), and an in-memory `paginateByCreatedAt` keyset helper for non-Prisma callers.
- `backend/src/contracts/apiSchemas.ts`: `TokenPagination` gains `nextCursor`/`hasMore`; `page`/`totalPages`/`hasNext`/`hasPrev` marked `@deprecated`. `TokenFilters` echoes back `cursor`.
- `backend/src/lib/openapi/spec.ts`: documents the new `cursor` param and `nextCursor`/`hasMore` response fields; marks `page` and the offset-derived pagination fields `deprecated: true`.
- `backend/src/app/api/tokens/route.ts`: implemented the literal stub the issue named, using the in-memory `paginateByCreatedAt` helper against `Database.getAllTokens()` (kept for completeness/forward-compat since it isn't currently wired into a running server).
- Updated `backend/src/routes/tokens.test.ts` for the new `where: { AND: [...] }` shape and added cursor-specific cases (returns `nextCursor` when more results exist, applies the keyset `WHERE` when a cursor is supplied and skips `skip` entirely, rejects a cursor combined with non-`created` sort, rejects a malformed cursor).

## Test plan
- [ ] Tests were not re-run for this change per explicit instruction from the requester partway through this session ("skip all test and just finish the given task") — please run `npx vitest run src/routes/tokens.test.ts` and `npx vitest run src/lib/pagination.test.ts` before merging.
- [x] `npx tsc --noEmit` showed no new type errors from these changes (two pre-existing, unrelated errors elsewhere on `main` — a merge-conflict in `pinata.ts` and an orphaned fragment in `stellar.exceptions.ts` — are out of scope here)

Closes #1334