### PR TITLE
feat(backend): parallel webhook delivery worker pool with configurable concurrency and back-pressure

### DIFF
--- a/backend/src/lib/WorkerPool.ts
+++ b/backend/src/lib/WorkerPool.ts
@@ -1,0 +1,88 @@
+/**
+ * Generic async worker pool with bounded concurrency and back-pressure.
+ *
+ * Unlike a naive `Promise.allSettled(tasks.map(fn))` fan-out — which starts
+ * every task immediately regardless of how many there are — this pool caps
+ * the number of tasks running at once. When the pool is saturated, new
+ * tasks wait in an internal queue and `enqueue()` only resolves once its
+ * task has actually run to completion. Back-pressure falls out naturally:
+ * a caller awaiting `enqueue()` for the (concurrency + 1)-th task is
+ * delayed until a worker slot frees up, rather than the call returning
+ * immediately and letting an unbounded queue build up in memory.
+ */
+
+export interface WorkerPoolOptions<T> {
+  /** Maximum number of tasks that may run concurrently. */
+  concurrency: number;
+  /** Function invoked for each enqueued task. */
+  worker: (task: T) => Promise<void>;
+}
+
+interface QueuedTask<T> {
+  task: T;
+  resolve: () => void;
+  reject: (err: unknown) => void;
+}
+
+export class WorkerPool<T> {
+  private readonly concurrency: number;
+  private readonly workerFn: (task: T) => Promise<void>;
+  private readonly queue: QueuedTask<T>[] = [];
+  private running = 0;
+
+  constructor(options: WorkerPoolOptions<T>) {
+    if (!Number.isFinite(options.concurrency) || options.concurrency < 1) {
+      throw new Error("WorkerPool concurrency must be >= 1");
+    }
+    this.concurrency = options.concurrency;
+    this.workerFn = options.worker;
+  }
+
+  /**
+   * Enqueue a task for processing.
+   *
+   * Resolves once the task has actually run to completion (or rejects if
+   * the worker throws). When all worker slots are busy the task sits in
+   * the internal queue and this promise simply stays pending — that delay
+   * IS the back-pressure signal: producers that `await pool.enqueue(...)`
+   * are naturally throttled to the pool's processing rate instead of
+   * flooding it with queued work.
+   */
+  enqueue(task: T): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      this.queue.push({ task, resolve, reject });
+      this.drain();
+    });
+  }
+
+  /** Number of tasks waiting for a free worker slot (not yet started). */
+  getQueueDepth(): number {
+    return this.queue.length;
+  }
+
+  /** Number of tasks currently being processed. */
+  getRunningCount(): number {
+    return this.running;
+  }
+
+  /** Configured maximum concurrency for this pool. */
+  getConcurrency(): number {
+    return this.concurrency;
+  }
+
+  private drain(): void {
+    while (this.running < this.concurrency && this.queue.length > 0) {
+      const next = this.queue.shift();
+      if (!next) break;
+      this.running++;
+
+      this.workerFn(next.task)
+        .then(next.resolve, next.reject)
+        .finally(() => {
+          this.running--;
+          // A slot just freed up — try to admit the next queued task.
+          this.drain();
+        });
+    }
+  }
+}

--- a/backend/src/lib/__tests__/WorkerPool.test.ts
+++ b/backend/src/lib/__tests__/WorkerPool.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Tests for backend/src/lib/WorkerPool.ts
+ *
+ * Coverage targets:
+ *  - Bounded concurrency: never more than N tasks run at once
+ *  - Queueing: the (N+1)th task is queued, not dropped, and eventually runs
+ *  - Back-pressure: enqueue() resolves only once the task has run, so
+ *    saturating the pool measurably delays callers instead of buffering
+ *    unbounded work synchronously
+ *  - Accessors: getConcurrency / getRunningCount / getQueueDepth
+ *  - Error handling: a throwing worker rejects only that task's promise
+ */
+
+import { describe, it, expect } from "vitest";
+import { WorkerPool } from "../WorkerPool";
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe("WorkerPool", () => {
+  describe("bounded concurrency", () => {
+    it("never runs more than `concurrency` tasks at the same time", async () => {
+      const concurrency = 3;
+      let inFlight = 0;
+      let maxInFlight = 0;
+
+      const pool = new WorkerPool<number>({
+        concurrency,
+        worker: async () => {
+          inFlight++;
+          maxInFlight = Math.max(maxInFlight, inFlight);
+          await delay(20);
+          inFlight--;
+        },
+      });
+
+      const tasks = Array.from({ length: 12 }, (_, i) => i);
+      await Promise.all(tasks.map((t) => pool.enqueue(t)));
+
+      expect(maxInFlight).toBeLessThanOrEqual(concurrency);
+      expect(maxInFlight).toBe(concurrency);
+    });
+
+    it("exposes the configured concurrency", () => {
+      const pool = new WorkerPool<number>({
+        concurrency: 7,
+        worker: async () => {},
+      });
+      expect(pool.getConcurrency()).toBe(7);
+    });
+  });
+
+  describe("queueing — extra tasks are queued, not dropped", () => {
+    it("the (N+1)th task is queued while the pool is saturated, then eventually runs", async () => {
+      const concurrency = 2;
+      const completed: number[] = [];
+      let releaseFirstBatch: (() => void) | null = null;
+      const firstBatchGate = new Promise<void>((resolve) => {
+        releaseFirstBatch = resolve;
+      });
+
+      const pool = new WorkerPool<number>({
+        concurrency,
+        worker: async (task) => {
+          if (task < concurrency) {
+            // First `concurrency` tasks block until explicitly released,
+            // holding every worker slot open.
+            await firstBatchGate;
+          }
+          completed.push(task);
+        },
+      });
+
+      const p0 = pool.enqueue(0);
+      const p1 = pool.enqueue(1);
+
+      // Give the two blocking tasks a tick to actually start.
+      await delay(5);
+      expect(pool.getRunningCount()).toBe(concurrency);
+
+      // A third task arrives while the pool is fully saturated.
+      const p2 = pool.enqueue(2);
+      await delay(5);
+
+      // It must be queued (not dropped, not started) — running count stays
+      // at the cap and the task has not completed yet.
+      expect(pool.getRunningCount()).toBe(concurrency);
+      expect(pool.getQueueDepth()).toBe(1);
+      expect(completed).not.toContain(2);
+
+      // Release the first batch — task 2 should now be admitted and run.
+      releaseFirstBatch!();
+      await Promise.all([p0, p1, p2]);
+
+      expect(completed).toContain(2);
+      expect(pool.getQueueDepth()).toBe(0);
+      expect(pool.getRunningCount()).toBe(0);
+    });
+  });
+
+  describe("back-pressure on enqueue", () => {
+    it("slows down enqueue() once the pool is saturated instead of buffering instantly", async () => {
+      const concurrency = 2;
+      const workMs = 30;
+
+      const pool = new WorkerPool<number>({
+        concurrency,
+        worker: async () => {
+          await delay(workMs);
+        },
+      });
+
+      // Saturate the pool.
+      const saturating = [pool.enqueue(0), pool.enqueue(1)];
+
+      // This enqueue cannot start until a slot frees, so it should take at
+      // least ~workMs to resolve — proving the call itself is throttled
+      // rather than returning immediately and queuing silently.
+      const start = Date.now();
+      await pool.enqueue(2);
+      const elapsed = Date.now() - start;
+
+      expect(elapsed).toBeGreaterThanOrEqual(workMs - 5);
+
+      await Promise.all(saturating);
+    });
+
+    it("queue depth grows under burst load and drains back to zero", async () => {
+      const concurrency = 2;
+      const pool = new WorkerPool<number>({
+        concurrency,
+        worker: async () => {
+          await delay(15);
+        },
+      });
+
+      const tasks = Array.from({ length: 10 }, (_, i) => i);
+      const promises = tasks.map((t) => pool.enqueue(t));
+
+      // Immediately after the burst, most tasks should be waiting in queue
+      // rather than all having started concurrently.
+      await delay(1);
+      expect(pool.getQueueDepth()).toBeGreaterThan(0);
+      expect(pool.getRunningCount()).toBeLessThanOrEqual(concurrency);
+
+      await Promise.all(promises);
+      expect(pool.getQueueDepth()).toBe(0);
+      expect(pool.getRunningCount()).toBe(0);
+    });
+  });
+
+  describe("error handling", () => {
+    it("rejects only the failing task's promise, leaving the pool usable", async () => {
+      const pool = new WorkerPool<number>({
+        concurrency: 2,
+        worker: async (task) => {
+          if (task === 1) throw new Error("boom");
+        },
+      });
+
+      const results = await Promise.allSettled([
+        pool.enqueue(0),
+        pool.enqueue(1),
+        pool.enqueue(2),
+      ]);
+
+      expect(results[0].status).toBe("fulfilled");
+      expect(results[1].status).toBe("rejected");
+      expect(results[2].status).toBe("fulfilled");
+
+      // Pool remains healthy for further work after a failure.
+      await expect(pool.enqueue(3)).resolves.toBeUndefined();
+    });
+  });
+
+  describe("constructor validation", () => {
+    it("throws when concurrency is less than 1", () => {
+      expect(
+        () => new WorkerPool<number>({ concurrency: 0, worker: async () => {} })
+      ).toThrow();
+    });
+  });
+});

--- a/backend/src/lib/metrics/index.ts
+++ b/backend/src/lib/metrics/index.ts
@@ -372,6 +372,27 @@ export const webhookDeliveryLatency = new Histogram({
   registers: [register],
 });
 
+/**
+ * Configured concurrency of the webhook delivery worker pool
+ * (WEBHOOK_WORKER_CONCURRENCY). Reported as a gauge so it shows up
+ * alongside live queue depth even though it rarely changes at runtime.
+ */
+export const webhookDeliveryWorkerPoolSize = new Gauge({
+  name: "webhook_delivery_worker_pool_size",
+  help: "Configured concurrency of the webhook delivery worker pool",
+  registers: [register],
+});
+
+/**
+ * Number of webhook deliveries currently waiting for a free worker slot
+ * in the delivery pool (i.e. not yet dispatched).
+ */
+export const webhookDeliveryQueueDepth = new Gauge({
+  name: "webhook_delivery_queue_depth",
+  help: "Current number of queued webhook deliveries awaiting a free worker slot",
+  registers: [register],
+});
+
 // ---------------------------------------------------------------------------
 // Background Job Metrics
 // ---------------------------------------------------------------------------
@@ -608,6 +629,11 @@ export class MetricsCollector {
 
   static updateJobQueueSize(queueName: string, size: number): void {
     jobQueueSize.set({ queue_name: queueName }, size);
+  }
+
+  static updateWebhookWorkerPool(poolSize: number, queueDepth: number): void {
+    webhookDeliveryWorkerPoolSize.set(poolSize);
+    webhookDeliveryQueueDepth.set(queueDepth);
   }
 
   static updateErrorRate(component: string, rate: number): void {

--- a/backend/src/services/webhookDeliveryService.ts
+++ b/backend/src/services/webhookDeliveryService.ts
@@ -1,6 +1,7 @@
 import axios, { AxiosError } from "axios";
 import { gzip } from "zlib";
 import { promisify } from "util";
+import Redis from "ioredis";
 import {
   WebhookSubscription,
   WebhookPayload,
@@ -10,8 +11,16 @@ import {
 import webhookService from "./webhookService";
 import webhookDeadLetterService from "./webhookDeadLetterService";
 import { IntegrationMetrics } from "../monitoring/metrics/prometheus-config";
-import { webhookDeliveryLatency } from "../lib/metrics";
+import {
+  webhookDeliveryLatency,
+  MetricsCollector,
+} from "../lib/metrics";
 import { CircuitBreaker } from "../lib/circuitBreaker";
+import { WorkerPool } from "../lib/WorkerPool";
+import {
+  createRedisClient,
+  incrementSlidingWindow,
+} from "../middleware/rateLimiter";
 
 const gzipAsync = promisify(gzip);
 
@@ -19,10 +28,36 @@ const TIMEOUT_MS = parseInt(process.env.WEBHOOK_TIMEOUT_MS || "5000");
 const MAX_RETRIES = parseInt(process.env.WEBHOOK_MAX_RETRIES || "3");
 const RETRY_DELAY_MS = parseInt(process.env.WEBHOOK_RETRY_DELAY_MS || "1000");
 
+// Bounded concurrency for the delivery worker pool. Workers fan out up to
+// this many deliveries at once; everything beyond that waits in the pool's
+// internal queue, which is what provides back-pressure under high
+// subscription counts instead of unbounded `Promise.allSettled` fan-out.
+const WORKER_CONCURRENCY = parseInt(process.env.WEBHOOK_WORKER_CONCURRENCY || "10");
+
+// Per-tenant delivery rate limit, enforced inside each pool worker (not as
+// HTTP middleware, since this code path is not a request handler).
+const TENANT_RATE_LIMIT_WINDOW_MS = parseInt(
+  process.env.WEBHOOK_TENANT_RATE_LIMIT_WINDOW_MS || "60000"
+);
+const TENANT_RATE_LIMIT_MAX = parseInt(
+  process.env.WEBHOOK_TENANT_RATE_LIMIT_MAX || "60"
+);
+
+interface DeliveryTask {
+  subscription: WebhookSubscription;
+  event: WebhookEventType;
+  data: WebhookEventData;
+  correlationId: string;
+}
+
 export class WebhookDeliveryService {
   private circuitBreaker: CircuitBreaker;
   // Read at construction time so tests can override via process.env before new WebhookDeliveryService()
   private readonly compressionThresholdBytes: number;
+  private readonly pool: WorkerPool<DeliveryTask>;
+  // Lazily created so environments/tests without Redis never pay the
+  // connection cost unless a delivery actually needs rate-limit checking.
+  private rateLimitRedis: Redis | null = null;
 
   constructor() {
     this.circuitBreaker = new CircuitBreaker({
@@ -34,7 +69,18 @@ export class WebhookDeliveryService {
     this.compressionThresholdBytes = parseInt(
       process.env.WEBHOOK_COMPRESSION_THRESHOLD_BYTES || "1024"
     );
+    this.pool = new WorkerPool<DeliveryTask>({
+      concurrency: WORKER_CONCURRENCY,
+      worker: (task) =>
+        this.deliverWebhook(
+          task.subscription,
+          task.event,
+          task.data,
+          task.correlationId
+        ),
+    });
   }
+
   /**
    * Trigger webhooks for an event
    */
@@ -54,12 +100,56 @@ export class WebhookDeliveryService {
       JSON.stringify({ event: 'webhook.trigger', correlationId: cid, webhookEvent: event, subscriptionCount: subscriptions.length })
     );
 
-    // Deliver webhooks in parallel
+    // Deliver through the bounded worker pool. Concurrency is capped by
+    // WEBHOOK_WORKER_CONCURRENCY; once every worker slot is busy, additional
+    // enqueue() calls wait their turn rather than starting immediately —
+    // this is the back-pressure mechanism for high subscription counts.
+    this.reportPoolMetrics();
     await Promise.allSettled(
       subscriptions.map((subscription) =>
-        this.deliverWebhook(subscription, event, data, cid)
+        this.pool.enqueue({ subscription, event, data, correlationId: cid })
       )
     );
+    this.reportPoolMetrics();
+  }
+
+  /**
+   * Publish current worker pool size / queue depth to Prometheus.
+   */
+  private reportPoolMetrics(): void {
+    MetricsCollector.updateWebhookWorkerPool(
+      this.pool.getConcurrency(),
+      this.pool.getQueueDepth()
+    );
+  }
+
+  /**
+   * Enforce the per-tenant delivery rate limit for a subscription's owner.
+   * Uses the same Redis-backed sliding-window limiter as the HTTP
+   * middleware, but invoked directly since delivery happens outside of any
+   * request/response cycle. Fails open (allows delivery) if Redis is
+   * unavailable, matching the existing middleware's fail-open behavior —
+   * a rate-limiter outage must not stop webhook delivery altogether.
+   */
+  private async isWithinTenantRateLimit(tenantId: string): Promise<boolean> {
+    // No Redis configured (e.g. local/test environments) — skip the check
+    // rather than attempting a real network connection on every delivery.
+    if (!process.env.REDIS_URL) {
+      return true;
+    }
+    try {
+      if (!this.rateLimitRedis) {
+        this.rateLimitRedis = createRedisClient();
+      }
+      const count = await incrementSlidingWindow(
+        this.rateLimitRedis,
+        `rl:webhook:delivery:tenant:${tenantId}`,
+        TENANT_RATE_LIMIT_WINDOW_MS
+      );
+      return count <= TENANT_RATE_LIMIT_MAX;
+    } catch {
+      return true;
+    }
   }
 
   /**
@@ -72,13 +162,29 @@ export class WebhookDeliveryService {
     data: WebhookEventData,
     correlationId?: string
   ): Promise<void> {
+    const cid = correlationId || `whk_${Date.now().toString(36)}`;
+
+    // Per-tenant rate limit: the subscription owner (createdBy) is the
+    // closest thing to a tenant id on this model. One slow retry-after-delay
+    // is attempted before skipping, since a worker holding a pool slot for a
+    // single delayed check is preferable to dropping the delivery outright.
+    const tenantId = subscription.createdBy;
+    if (!(await this.isWithinTenantRateLimit(tenantId))) {
+      await this.delay(TENANT_RATE_LIMIT_WINDOW_MS / TENANT_RATE_LIMIT_MAX);
+      if (!(await this.isWithinTenantRateLimit(tenantId))) {
+        console.warn(
+          JSON.stringify({ event: 'webhook.rate_limited', correlationId: cid, subscriptionId: subscription.id, tenantId })
+        );
+        return;
+      }
+    }
+
     const payload = webhookService.createPayload(
       event,
       data,
       subscription.secret
     );
 
-    const cid = correlationId || `whk_${Date.now().toString(36)}`;
     // Attach correlation ID to payload headers (not body — body is signed)
     const extraHeaders: Record<string, string> = {
       'X-Correlation-Id': cid,


### PR DESCRIPTION
Closes #1404

## Summary

- Adds a generic, reusable `WorkerPool<T>` (`backend/src/lib/WorkerPool.ts`) with bounded concurrency. `enqueue(task)` resolves once the task has actually run to completion; when every worker slot is busy, the task waits in an internal queue and the `enqueue()` call itself stays pending — this is the back-pressure mechanism (callers are naturally throttled instead of buffering unbounded work or having tasks silently dropped).
- `WebhookDeliveryService.triggerEvent()` now routes each subscription's delivery through a shared `WorkerPool` instance instead of an unbounded `Promise.allSettled` fan-out, so delivery concurrency no longer scales unboundedly with subscription count. Pool concurrency is configurable via `WEBHOOK_WORKER_CONCURRENCY` (default `10`).
- Each pool worker enforces a per-tenant rate limit before delivering, using the subscription owner (`subscription.createdBy`) as the tenant key against the existing Redis-backed sliding-window limiter (`incrementSlidingWindow` from `backend/src/middleware/rateLimiter.ts`), called directly since this is not an HTTP request path. If a tenant is over limit, one short backoff is attempted before skipping that delivery (logged as `webhook.rate_limited`) rather than dropping it silently or blocking other tenants' deliveries.
- Adds two new Prometheus gauges in `backend/src/lib/metrics/index.ts`, following the existing naming/registration conventions: `webhook_delivery_worker_pool_size` (configured pool concurrency) and `webhook_delivery_queue_depth` (current queued task count), plus a `MetricsCollector.updateWebhookWorkerPool()` helper. These are updated before and after each `triggerEvent()` call.
- New tests in `backend/src/lib/__tests__/WorkerPool.test.ts` covering: bounded concurrency (never exceeds configured N), queued tasks beyond N eventually run rather than being dropped, back-pressure (an `enqueue()` call on a saturated pool measurably waits for a slot rather than resolving immediately), queue-depth observability under burst load, and per-task error isolation.

## Caveats / design notes

- **Per-tenant rate limiting integration**: `WebhookSubscription` has no explicit tenant/account id field, so `createdBy` (the wallet address that owns the subscription) is used as the tenant key — this is the same field the HTTP-layer rate limiters in `rateLimiter.ts` use for wallet-based keying. The check is invoked directly (not as Express middleware) since webhook delivery happens outside any request/response cycle.
- **Redis availability in tests/dev**: the existing parallel-delivery property test (and several other webhook test suites) run without Redis configured. To avoid making a real network connection attempt (and any associated latency/flakiness) on every delivery in those environments, the rate-limit check is a no-op whenever `REDIS_URL` is unset — it only activates when Redis is actually configured. When Redis *is* configured but unreachable, the check fails open (delivery proceeds), mirroring the existing `createRateLimiter` middleware's fail-open behavior — a rate-limiter outage must not stop webhook delivery.
- Default pool concurrency (10) is well above the subscription counts used in the existing parallel-delivery and fan-out-storm tests, so those suites' timing/completeness assertions are expected to keep passing unmodified — no existing test files were changed.
- Per the task instructions, I did not run `npm test` / `vitest` / lint / type-check. See manual verification checklist below.

## Manual verification checklist

- [ ] `cd backend && npx vitest run src/lib/__tests__/WorkerPool.test.ts` — new WorkerPool unit tests pass (bounded concurrency, queuing, back-pressure, error isolation).
- [ ] `cd backend && npx vitest run src/__tests__/property.webhook-parallel-delivery.test.ts` — existing Property 69-A/B tests still pass (all subscriptions delivered; parallel wall-clock time still well under sequential).
- [ ] `cd backend && npx vitest run src/__tests__/chaos.webhook-fanout-storm.test.ts src/__tests__/webhookDeliveryService.chaos.test.ts src/__tests__/webhookCompression.test.ts src/__tests__/webhook-network-failures.integration.test.ts src/__tests__/webhook-subscription-filtering.integration.test.ts src/__tests__/webhookDeliveryLogging.integration.test.ts` — other webhook delivery suites unaffected.
- [ ] `cd backend && npx tsc --noEmit` — type-checks cleanly (new imports: `ioredis` default import, `WorkerPool`, `MetricsCollector`, `createRedisClient`/`incrementSlidingWindow`).
- [ ] Set `WEBHOOK_WORKER_CONCURRENCY=2` locally and trigger an event with >2 active subscriptions; confirm via logs/metrics that only 2 deliveries run at once and the rest queue.
- [ ] Scrape `/metrics` and confirm `webhook_delivery_worker_pool_size` and `webhook_delivery_queue_depth` are present and update across a trigger.
- [ ] With `REDIS_URL` set to a real Redis instance, simulate exceeding `WEBHOOK_TENANT_RATE_LIMIT_MAX` for one tenant and confirm deliveries for that tenant are delayed/skipped (`webhook.rate_limited` log) while other tenants' deliveries are unaffected.