### PR TITLE
feat(webhook): dead-letter queue inspection, retry, and discard API

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -1347,6 +1347,198 @@
           }
         }
       }
+    },
+    "/api/webhooks/dead-letter": {
+      "get": {
+        "tags": [
+          "Webhooks"
+        ],
+        "summary": "List webhook dead-letter entries (admin only)",
+        "description": "Paginated list of failed webhook deliveries that exhausted all retries, across all subscriptions. Supports filtering by tenant (the subscription owner's `createdBy` address — the closest existing field to a tenant identifier in this codebase) and by failure reason (substring match on the last error message).",
+        "security": [{ "BearerAuth": [] }],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PageParam"
+          },
+          {
+            "$ref": "#/components/parameters/LimitParam"
+          },
+          {
+            "name": "tenant",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter by subscription owner (created_by) address"
+          },
+          {
+            "name": "failureReason",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Substring match against the last recorded error message"
+          },
+          {
+            "name": "resolved",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": ["true", "false"]
+            },
+            "description": "Filter by resolution status"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated dead-letter entries",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "entries": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/DeadLetterEntry"
+                          }
+                        },
+                        "pagination": {
+                          "$ref": "#/components/schemas/Pagination"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid query parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Admin access required"
+          }
+        }
+      }
+    },
+    "/api/webhooks/dead-letter/{id}/retry": {
+      "post": {
+        "tags": [
+          "Webhooks"
+        ],
+        "summary": "Retry a dead-lettered delivery (admin only)",
+        "description": "Re-enqueues the original payload for delivery with a fresh attempt counter (does not resume the exhausted counter that originally routed the entry to the dead-letter queue). Writes an audit log entry.",
+        "security": [{ "BearerAuth": [] }],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Entry re-enqueued for delivery"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Admin access required"
+          },
+          "404": {
+            "description": "Dead-letter entry or associated subscription not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Entry already resolved",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/webhooks/dead-letter/{id}": {
+      "delete": {
+        "tags": [
+          "Webhooks"
+        ],
+        "summary": "Discard a dead-lettered delivery (admin only)",
+        "description": "Marks the dead-letter entry as archived without retrying delivery. Writes an audit log entry.",
+        "security": [{ "BearerAuth": [] }],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Entry discarded"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "Admin access required"
+          },
+          "404": {
+            "description": "Dead-letter entry not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Entry already resolved",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -1797,6 +1989,73 @@
             "format": "date-time"
           }
         }
+      },
+      "DeadLetterEntry": {
+        "type": "object",
+        "description": "A webhook delivery that exhausted all retry attempts and was routed to the dead-letter store.",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "subscriptionId": {
+            "type": "string"
+          },
+          "event": {
+            "type": "string",
+            "enum": [
+              "token.burn.self",
+              "token.burn.admin",
+              "token.created",
+              "token.metadata.updated"
+            ]
+          },
+          "payload": {
+            "type": "string",
+            "description": "JSON-stringified original webhook payload"
+          },
+          "statusCode": {
+            "type": "integer",
+            "nullable": true
+          },
+          "lastError": {
+            "type": "string",
+            "nullable": true
+          },
+          "attemptCount": {
+            "type": "integer",
+            "description": "Attempts made before exhaustion (pre-retry)"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "resolvedAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "resolution": {
+            "type": "string",
+            "enum": [
+              "retried",
+              "skipped",
+              "archived"
+            ],
+            "nullable": true
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "BearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT",
+        "description": "Admin JWT issued for users with role 'admin' or 'super_admin'."
       }
     },
     "parameters": {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -19,6 +19,7 @@ import vaultRoutes from "./routes/vaults";
 import versionRoutes from "./routes/version";
 import searchRoutes from "./routes/search";
 import exportRoutes from "./routes/export";
+import webhooksDeadLetterRoutes from "./routes/webhooks-deadletter";
 import graphqlRouter, { attachGraphqlSubscriptions } from "./graphql";
 import openApiRouter from "./lib/openapi/router";
 import { Database } from "./config/database";
@@ -102,6 +103,9 @@ v1Router.use("/vaults", limiter, vaultRoutes);
 v1Router.use("/version", versionRoutes);
 v1Router.use("/search", searchRoutes);
 v1Router.use("/export", exportRoutes);
+// Admin-only dead-letter inspection/retry/discard API — mounted before any
+// broader /webhooks router so its more specific path takes precedence.
+v1Router.use("/webhooks/dead-letter", webhooksDeadLetterRoutes);
 v1Router.use("/graphql", graphqlRouter);
 v1Router.use("/docs", openApiRouter);
 

--- a/backend/src/lib/openapi/spec.ts
+++ b/backend/src/lib/openapi/spec.ts
@@ -162,6 +162,28 @@ const schemas = {
       timestamp: { type: "string", format: "date-time" },
     },
   },
+
+  DeadLetterEntry: {
+    type: "object",
+    description:
+      "A webhook delivery that exhausted all retry attempts and was routed to the dead-letter store.",
+    properties: {
+      id: { type: "string" },
+      subscriptionId: { type: "string" },
+      event: {
+        type: "string",
+        enum: ["token.burn.self", "token.burn.admin", "token.created", "token.metadata.updated"],
+      },
+      payload: { type: "string", description: "JSON-stringified original webhook payload" },
+      statusCode: { type: "integer", nullable: true },
+      lastError: { type: "string", nullable: true },
+      attemptCount: { type: "integer", description: "Attempts made before exhaustion (pre-retry)" },
+      createdAt: { type: "string", format: "date-time" },
+      updatedAt: { type: "string", format: "date-time" },
+      resolvedAt: { type: "string", format: "date-time", nullable: true },
+      resolution: { type: "string", enum: ["retried", "skipped", "archived"], nullable: true },
+    },
+  },
 } as const;
 
 // ---------------------------------------------------------------------------
@@ -683,6 +705,85 @@ const paths: OpenAPIObject["paths"] = {
       responses: { "200": { description: "Test result" } },
     },
   },
+
+  // Webhook dead-letter queue (admin-only)
+  "/api/webhooks/dead-letter": {
+    get: {
+      tags: ["Webhooks"],
+      summary: "List webhook dead-letter entries (admin only)",
+      description:
+        "Paginated list of failed webhook deliveries that exhausted all retries, across all subscriptions. " +
+        "Supports filtering by tenant (the subscription owner's `createdBy` address — the closest existing field " +
+        "to a tenant identifier in this codebase) and by failure reason (substring match on the last error message).",
+      security: [{ BearerAuth: [] }],
+      parameters: [
+        { $ref: "#/components/parameters/PageParam" },
+        { $ref: "#/components/parameters/LimitParam" },
+        { name: "tenant", in: "query", schema: { type: "string" }, description: "Filter by subscription owner (created_by) address" },
+        { name: "failureReason", in: "query", schema: { type: "string" }, description: "Substring match against the last recorded error message" },
+        { name: "resolved", in: "query", schema: { type: "string", enum: ["true", "false"] }, description: "Filter by resolution status" },
+      ],
+      responses: {
+        "200": {
+          description: "Paginated dead-letter entries",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  success: { type: "boolean" },
+                  data: {
+                    type: "object",
+                    properties: {
+                      entries: { type: "array", items: { $ref: "#/components/schemas/DeadLetterEntry" } },
+                      pagination: { $ref: "#/components/schemas/Pagination" },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        "400": { description: "Invalid query parameters", content: { "application/json": { schema: { $ref: "#/components/schemas/ErrorResponse" } } } },
+        "401": { description: "Authentication required" },
+        "403": { description: "Admin access required" },
+      },
+    },
+  },
+  "/api/webhooks/dead-letter/{id}/retry": {
+    post: {
+      tags: ["Webhooks"],
+      summary: "Retry a dead-lettered delivery (admin only)",
+      description:
+        "Re-enqueues the original payload for delivery with a fresh attempt counter (does not resume the " +
+        "exhausted counter that originally routed the entry to the dead-letter queue). Writes an audit log entry.",
+      security: [{ BearerAuth: [] }],
+      parameters: [{ name: "id", in: "path", required: true, schema: { type: "string" } }],
+      responses: {
+        "200": { description: "Entry re-enqueued for delivery" },
+        "401": { description: "Authentication required" },
+        "403": { description: "Admin access required" },
+        "404": { description: "Dead-letter entry or associated subscription not found", content: { "application/json": { schema: { $ref: "#/components/schemas/ErrorResponse" } } } },
+        "409": { description: "Entry already resolved", content: { "application/json": { schema: { $ref: "#/components/schemas/ErrorResponse" } } } },
+      },
+    },
+  },
+  "/api/webhooks/dead-letter/{id}": {
+    delete: {
+      tags: ["Webhooks"],
+      summary: "Discard a dead-lettered delivery (admin only)",
+      description: "Marks the dead-letter entry as archived without retrying delivery. Writes an audit log entry.",
+      security: [{ BearerAuth: [] }],
+      parameters: [{ name: "id", in: "path", required: true, schema: { type: "string" } }],
+      responses: {
+        "200": { description: "Entry discarded" },
+        "401": { description: "Authentication required" },
+        "403": { description: "Admin access required" },
+        "404": { description: "Dead-letter entry not found", content: { "application/json": { schema: { $ref: "#/components/schemas/ErrorResponse" } } } },
+        "409": { description: "Entry already resolved", content: { "application/json": { schema: { $ref: "#/components/schemas/ErrorResponse" } } } },
+      },
+    },
+  },
 };
 
 // ---------------------------------------------------------------------------
@@ -718,6 +819,14 @@ export const openApiSpec: OpenAPIObject = {
   components: {
     schemas: schemas as unknown as OpenAPIObject["components"]["schemas"],
     parameters: parameters as unknown as OpenAPIObject["components"]["parameters"],
+    securitySchemes: {
+      BearerAuth: {
+        type: "http",
+        scheme: "bearer",
+        bearerFormat: "JWT",
+        description: "Admin JWT issued for users with role 'admin' or 'super_admin'.",
+      },
+    },
   },
 };
 

--- a/backend/src/routes/webhooks-deadletter.ts
+++ b/backend/src/routes/webhooks-deadletter.ts
@@ -1,0 +1,219 @@
+import { Router, Response } from "express";
+import { z } from "zod";
+import webhookDeadLetterService from "../services/webhookDeadLetterService";
+import webhookService from "../services/webhookService";
+import webhookDeliveryService from "../services/webhookDeliveryService";
+import { authenticateAdmin, AuthRequest } from "../middleware/auth";
+import { auditLog } from "../middleware/auditLog";
+import { successResponse, errorResponse } from "../utils/response";
+
+/**
+ * Admin-only API for inspecting, retrying, and discarding webhook
+ * dead-letter entries (failed deliveries that exhausted all retries).
+ *
+ * All endpoints in this router require admin authentication — see
+ * `authenticateAdmin` in `../middleware/auth`.
+ *
+ * Tenant filtering: there is no dedicated "tenant" column on webhook
+ * subscriptions or dead-letter rows in this codebase. The closest existing
+ * field is `webhook_subscriptions.created_by` (the Stellar address that
+ * created the subscription). `GET /` filters by tenant via that field —
+ * see `DeadLetterListFilters` in `webhookDeadLetterService.ts` for the
+ * underlying query and rationale.
+ */
+
+const router = Router();
+
+const listQuerySchema = z.object({
+  page: z.coerce.number().int().min(1).optional().default(1),
+  limit: z.coerce.number().int().min(1).max(100).optional().default(10),
+  tenant: z.string().optional(),
+  failureReason: z.string().optional(),
+  resolved: z
+    .enum(["true", "false"])
+    .optional()
+    .transform((v) => (v === undefined ? undefined : v === "true")),
+});
+
+/**
+ * GET /api/webhooks/dead-letter
+ * List dead-letter entries across all subscriptions, paginated and
+ * optionally filtered by tenant (subscription owner) and failure reason.
+ */
+router.get(
+  "/",
+  authenticateAdmin,
+  auditLog("list_dead_letters", "webhook_dead_letter"),
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const parsed = listQuerySchema.safeParse(req.query);
+      if (!parsed.success) {
+        return res.status(400).json(
+          errorResponse({
+            code: "VALIDATION_ERROR",
+            message: "Invalid query parameters",
+            details: parsed.error.errors,
+          })
+        );
+      }
+
+      const { page, limit, tenant, failureReason, resolved } = parsed.data;
+
+      const { entries, total } = await webhookDeadLetterService.listAllPaginated(
+        page,
+        limit,
+        { tenant, failureReason, resolved }
+      );
+
+      res.json(
+        successResponse({
+          entries,
+          pagination: {
+            page,
+            limit,
+            total,
+          },
+        })
+      );
+    } catch (error) {
+      console.error("Error listing dead-letter entries:", error);
+      res.status(500).json(
+        errorResponse({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Failed to list dead-letter entries",
+        })
+      );
+    }
+  }
+);
+
+/**
+ * POST /api/webhooks/dead-letter/:id/retry
+ * Re-enqueue the original payload for delivery with a FRESH attempt
+ * counter (the underlying delivery service always starts a new call at
+ * attempt 1, so this never resumes the previously exhausted counter).
+ */
+router.post(
+  "/:id/retry",
+  authenticateAdmin,
+  auditLog("retry_dead_letter", "webhook_dead_letter"),
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const { id } = req.params;
+      const deadLetter = await webhookDeadLetterService.getEntry(id);
+
+      if (!deadLetter) {
+        return res.status(404).json(
+          errorResponse({
+            code: "NOT_FOUND",
+            message: "Dead-letter entry not found",
+          })
+        );
+      }
+
+      if (deadLetter.resolvedAt) {
+        return res.status(409).json(
+          errorResponse({
+            code: "ALREADY_RESOLVED",
+            message: `Dead-letter entry was already resolved (${deadLetter.resolution})`,
+          })
+        );
+      }
+
+      const subscription = await webhookService.getSubscription(
+        deadLetter.subscriptionId
+      );
+      if (!subscription) {
+        return res.status(404).json(
+          errorResponse({
+            code: "SUBSCRIPTION_NOT_FOUND",
+            message: "Associated webhook subscription no longer exists",
+          })
+        );
+      }
+
+      const payload = JSON.parse(deadLetter.payload);
+
+      // Re-deliver via the standard delivery path. Each call to
+      // deliverWebhook starts its own retry loop at attempt 1, so this is
+      // always a fresh attempt counter — never a resumption of the
+      // exhausted one that landed the entry in the dead-letter queue.
+      await webhookDeliveryService.deliverWebhook(
+        subscription,
+        deadLetter.event,
+        payload.data || payload,
+        `admin_retry_${id}`
+      );
+
+      await webhookDeadLetterService.markResolved(id, "retried");
+
+      res.json(
+        successResponse({
+          message: "Dead-letter entry re-enqueued for delivery",
+          id,
+        })
+      );
+    } catch (error) {
+      console.error("Error retrying dead-letter entry:", error);
+      res.status(500).json(
+        errorResponse({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Failed to retry dead-letter entry",
+        })
+      );
+    }
+  }
+);
+
+/**
+ * DELETE /api/webhooks/dead-letter/:id
+ * Discard a dead-letter entry without retrying delivery.
+ */
+router.delete(
+  "/:id",
+  authenticateAdmin,
+  auditLog("discard_dead_letter", "webhook_dead_letter"),
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const { id } = req.params;
+      const deadLetter = await webhookDeadLetterService.getEntry(id);
+
+      if (!deadLetter) {
+        return res.status(404).json(
+          errorResponse({
+            code: "NOT_FOUND",
+            message: "Dead-letter entry not found",
+          })
+        );
+      }
+
+      if (deadLetter.resolvedAt) {
+        return res.status(409).json(
+          errorResponse({
+            code: "ALREADY_RESOLVED",
+            message: `Dead-letter entry was already resolved (${deadLetter.resolution})`,
+          })
+        );
+      }
+
+      await webhookDeadLetterService.markResolved(id, "archived");
+
+      res.json(
+        successResponse({
+          message: "Dead-letter entry discarded",
+          id,
+        })
+      );
+    } catch (error) {
+      console.error("Error discarding dead-letter entry:", error);
+      res.status(500).json(
+        errorResponse({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Failed to discard dead-letter entry",
+        })
+      );
+    }
+  }
+);
+
+export default router;

--- a/backend/src/services/webhookDeadLetterService.ts
+++ b/backend/src/services/webhookDeadLetterService.ts
@@ -16,6 +16,27 @@ export interface DeadLetterEntry {
   resolution: string | null;
 }
 
+/**
+ * Filters supported when listing dead-letter entries across all subscriptions.
+ *
+ * Tenant note: this codebase has no dedicated "tenant" column anywhere in the
+ * webhook tables. The closest analog is `webhook_subscriptions.created_by`
+ * (the Stellar address that owns the subscription) — every dead-letter entry
+ * is joined back to its subscription so admins can filter "by tenant" using
+ * that `createdBy` address. If a real multi-tenant column is introduced later,
+ * update `listAllPaginated` to filter on it directly instead of joining.
+ */
+export interface DeadLetterListFilters {
+  tenant?: string; // matches webhook_subscriptions.created_by
+  failureReason?: string; // matches webhook_dead_letters.last_error (substring, case-insensitive)
+  resolved?: boolean; // when omitted, returns both resolved and unresolved entries
+}
+
+export interface DeadLetterListResult {
+  entries: DeadLetterEntry[];
+  total: number;
+}
+
 export class WebhookDeadLetterService {
   /**
    * Store a failed delivery in the dead-letter queue
@@ -65,6 +86,67 @@ export class WebhookDeadLetterService {
 
     const result = await db.query(query, [subscriptionId, limit]);
     return result.rows.map(this.mapRowToEntry);
+  }
+
+  /**
+   * List dead-letter entries across ALL subscriptions, with pagination and
+   * optional filtering by tenant (subscription owner) and failure reason.
+   *
+   * Joins to `webhook_subscriptions` so callers can filter by `created_by`
+   * (the closest existing field to a "tenant" identifier — see
+   * `DeadLetterListFilters` for rationale).
+   */
+  async listAllPaginated(
+    page: number,
+    limit: number,
+    filters: DeadLetterListFilters = {}
+  ): Promise<DeadLetterListResult> {
+    const conditions: string[] = [];
+    const params: any[] = [];
+
+    if (filters.tenant) {
+      params.push(filters.tenant);
+      conditions.push(`s.created_by = $${params.length}`);
+    }
+
+    if (filters.failureReason) {
+      params.push(`%${filters.failureReason}%`);
+      conditions.push(`d.last_error ILIKE $${params.length}`);
+    }
+
+    if (filters.resolved === true) {
+      conditions.push(`d.resolved_at IS NOT NULL`);
+    } else if (filters.resolved === false) {
+      conditions.push(`d.resolved_at IS NULL`);
+    }
+
+    const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+
+    const countQuery = `
+      SELECT COUNT(*) AS total
+      FROM webhook_dead_letters d
+      JOIN webhook_subscriptions s ON s.id = d.subscription_id
+      ${whereClause}
+    `;
+    const countResult = await db.query(countQuery, params);
+    const total = parseInt(countResult.rows[0]?.total ?? "0", 10);
+
+    const offset = (page - 1) * limit;
+    const listParams = [...params, limit, offset];
+    const listQuery = `
+      SELECT d.*
+      FROM webhook_dead_letters d
+      JOIN webhook_subscriptions s ON s.id = d.subscription_id
+      ${whereClause}
+      ORDER BY d.created_at DESC
+      LIMIT $${listParams.length - 1} OFFSET $${listParams.length}
+    `;
+    const listResult = await db.query(listQuery, listParams);
+
+    return {
+      entries: listResult.rows.map(this.mapRowToEntry),
+      total,
+    };
   }
 
   /**


### PR DESCRIPTION
Closes #1337

## Summary
- Adds `backend/src/routes/webhooks-deadletter.ts` with three admin-only endpoints, all gated by `authenticateAdmin` and audit-logged via `auditLog`:
  - `GET /api/webhooks/dead-letter` — paginated list, filterable by `tenant` (subscription owner's `createdBy` address — the closest existing tenant identifier in this codebase), `failureReason` (substring match on last error), and `resolved`.
  - `POST /api/webhooks/dead-letter/:id/retry` — re-enqueues the original payload through the normal `webhookDeliveryService.deliverWebhook` path, which always starts a fresh attempt counter; marks the entry resolved (`retried`) on success.
  - `DELETE /api/webhooks/dead-letter/:id` — marks the entry resolved (`archived`) without retrying.
- `webhookDeadLetterService.ts`: new `listAllPaginated()` with tenant/failure-reason/resolved filtering (joins `webhook_subscriptions` for the tenant filter).
- `openapi.json` / `lib/openapi/spec.ts`: documents all three endpoints and the `DeadLetterEntry` schema.
- Mounted in `index.ts` ahead of any broader `/webhooks` router so the more specific path takes precedence.

## Test plan
- [x] `tsc --noEmit` clean for touched files
- [x] Manual verification with mocked DB/auth: `GET /` returns paginated entries with correct shape; `DELETE /:id` 404s on an unknown id
- [x] Reviewed retry path re-derives the subscription and starts delivery at a fresh attempt counter (never resumes the exhausted one)

🤖 Generated with [Claude Code](https://claude.com/claude-code)