### PR TITLE
feat(integration): gas dashboard with Horizon real-time fee estimation and historical trend charts

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -19,6 +19,7 @@ import vaultRoutes from "./routes/vaults";
 import versionRoutes from "./routes/version";
 import searchRoutes from "./routes/search";
 import exportRoutes from "./routes/export";
+import stellarRoutes from "./routes/stellar";
 import graphqlRouter, { attachGraphqlSubscriptions } from "./graphql";
 import openApiRouter from "./lib/openapi/router";
 import { Database } from "./config/database";
@@ -102,6 +103,7 @@ v1Router.use("/vaults", limiter, vaultRoutes);
 v1Router.use("/version", versionRoutes);
 v1Router.use("/search", searchRoutes);
 v1Router.use("/export", exportRoutes);
+v1Router.use("/stellar", limiter, stellarRoutes);
 v1Router.use("/graphql", graphqlRouter);
 v1Router.use("/docs", openApiRouter);
 

--- a/backend/src/routes/__tests__/stellar.test.ts
+++ b/backend/src/routes/__tests__/stellar.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Integration tests for GET /api/stellar/fee-stats
+ *
+ * Covers:
+ *  - Happy path: proxies and normalizes Horizon's /fee_stats response
+ *  - Caching: a second request within the cache window does not re-hit Horizon
+ *  - Upstream failure: Horizon error surfaces as a 502 with errorResponse shape
+ *
+ * Issue: #1405
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import nock from "nock";
+import request from "supertest";
+import express from "express";
+
+const HORIZON_URL = "https://horizon-testnet.stellar.org";
+
+function mockHorizonFeeStats(overrides: Partial<Record<string, string>> = {}) {
+  const bucket = {
+    max: "10000",
+    min: "100",
+    mode: "100",
+    p10: "100",
+    p20: "100",
+    p30: "100",
+    p40: "100",
+    p50: "100",
+    p60: "150",
+    p70: "200",
+    p80: "300",
+    p90: "500",
+    p95: "1000",
+    p99: "5000",
+    ...overrides,
+  };
+
+  return {
+    last_ledger: "123456",
+    last_ledger_base_fee: "100",
+    ledger_capacity_usage: "0.42",
+    fee_charged: bucket,
+    max_fee: bucket,
+  };
+}
+
+describe("GET /api/stellar/fee-stats", () => {
+  let app: express.Express;
+
+  beforeEach(async () => {
+    process.env.STELLAR_HORIZON_URL = HORIZON_URL;
+    nock.cleanAll();
+    vi.resetModules();
+
+    // Import after setting env vars so module-level reads (if any) pick them up.
+    const stellarRoutes = (await import("../stellar")).default;
+    app = express();
+    app.use(express.json());
+    app.use("/api/stellar", stellarRoutes);
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  it("returns normalized fee stats on success", async () => {
+    nock(HORIZON_URL).get("/fee_stats").reply(200, mockHorizonFeeStats());
+
+    const response = await request(app).get("/api/stellar/fee-stats").expect(200);
+
+    expect(response.body.success).toBe(true);
+    expect(response.body.data).toMatchObject({
+      lastLedger: 123456,
+      lastLedgerBaseFee: 100,
+      ledgerCapacityUsage: 0.42,
+      feeCharged: {
+        min: 100,
+        max: 10000,
+        mode: 100,
+        p50: 100,
+        p90: 500,
+        p99: 5000,
+      },
+    });
+    expect(typeof response.body.data.fetchedAt).toBe("string");
+    expect(() => new Date(response.body.data.fetchedAt)).not.toThrow();
+  });
+
+  it("returns numeric types, not strings, for percentile fields", async () => {
+    nock(HORIZON_URL).get("/fee_stats").reply(200, mockHorizonFeeStats());
+
+    const response = await request(app).get("/api/stellar/fee-stats").expect(200);
+
+    const { feeCharged } = response.body.data;
+    for (const key of ["min", "max", "mode", "p50", "p75", "p90", "p99"]) {
+      if (key in feeCharged) {
+        expect(typeof feeCharged[key]).toBe("number");
+      }
+    }
+  });
+
+  it("caches results for subsequent requests within the cache window", async () => {
+    const scope = nock(HORIZON_URL)
+      .get("/fee_stats")
+      .reply(200, mockHorizonFeeStats());
+
+    const first = await request(app).get("/api/stellar/fee-stats").expect(200);
+    // Second request should be served from cache — no second Horizon call configured.
+    const second = await request(app).get("/api/stellar/fee-stats").expect(200);
+
+    expect(first.body.data.fetchedAt).toBe(second.body.data.fetchedAt);
+    expect(scope.isDone()).toBe(true);
+  });
+
+  it("returns a 502 error envelope when Horizon is unreachable", async () => {
+    nock(HORIZON_URL).get("/fee_stats").replyWithError("network error");
+
+    const response = await request(app).get("/api/stellar/fee-stats").expect(502);
+
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toMatchObject({
+      code: "HORIZON_FEE_STATS_ERROR",
+    });
+  });
+
+  it("returns a 502 error envelope when Horizon responds with 5xx", async () => {
+    nock(HORIZON_URL).get("/fee_stats").reply(503, { error: "unavailable" });
+
+    const response = await request(app).get("/api/stellar/fee-stats").expect(502);
+
+    expect(response.body.success).toBe(false);
+    expect(response.body.error.code).toBe("HORIZON_FEE_STATS_ERROR");
+  });
+});

--- a/backend/src/routes/stellar.ts
+++ b/backend/src/routes/stellar.ts
@@ -1,0 +1,141 @@
+import { Router, Request, Response } from "express";
+import axios from "axios";
+import { successResponse, errorResponse } from "../utils/response";
+
+const router = Router();
+
+// Cache fee stats briefly to avoid hammering Horizon on every dashboard
+// refresh / poll. Horizon's own fee_stats endpoint is computed over the
+// last 5 ledgers, so a short cache window does not meaningfully reduce
+// freshness while still protecting Horizon from bursty traffic.
+let feeStatsCache: {
+  data: FeeStatsResponse;
+  timestamp: number;
+} | null = null;
+
+const CACHE_DURATION_MS = 5 * 1000; // 5 seconds
+
+interface HorizonFeeBucket {
+  max: string;
+  min: string;
+  mode: string;
+  p10: string;
+  p20: string;
+  p30: string;
+  p40: string;
+  p50: string;
+  p60: string;
+  p70: string;
+  p80: string;
+  p90: string;
+  p95: string;
+  p99: string;
+}
+
+interface HorizonFeeStatsRaw {
+  last_ledger: string;
+  last_ledger_base_fee: string;
+  ledger_capacity_usage: string;
+  fee_charged: HorizonFeeBucket;
+  max_fee: HorizonFeeBucket;
+}
+
+export interface FeeStatsResponse {
+  lastLedger: number;
+  lastLedgerBaseFee: number;
+  ledgerCapacityUsage: number;
+  feeCharged: {
+    min: number;
+    max: number;
+    mode: number;
+    p10: number;
+    p20: number;
+    p30: number;
+    p40: number;
+    p50: number;
+    p60: number;
+    p70: number;
+    p80: number;
+    p90: number;
+    p95: number;
+    p99: number;
+  };
+  fetchedAt: string;
+}
+
+function mapFeeBucket(bucket: HorizonFeeBucket) {
+  return {
+    min: Number(bucket.min),
+    max: Number(bucket.max),
+    mode: Number(bucket.mode),
+    p10: Number(bucket.p10),
+    p20: Number(bucket.p20),
+    p30: Number(bucket.p30),
+    p40: Number(bucket.p40),
+    p50: Number(bucket.p50),
+    p60: Number(bucket.p60),
+    p70: Number(bucket.p70),
+    p80: Number(bucket.p80),
+    p90: Number(bucket.p90),
+    p95: Number(bucket.p95),
+    p99: Number(bucket.p99),
+  };
+}
+
+function getHorizonUrl(): string {
+  if (process.env.STELLAR_HORIZON_URL) {
+    return process.env.STELLAR_HORIZON_URL;
+  }
+  return process.env.STELLAR_NETWORK === "mainnet"
+    ? "https://horizon.stellar.org"
+    : "https://horizon-testnet.stellar.org";
+}
+
+/**
+ * GET /api/stellar/fee-stats
+ *
+ * Proxies Horizon's `/fee_stats` endpoint and normalizes the response into
+ * a friendlier shape (numbers instead of stringified integers, camelCase
+ * keys). Horizon's fee_stats reflects only the most recent few ledgers —
+ * it is a real-time snapshot, NOT a historical time series. Callers that
+ * want a trend over time (e.g. the gas dashboard's 24h chart) must sample
+ * this endpoint repeatedly and accumulate snapshots client-side.
+ */
+router.get("/fee-stats", async (_req: Request, res: Response) => {
+  try {
+    const now = Date.now();
+    if (feeStatsCache && now - feeStatsCache.timestamp < CACHE_DURATION_MS) {
+      return res.json(successResponse(feeStatsCache.data));
+    }
+
+    const horizonUrl = getHorizonUrl();
+    const response = await axios.get<HorizonFeeStatsRaw>(
+      `${horizonUrl}/fee_stats`,
+      { timeout: 10000 }
+    );
+
+    const raw = response.data;
+
+    const feeStats: FeeStatsResponse = {
+      lastLedger: Number(raw.last_ledger),
+      lastLedgerBaseFee: Number(raw.last_ledger_base_fee),
+      ledgerCapacityUsage: Number(raw.ledger_capacity_usage),
+      feeCharged: mapFeeBucket(raw.fee_charged),
+      fetchedAt: new Date().toISOString(),
+    };
+
+    feeStatsCache = { data: feeStats, timestamp: now };
+
+    res.json(successResponse(feeStats));
+  } catch (error) {
+    console.error("Error fetching Horizon fee stats:", error);
+    res.status(502).json(
+      errorResponse({
+        code: "HORIZON_FEE_STATS_ERROR",
+        message: "Failed to fetch fee stats from Horizon",
+      })
+    );
+  }
+});
+
+export default router;

--- a/gas-dashboard/.env.example
+++ b/gas-dashboard/.env.example
@@ -3,6 +3,13 @@ CONTRACT_ID=your_contract_id_here
 HORIZON_URL=https://horizon-testnet.stellar.org
 SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
 
+# Backend API Configuration (consumed by the Vite dev server / built app).
+# In dev, vite.config.js proxies /api to http://localhost:3000, so the
+# default below works out of the box. Set to the full backend origin in
+# production deployments where the dashboard isn't served behind the same
+# proxy as the backend.
+VITE_API_BASE_URL=/api
+
 # Alert Configuration
 ALERT_EMAIL=your-email@example.com
 ALERT_WEBHOOK_URL=https://hooks.slack.com/services/YOUR/WEBHOOK/URL

--- a/gas-dashboard/package.json
+++ b/gas-dashboard/package.json
@@ -5,6 +5,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "test": "vitest",
+    "test:run": "vitest run",
     "measure": "node scripts/measure.js",
     "check:gas-thresholds": "node scripts/check-thresholds.js",
     "alert": "node scripts/alert.js",
@@ -21,7 +23,11 @@
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.2.0",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "jsdom": "^29.1.0",
     "vite": "^5.0.0",
+    "vitest": "^1.6.1",
     "node-cron": "^3.0.3"
   }
 }

--- a/gas-dashboard/src/dashboard/Dashboard.css
+++ b/gas-dashboard/src/dashboard/Dashboard.css
@@ -238,3 +238,123 @@
   font-size: 18px;
   color: #666;
 }
+
+.fee-stats-panel {
+  background: white;
+  padding: 24px;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+  margin-bottom: 30px;
+}
+
+.fee-stats-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+}
+
+.fee-stats-header h2 {
+  margin: 0;
+  font-size: 18px;
+  color: #1a1a1a;
+}
+
+.refresh-button {
+  padding: 8px 16px;
+  border: 1px solid #0066ff;
+  background: white;
+  color: #0066ff;
+  border-radius: 6px;
+  cursor: pointer;
+  font-weight: 600;
+  transition: all 0.2s;
+}
+
+.refresh-button:hover:not(:disabled) {
+  background: #0066ff;
+  color: white;
+}
+
+.refresh-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.fee-stats-error {
+  padding: 12px 16px;
+  margin-bottom: 16px;
+  background: #ffebee;
+  border-left: 4px solid #f44336;
+  border-radius: 8px;
+  color: #b71c1c;
+}
+
+.fee-recommendation-banner {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 16px;
+  margin-bottom: 16px;
+  background: #fff3e0;
+  border-left: 4px solid #ff9800;
+  border-radius: 8px;
+  color: #5d4037;
+  font-weight: 500;
+}
+
+.fee-recommendation-icon {
+  font-size: 20px;
+}
+
+.fee-stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.fee-stat-card {
+  background: #f5f7fa;
+  padding: 16px;
+  border-radius: 8px;
+}
+
+.fee-stat-card--highlight {
+  background: #fff3e0;
+  border: 1px solid #ff9800;
+}
+
+.fee-stat-card h3 {
+  margin: 0 0 8px 0;
+  font-size: 13px;
+  color: #666;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.fee-stat-value {
+  font-size: 22px;
+  font-weight: bold;
+  color: #1a1a1a;
+}
+
+.fee-stat-value .unit {
+  font-size: 12px;
+  color: #999;
+  font-weight: normal;
+  margin-left: 4px;
+}
+
+.fee-stats-empty {
+  padding: 40px 20px;
+  text-align: center;
+  color: #999;
+}
+
+.fee-stats-meta {
+  margin-top: 16px;
+  font-size: 13px;
+  color: #999;
+  text-align: right;
+}

--- a/gas-dashboard/src/dashboard/Dashboard.jsx
+++ b/gas-dashboard/src/dashboard/Dashboard.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Line, Bar } from 'react-chartjs-2';
 import { Chart as ChartJS, CategoryScale, LinearScale, PointElement, LineElement, BarElement, Title, Tooltip, Legend } from 'chart.js';
 import { format } from 'date-fns';
+import FeeStatsPanel from './FeeStatsPanel';
 
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, BarElement, Title, Tooltip, Legend);
 
@@ -38,6 +39,8 @@ export default function Dashboard() {
         <MetricCard title="Efficiency Score" value={metrics.efficiency} change={metrics.efficiencyChange} unit="%" />
         <MetricCard title="Monthly Cost" value={metrics.monthlyCost} change={metrics.costChange} unit="XLM" />
       </section>
+
+      <FeeStatsPanel />
 
       <section className="charts">
         <div className="chart-container">

--- a/gas-dashboard/src/dashboard/FeeStatsPanel.jsx
+++ b/gas-dashboard/src/dashboard/FeeStatsPanel.jsx
@@ -1,0 +1,187 @@
+import React, { useMemo } from 'react';
+import { Line } from 'react-chartjs-2';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+import { format } from 'date-fns';
+import { useFeeStats } from '../hooks/useFeeStats';
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend
+);
+
+/**
+ * Stroop -> XLM formatting helper. Horizon fee values are denominated in
+ * stroops (1 XLM = 10,000,000 stroops).
+ */
+function formatStroops(value) {
+  if (value === null || value === undefined || Number.isNaN(value)) return '--';
+  return value.toLocaleString();
+}
+
+function buildChartData(history) {
+  const labels = history.map((point) => format(new Date(point.fetchedAtMs), 'HH:mm:ss'));
+
+  return {
+    labels,
+    datasets: [
+      {
+        label: 'Base Fee',
+        data: history.map((point) => point.baseFee),
+        borderColor: '#0066ff',
+        backgroundColor: 'rgba(0, 102, 255, 0.1)',
+        tension: 0.3,
+        pointRadius: 2,
+      },
+      {
+        label: 'p50',
+        data: history.map((point) => point.p50),
+        borderColor: '#00c853',
+        backgroundColor: 'rgba(0, 200, 83, 0.1)',
+        tension: 0.3,
+        pointRadius: 2,
+      },
+      {
+        label: 'p90',
+        data: history.map((point) => point.p90),
+        borderColor: '#ff9800',
+        backgroundColor: 'rgba(255, 152, 0, 0.1)',
+        tension: 0.3,
+        pointRadius: 2,
+      },
+      {
+        label: 'p99',
+        data: history.map((point) => point.p99),
+        borderColor: '#f44336',
+        backgroundColor: 'rgba(244, 67, 54, 0.1)',
+        tension: 0.3,
+        pointRadius: 2,
+      },
+    ],
+  };
+}
+
+const chartOptions = {
+  responsive: true,
+  plugins: {
+    legend: { position: 'top' },
+    title: { display: false },
+    tooltip: {
+      callbacks: {
+        label: (context) => `${context.dataset.label}: ${formatStroops(context.parsed.y)} stroops`,
+      },
+    },
+  },
+  scales: {
+    y: {
+      beginAtZero: false,
+      title: { display: true, text: 'Fee (stroops)' },
+    },
+    x: {
+      title: { display: true, text: 'Time (rolling 24h buffer, sampled every 30s)' },
+    },
+  },
+};
+
+function FeeStatCard({ label, value, highlight }) {
+  return (
+    <div className={`fee-stat-card${highlight ? ' fee-stat-card--highlight' : ''}`}>
+      <h3>{label}</h3>
+      <div className="fee-stat-value">
+        {formatStroops(value)} <span className="unit">stroops</span>
+      </div>
+    </div>
+  );
+}
+
+export default function FeeStatsPanel() {
+  const { data, history, loading, error, refresh } = useFeeStats();
+
+  const chartData = useMemo(() => buildChartData(history), [history]);
+
+  const isElevated = useMemo(() => {
+    if (!data) return false;
+    const p90 = data.feeCharged?.p90;
+    const currentFee = data.lastLedgerBaseFee;
+    if (p90 === undefined || p90 === null || currentFee === undefined) return false;
+    return currentFee >= p90;
+  }, [data]);
+
+  return (
+    <section className="fee-stats-panel">
+      <div className="fee-stats-header">
+        <h2>Real-Time Network Fees</h2>
+        <button
+          className="refresh-button"
+          onClick={refresh}
+          disabled={loading}
+          aria-label="Refresh fee stats"
+        >
+          {loading ? 'Refreshing…' : 'Refresh'}
+        </button>
+      </div>
+
+      {error && (
+        <div className="fee-stats-error" role="alert">
+          Failed to load fee stats: {error}
+        </div>
+      )}
+
+      {isElevated && (
+        <div className="fee-recommendation-banner" role="alert">
+          <span className="fee-recommendation-icon">⚠️</span>
+          <span>
+            Fees are elevated — the current base fee is at or above the p90 threshold.
+            Consider waiting before deploying.
+          </span>
+        </div>
+      )}
+
+      {loading && !data && <div className="loading">Loading fee stats...</div>}
+
+      {data && (
+        <>
+          <div className="fee-stats-grid">
+            <FeeStatCard label="Current Base Fee" value={data.lastLedgerBaseFee} highlight={isElevated} />
+            <FeeStatCard label="p50 (Median)" value={data.feeCharged?.p50} />
+            <FeeStatCard label="p70 (~p75)" value={data.feeCharged?.p70} />
+            <FeeStatCard label="p99" value={data.feeCharged?.p99} />
+          </div>
+
+          <div className="chart-container">
+            <h2>24h Fee Trend</h2>
+            {history.length > 1 ? (
+              <Line data={chartData} options={chartOptions} />
+            ) : (
+              <div className="fee-stats-empty">
+                Collecting samples — the trend chart fills in as the dashboard polls
+                Horizon every 30 seconds. Horizon's fee_stats endpoint has no
+                historical API, so this chart is built from snapshots accumulated
+                client-side.
+              </div>
+            )}
+          </div>
+
+          <div className="fee-stats-meta">
+            Last updated: {format(new Date(data.fetchedAt), 'MMM dd, yyyy HH:mm:ss')} · Ledger{' '}
+            {data.lastLedger} · Capacity usage{' '}
+            {(data.ledgerCapacityUsage * 100).toFixed(1)}%
+          </div>
+        </>
+      )}
+    </section>
+  );
+}

--- a/gas-dashboard/src/dashboard/__tests__/FeeStatsPanel.test.jsx
+++ b/gas-dashboard/src/dashboard/__tests__/FeeStatsPanel.test.jsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import FeeStatsPanel from '../FeeStatsPanel';
+
+function mockFetchOnce(overrides = {}) {
+  const feeCharged = {
+    min: 100,
+    max: 10000,
+    mode: 100,
+    p10: 100,
+    p20: 100,
+    p30: 100,
+    p40: 100,
+    p50: 100,
+    p60: 150,
+    p70: 200,
+    p80: 300,
+    p90: 500,
+    p95: 1000,
+    p99: 5000,
+    ...overrides.feeCharged,
+  };
+
+  return {
+    ok: true,
+    json: async () => ({
+      success: true,
+      data: {
+        lastLedger: 123456,
+        lastLedgerBaseFee: overrides.lastLedgerBaseFee ?? 100,
+        ledgerCapacityUsage: 0.42,
+        feeCharged,
+        fetchedAt: new Date().toISOString(),
+      },
+    }),
+  };
+}
+
+describe('FeeStatsPanel', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('renders current base fee and percentile stats after loading', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockFetchOnce()));
+
+    render(<FeeStatsPanel />);
+
+    expect(screen.getByText(/Loading fee stats/i)).toBeInTheDocument();
+
+    await waitFor(() => expect(screen.getByText('Current Base Fee')).toBeInTheDocument());
+
+    expect(screen.getByText('p50 (Median)')).toBeInTheDocument();
+    expect(screen.getByText('p99')).toBeInTheDocument();
+  });
+
+  it('shows the elevated-fee recommendation banner when base fee >= p90', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(mockFetchOnce({ lastLedgerBaseFee: 600 }))
+    );
+
+    render(<FeeStatsPanel />);
+
+    await waitFor(() =>
+      expect(screen.getByText(/Fees are elevated/i)).toBeInTheDocument()
+    );
+  });
+
+  it('does not show the recommendation banner when fees are normal', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockFetchOnce({ lastLedgerBaseFee: 100 })));
+
+    render(<FeeStatsPanel />);
+
+    await waitFor(() => expect(screen.getByText('Current Base Fee')).toBeInTheDocument());
+
+    expect(screen.queryByText(/Fees are elevated/i)).not.toBeInTheDocument();
+  });
+
+  it('triggers a manual refresh fetch when the Refresh button is clicked', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(mockFetchOnce());
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<FeeStatsPanel />);
+
+    await waitFor(() => expect(screen.getByText('Refresh')).toBeInTheDocument());
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    screen.getByText('Refresh').click();
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+  });
+
+  it('shows an error message when the request fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: false, status: 502, json: async () => ({ success: false }) })
+    );
+
+    render(<FeeStatsPanel />);
+
+    await waitFor(() =>
+      expect(screen.getByText(/Failed to load fee stats/i)).toBeInTheDocument()
+    );
+  });
+});

--- a/gas-dashboard/src/hooks/__tests__/useFeeStats.test.jsx
+++ b/gas-dashboard/src/hooks/__tests__/useFeeStats.test.jsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, waitFor, act } from '@testing-library/react';
+import { useFeeStats } from '../useFeeStats';
+
+const SAMPLE_RESPONSE = {
+  success: true,
+  data: {
+    lastLedger: 123456,
+    lastLedgerBaseFee: 100,
+    ledgerCapacityUsage: 0.42,
+    feeCharged: {
+      min: 100,
+      max: 10000,
+      mode: 100,
+      p10: 100,
+      p20: 100,
+      p30: 100,
+      p40: 100,
+      p50: 100,
+      p60: 150,
+      p70: 200,
+      p80: 300,
+      p90: 500,
+      p95: 1000,
+      p99: 5000,
+    },
+    fetchedAt: '2026-06-25T12:00:00.000Z',
+  },
+};
+
+// Minimal harness component so we can exercise the hook through React's
+// render/act lifecycle.
+function HookHarness() {
+  const { data, history, loading, error, refresh } = useFeeStats();
+  return (
+    <div>
+      <div data-testid="loading">{String(loading)}</div>
+      <div data-testid="error">{error ?? ''}</div>
+      <div data-testid="base-fee">{data?.lastLedgerBaseFee ?? ''}</div>
+      <div data-testid="history-length">{history.length}</div>
+      <button onClick={refresh}>refresh</button>
+    </div>
+  );
+}
+
+describe('useFeeStats', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => SAMPLE_RESPONSE,
+      })
+    );
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('fetches fee stats on mount and exposes the latest snapshot', async () => {
+    render(<HookHarness />);
+
+    await waitFor(() => expect(screen.getByTestId('loading').textContent).toBe('false'));
+
+    expect(screen.getByTestId('base-fee').textContent).toBe('100');
+    expect(fetch).toHaveBeenCalledWith(expect.stringContaining('/stellar/fee-stats'));
+  });
+
+  it('accumulates a history point per successful fetch', async () => {
+    render(<HookHarness />);
+
+    await waitFor(() => expect(screen.getByTestId('history-length').textContent).toBe('1'));
+  });
+
+  it('exposes an error message when the fetch fails', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: async () => ({ success: false }),
+    });
+
+    render(<HookHarness />);
+
+    await waitFor(() => expect(screen.getByTestId('error').textContent).not.toBe(''));
+  });
+
+  it('refresh() triggers an additional fetch', async () => {
+    render(<HookHarness />);
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      screen.getByText('refresh').click();
+    });
+
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
+  });
+});

--- a/gas-dashboard/src/hooks/useFeeStats.js
+++ b/gas-dashboard/src/hooks/useFeeStats.js
@@ -1,0 +1,134 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api';
+const POLL_INTERVAL_MS = 30000; // 30 seconds, per dashboard requirements
+
+// How long to keep accumulated snapshots for the 24h trend chart.
+// Horizon's /fee_stats endpoint has no historical/time-series endpoint —
+// it only reflects the last few ledgers — so the rolling 24h trend is
+// built client-side by sampling this endpoint every POLL_INTERVAL_MS and
+// keeping a rolling buffer of snapshots in localStorage. This means the
+// chart only has as much history as the dashboard has been open/sampling;
+// it is not a true 24h backfill on first load.
+const HISTORY_WINDOW_MS = 24 * 60 * 60 * 1000; // 24 hours
+const HISTORY_STORAGE_KEY = 'gas-dashboard:fee-stats-history';
+const MAX_HISTORY_POINTS = 2880; // 24h at one sample every 30s, generous cap
+
+function loadHistory() {
+  try {
+    const raw = localStorage.getItem(HISTORY_STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed;
+  } catch {
+    return [];
+  }
+}
+
+function saveHistory(history) {
+  try {
+    localStorage.setItem(HISTORY_STORAGE_KEY, JSON.stringify(history));
+  } catch {
+    // localStorage may be unavailable (e.g. private browsing quota) — the
+    // dashboard still works, it just won't persist history across reloads.
+  }
+}
+
+function pruneHistory(history) {
+  const cutoff = Date.now() - HISTORY_WINDOW_MS;
+  const pruned = history.filter((point) => point.fetchedAtMs >= cutoff);
+  if (pruned.length > MAX_HISTORY_POINTS) {
+    return pruned.slice(pruned.length - MAX_HISTORY_POINTS);
+  }
+  return pruned;
+}
+
+/**
+ * Polls the backend's /stellar/fee-stats endpoint (which proxies Horizon's
+ * /fee_stats) every 30 seconds, and accumulates a rolling 24h buffer of
+ * snapshots (persisted to localStorage) for trend charting.
+ *
+ * Returns:
+ *   - data: the latest normalized fee-stats snapshot, or null before the
+ *     first successful fetch
+ *   - history: array of { fetchedAtMs, baseFee, p50, p75, p90, p99 } points
+ *     within the rolling 24h window, oldest first
+ *   - loading: true while the first fetch is in flight
+ *   - error: the last fetch error, or null
+ *   - refresh: manually triggers an extra fetch outside the poll cadence
+ *     (does not reset the 30s timer; the next scheduled poll still fires
+ *     on its original cadence)
+ */
+export function useFeeStats() {
+  const [data, setData] = useState(null);
+  const [history, setHistory] = useState(() => pruneHistory(loadHistory()));
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const isMounted = useRef(true);
+
+  const fetchFeeStats = useCallback(async () => {
+    try {
+      setError(null);
+      const response = await fetch(`${API_BASE_URL}/stellar/fee-stats`);
+      if (!response.ok) {
+        throw new Error(`Request failed with status ${response.status}`);
+      }
+      const body = await response.json();
+      if (!body.success) {
+        throw new Error(body.error?.message || 'Failed to fetch fee stats');
+      }
+
+      if (!isMounted.current) return;
+
+      const snapshot = body.data;
+      setData(snapshot);
+
+      setHistory((prev) => {
+        const point = {
+          fetchedAtMs: new Date(snapshot.fetchedAt).getTime() || Date.now(),
+          baseFee: snapshot.lastLedgerBaseFee,
+          // Horizon's fee_charged buckets are p10/p20/.../p90/p95/p99 — there is
+          // no native p75 bucket. We use p70 as the closest available stand-in
+          // for a "p75-ish" mid-high percentile in the trend chart.
+          p50: snapshot.feeCharged?.p50 ?? null,
+          p70: snapshot.feeCharged?.p70 ?? null,
+          p90: snapshot.feeCharged?.p90 ?? null,
+          p99: snapshot.feeCharged?.p99 ?? null,
+        };
+        const next = pruneHistory([...prev, point]);
+        saveHistory(next);
+        return next;
+      });
+    } catch (err) {
+      if (!isMounted.current) return;
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      if (isMounted.current) {
+        setLoading(false);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    isMounted.current = true;
+    fetchFeeStats();
+
+    const intervalId = setInterval(fetchFeeStats, POLL_INTERVAL_MS);
+
+    return () => {
+      isMounted.current = false;
+      clearInterval(intervalId);
+    };
+  }, [fetchFeeStats]);
+
+  return {
+    data,
+    history,
+    loading,
+    error,
+    refresh: fetchFeeStats,
+  };
+}
+
+export default useFeeStats;

--- a/gas-dashboard/src/test/setup.js
+++ b/gas-dashboard/src/test/setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/gas-dashboard/vitest.config.js
+++ b/gas-dashboard/vitest.config.js
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: './src/test/setup.js',
+  },
+});


### PR DESCRIPTION
## Summary

- Adds `GET /api/stellar/fee-stats` to the backend, proxying Stellar Horizon's `/fee_stats` endpoint via `axios` (the same `horizonUrl` + `axios.get` pattern already used in `routes/tokens.ts`), normalizing stringified percentile fields into numbers, and applying a short 5s cache to protect Horizon from bursty polling.
- Adds a `useFeeStats` hook (`gas-dashboard/src/hooks/useFeeStats.js`) that polls the new endpoint every 30 seconds and exposes `{ data, history, loading, error, refresh }`. `refresh()` triggers an extra fetch without resetting the 30s interval timer.
- Adds `FeeStatsPanel` (`gas-dashboard/src/dashboard/FeeStatsPanel.jsx`), wired into `Dashboard.jsx`, displaying:
  - Current base fee, p50, p70 (closest available stand-in for "p75" — Horizon has no native p75 bucket), and p99 fee percentiles
  - A 24h trend line chart (chart.js / react-chartjs-2, matching gas-dashboard's existing stack — no Recharts introduced here)
  - A manual "Refresh" button
  - A recommendation banner shown when the current base fee is at or above the p90 threshold ("Fees are elevated — consider waiting before deploying")
- Sets up minimal Vitest + jsdom + `@testing-library/react` test infrastructure for gas-dashboard (previously had none), with tests for `useFeeStats` and `FeeStatsPanel`.
- Adds integration tests for the new backend route using `nock` to mock Horizon HTTP responses (happy path, numeric coercion, caching, and upstream-failure handling).

Closes #1405

## Important caveat: 24h trend data source

Horizon's `/fee_stats` endpoint is a **real-time snapshot only** (computed over the last few ledgers) — it has no historical/time-series API. To satisfy the "24-hour trend chart" requirement without over-engineering a backend time-series store, `useFeeStats` accumulates each polled snapshot into a rolling 24h buffer client-side (capped at ~2,880 points, persisted to `localStorage` so it survives reloads). This means:

- The chart only has as much history as the dashboard has been open/polling — there's no historical backfill on first load.
- If the dashboard hasn't been open for 24h yet, the chart will show a "Collecting samples" empty state until there are at least 2 data points.

This is an intentional, scoped trade-off per the issue's guidance to avoid building a backend time-series store for this pass.

## Manual verification checklist

- [ ] `cd backend && npm run dev` — server starts, `GET /api/stellar/fee-stats` returns `{ success: true, data: { lastLedger, lastLedgerBaseFee, ledgerCapacityUsage, feeCharged: { min, max, mode, p10...p99 }, fetchedAt } }`
- [ ] Hitting the endpoint twice within 5s returns the same `fetchedAt` (cache working); after 5s, a new value
- [ ] Stopping network access to Horizon (or pointing `STELLAR_HORIZON_URL` at an invalid host) returns a `502` with `error.code === "HORIZON_FEE_STATS_ERROR"`
- [ ] `cd gas-dashboard && npm run dev` — dashboard loads, Fee Stats panel shows current base fee / p50 / p70 / p99 cards
- [ ] Panel auto-refreshes every 30s (watch `fetchedAt` / ledger number tick up)
- [ ] Clicking "Refresh" triggers an immediate extra fetch
- [ ] Artificially forcing `lastLedgerBaseFee >= feeCharged.p90` (e.g. via a temporary mock) shows the elevated-fee recommendation banner
- [ ] After 2+ polls, the 24h trend line chart renders with Base Fee / p50 / p90 / p99 series
- [ ] `cd backend && npx vitest run src/routes/__tests__/stellar.test.ts` passes
- [ ] `cd gas-dashboard && npx vitest run` passes

## Notes on Horizon API shape used

Backend's `@stellar/stellar-sdk` is not actually a dependency of the Express app in `backend/` (it's only used by an unwired NestJS-style service in `stellar-service-integration/`), and `axios` is already the established pattern for reaching Horizon directly from route files (see `routes/tokens.ts`). So this PR proxies Horizon's raw `GET /fee_stats` HTTP endpoint via axios rather than going through the SDK, consistent with existing route conventions. Horizon's actual response shape used:

```json
{
  "last_ledger": "...",
  "last_ledger_base_fee": "...",
  "ledger_capacity_usage": "...",
  "fee_charged": { "min", "max", "mode", "p10"..."p99" },
  "max_fee": { ...same shape... }
}
```