### PR TITLE
feat(frontend): IPFS pin monitor dashboard with automated re-pin trigger in admin UI

### DIFF
--- a/backend/prisma/migrations/20260625000000_add_ipfs_pin/migration.sql
+++ b/backend/prisma/migrations/20260625000000_add_ipfs_pin/migration.sql
@@ -1,0 +1,27 @@
+-- CreateTable
+CREATE TABLE "IPFSPin" (
+    "id" TEXT NOT NULL,
+    "cid" TEXT NOT NULL,
+    "tokenName" TEXT,
+    "tokenAddress" TEXT,
+    "pinned" BOOLEAN NOT NULL DEFAULT false,
+    "failureCount" INTEGER NOT NULL DEFAULT 0,
+    "lastChecked" TIMESTAMP(3),
+    "error" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "IPFSPin_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "IPFSPin_cid_key" ON "IPFSPin"("cid");
+
+-- CreateIndex
+CREATE INDEX "IPFSPin_pinned_idx" ON "IPFSPin"("pinned");
+
+-- CreateIndex
+CREATE INDEX "IPFSPin_failureCount_idx" ON "IPFSPin"("failureCount");
+
+-- CreateIndex
+CREATE INDEX "IPFSPin_tokenAddress_idx" ON "IPFSPin"("tokenAddress");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -404,3 +404,24 @@ model IntegrationState {
   value     String
   updatedAt DateTime @updatedAt
 }
+
+/// Tracks pin status for content stored on IPFS via Pinata (#1403).
+/// Populated/updated by the pin monitor and the admin re-pin endpoint so the
+/// admin dashboard has durable visibility into pin health without re-querying
+/// Pinata for every request.
+model IPFSPin {
+  id            String    @id @default(uuid())
+  cid           String    @unique
+  tokenName     String?
+  tokenAddress  String?
+  pinned        Boolean   @default(false)
+  failureCount  Int       @default(0)
+  lastChecked   DateTime?
+  error         String?
+  createdAt     DateTime  @default(now())
+  updatedAt     DateTime  @updatedAt
+
+  @@index([pinned])
+  @@index([failureCount])
+  @@index([tokenAddress])
+}

--- a/backend/src/routes/admin/__tests__/ipfs.test.ts
+++ b/backend/src/routes/admin/__tests__/ipfs.test.ts
@@ -1,0 +1,308 @@
+/**
+ * Integration tests for Admin IPFS Pin Monitor routes (#1403)
+ *
+ * Coverage:
+ *  - GET /api/admin/ipfs/pins — list tracked pins with derived status
+ *  - POST /api/admin/ipfs/re-pin/:cid — trigger re-pin, update tracking record
+ *  - Authentication requirements
+ *  - Success, validation, and error paths
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import request from "supertest";
+import express, { Express } from "express";
+import ipfsRouter from "../ipfs";
+import { prisma } from "../../../lib/prisma";
+import { checkPinStatus } from "../../../lib/ipfs/pinMonitor";
+import { getActivePinataCredentials } from "../../../lib/ipfs/pinata.js";
+import { pinataQueue } from "../../../lib/ipfs/pinataQueue.js";
+import { MetricsCollector } from "../../../lib/metrics";
+
+// Mock Prisma
+vi.mock("../../../lib/prisma", () => ({
+  prisma: {
+    iPFSPin: {
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+      upsert: vi.fn(),
+    },
+  },
+}));
+
+// Mock pin monitor
+vi.mock("../../../lib/ipfs/pinMonitor", () => ({
+  checkPinStatus: vi.fn(),
+}));
+
+// Mock Pinata credential accessor
+vi.mock("../../../lib/ipfs/pinata.js", () => ({
+  getActivePinataCredentials: vi.fn(),
+}));
+
+// Mock Pinata queue
+vi.mock("../../../lib/ipfs/pinataQueue.js", () => ({
+  pinataQueue: {
+    enqueue: vi.fn((fn: () => Promise<unknown>) => fn()),
+  },
+}));
+
+// Mock metrics collector
+vi.mock("../../../lib/metrics", () => ({
+  MetricsCollector: {
+    recordIPFSOperation: vi.fn(),
+  },
+}));
+
+// Mock the auth middleware
+vi.mock("../../../middleware/auth", () => ({
+  authenticateAdmin: (_req: any, res: any, next: any) => {
+    const token = _req.headers.authorization?.replace("Bearer ", "");
+    if (token === "valid-token") {
+      next();
+    } else {
+      res.status(401).json({ success: false, error: { code: "UNAUTHORIZED" } });
+    }
+  },
+}));
+
+let app: Express;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(pinataQueue.enqueue).mockImplementation((fn: () => Promise<unknown>) => fn());
+  app = express();
+  app.use(express.json());
+  app.use("/api/admin/ipfs", ipfsRouter);
+});
+
+// ── GET /pins ────────────────────────────────────────────────────────────────
+
+describe("GET /api/admin/ipfs/pins", () => {
+  it("returns pins with derived status when authenticated", async () => {
+    const now = new Date();
+    vi.mocked(prisma.iPFSPin.findMany).mockResolvedValueOnce([
+      {
+        id: "1",
+        cid: "QmGood",
+        tokenName: "GoodToken",
+        tokenAddress: "0xabc",
+        pinned: true,
+        failureCount: 0,
+        lastChecked: now,
+        error: null,
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        id: "2",
+        cid: "QmWarn",
+        tokenName: "WarnToken",
+        tokenAddress: "0xdef",
+        pinned: false,
+        failureCount: 2,
+        lastChecked: now,
+        error: "timeout",
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        id: "3",
+        cid: "QmFail",
+        tokenName: "FailToken",
+        tokenAddress: "0xghi",
+        pinned: false,
+        failureCount: 4,
+        lastChecked: now,
+        error: "not found",
+        createdAt: now,
+        updatedAt: now,
+      },
+    ] as any);
+
+    const res = await request(app)
+      .get("/api/admin/ipfs/pins")
+      .set("Authorization", "Bearer valid-token");
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.total).toBe(3);
+    expect(res.body.data.pins[0].status).toBe("pinned");
+    expect(res.body.data.pins[1].status).toBe("warning");
+    expect(res.body.data.pins[2].status).toBe("failed");
+  });
+
+  it("returns empty list when no pins are tracked", async () => {
+    vi.mocked(prisma.iPFSPin.findMany).mockResolvedValueOnce([]);
+
+    const res = await request(app)
+      .get("/api/admin/ipfs/pins")
+      .set("Authorization", "Bearer valid-token");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual({ pins: [], total: 0 });
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    const res = await request(app).get("/api/admin/ipfs/pins");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 500 when prisma throws", async () => {
+    vi.mocked(prisma.iPFSPin.findMany).mockRejectedValueOnce(new Error("DB down"));
+
+    const res = await request(app)
+      .get("/api/admin/ipfs/pins")
+      .set("Authorization", "Bearer valid-token");
+
+    expect(res.status).toBe(500);
+    expect(res.body.error.code).toBe("INTERNAL_SERVER_ERROR");
+  });
+});
+
+// ── POST /re-pin/:cid ──────────────────────────────────────────────────────────
+
+describe("POST /api/admin/ipfs/re-pin/:cid", () => {
+  beforeEach(() => {
+    vi.mocked(getActivePinataCredentials).mockReturnValue({
+      apiKey: "test-key",
+      apiSecret: "test-secret",
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({}),
+        text: async () => "",
+      })
+    );
+  });
+
+  it("re-pins successfully and updates the tracking record", async () => {
+    vi.mocked(checkPinStatus).mockResolvedValueOnce({ cid: "QmABC", pinned: true });
+    vi.mocked(prisma.iPFSPin.findUnique).mockResolvedValueOnce(null);
+    vi.mocked(prisma.iPFSPin.upsert).mockResolvedValueOnce({
+      id: "1",
+      cid: "QmABC",
+      tokenName: null,
+      tokenAddress: null,
+      pinned: true,
+      failureCount: 0,
+      lastChecked: new Date(),
+      error: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as any);
+
+    const res = await request(app)
+      .post("/api/admin/ipfs/re-pin/QmABC")
+      .set("Authorization", "Bearer valid-token");
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.pinned).toBe(true);
+    expect(res.body.data.status).toBe("pinned");
+    expect(vi.mocked(prisma.iPFSPin.upsert)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { cid: "QmABC" },
+        create: expect.objectContaining({ cid: "QmABC", pinned: true, failureCount: 0 }),
+        update: expect.objectContaining({ pinned: true, failureCount: 0 }),
+      })
+    );
+    expect(MetricsCollector.recordIPFSOperation).toHaveBeenCalledWith(
+      "re-pin",
+      "success",
+      expect.any(Number)
+    );
+  });
+
+  it("increments failureCount when the re-pin cannot be verified", async () => {
+    vi.mocked(checkPinStatus).mockResolvedValueOnce({
+      cid: "QmBAD",
+      pinned: false,
+      error: "Pinata API error: HTTP 500",
+    });
+    vi.mocked(prisma.iPFSPin.findUnique).mockResolvedValueOnce({
+      id: "2",
+      cid: "QmBAD",
+      tokenName: null,
+      tokenAddress: null,
+      pinned: false,
+      failureCount: 2,
+      lastChecked: new Date(),
+      error: "previous error",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as any);
+    vi.mocked(prisma.iPFSPin.upsert).mockResolvedValueOnce({
+      id: "2",
+      cid: "QmBAD",
+      tokenName: null,
+      tokenAddress: null,
+      pinned: false,
+      failureCount: 3,
+      lastChecked: new Date(),
+      error: "Pinata API error: HTTP 500",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as any);
+
+    const res = await request(app)
+      .post("/api/admin/ipfs/re-pin/QmBAD")
+      .set("Authorization", "Bearer valid-token");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.pinned).toBe(false);
+    expect(res.body.data.failureCount).toBe(3);
+    expect(res.body.data.status).toBe("warning");
+    expect(vi.mocked(prisma.iPFSPin.upsert)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({ failureCount: 3 }),
+      })
+    );
+  });
+
+  it("returns 503 when Pinata credentials are not configured", async () => {
+    vi.mocked(getActivePinataCredentials).mockImplementationOnce(() => {
+      throw new Error("Pinata credentials are not configured");
+    });
+
+    const res = await request(app)
+      .post("/api/admin/ipfs/re-pin/QmABC")
+      .set("Authorization", "Bearer valid-token");
+
+    expect(res.status).toBe(503);
+    expect(res.body.error.code).toBe("PINATA_NOT_CONFIGURED");
+  });
+
+  it("returns 500 and records a failed attempt when the Pinata pin call fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        text: async () => "Internal error",
+        json: async () => ({}),
+      })
+    );
+    vi.mocked(prisma.iPFSPin.findUnique).mockResolvedValueOnce(null);
+    vi.mocked(prisma.iPFSPin.upsert).mockResolvedValueOnce({} as any);
+
+    const res = await request(app)
+      .post("/api/admin/ipfs/re-pin/QmFAIL")
+      .set("Authorization", "Bearer valid-token");
+
+    expect(res.status).toBe(500);
+    expect(res.body.error.code).toBe("RE_PIN_FAILED");
+    expect(MetricsCollector.recordIPFSOperation).toHaveBeenCalledWith(
+      "re-pin",
+      "failure",
+      expect.any(Number)
+    );
+    expect(prisma.iPFSPin.upsert).toHaveBeenCalled();
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    const res = await request(app).post("/api/admin/ipfs/re-pin/QmABC");
+    expect(res.status).toBe(401);
+  });
+});

--- a/backend/src/routes/admin/index.ts
+++ b/backend/src/routes/admin/index.ts
@@ -5,6 +5,7 @@ import usersRouter from "./users";
 import auditRouter from "./audit";
 import operationalRouter from "./operational";
 import backupRouter from "./backup";
+import ipfsRouter from "./ipfs";
 
 const router = Router();
 
@@ -14,5 +15,6 @@ router.use("/users", usersRouter);
 router.use("/audit", auditRouter);
 router.use("/operational", operationalRouter);
 router.use("/backup", backupRouter);
+router.use("/ipfs", ipfsRouter);
 
 export default router;

--- a/backend/src/routes/admin/ipfs.ts
+++ b/backend/src/routes/admin/ipfs.ts
@@ -1,0 +1,206 @@
+/**
+ * Admin IPFS Pin Monitor routes (#1403).
+ *
+ * Exposes the durable IPFSPin tracking table to the admin dashboard so
+ * operators can see pin health (pinned/failed/warning) for every tracked
+ * CID, and manually trigger a re-pin attempt when Pinata drops content.
+ */
+import { Router } from "express";
+import { z } from "zod";
+import { prisma } from "../../lib/prisma";
+import { authenticateAdmin } from "../../middleware/auth";
+import { successResponse, errorResponse } from "../../utils/response";
+import { checkPinStatus } from "../../lib/ipfs/pinMonitor";
+import { getActivePinataCredentials } from "../../lib/ipfs/pinata.js";
+import { pinataQueue } from "../../lib/ipfs/pinataQueue.js";
+import { MetricsCollector } from "../../lib/metrics";
+
+const router = Router();
+
+/** Threshold beyond which a pin is considered "failed" (red) rather than just "warning" (yellow). */
+const FAILURE_THRESHOLD = 3;
+
+function pinHealthStatus(pinned: boolean, failureCount: number): "pinned" | "warning" | "failed" {
+  if (pinned && failureCount === 0) return "pinned";
+  if (failureCount > FAILURE_THRESHOLD) return "failed";
+  if (failureCount > 1) return "warning";
+  return pinned ? "pinned" : "warning";
+}
+
+// GET /api/admin/ipfs/pins - List all tracked pins with status/failure count/last checked
+router.get("/pins", authenticateAdmin, async (_req, res) => {
+  try {
+    const pins = await prisma.iPFSPin.findMany({
+      orderBy: { updatedAt: "desc" },
+    });
+
+    const data = pins.map((pin) => ({
+      cid: pin.cid,
+      tokenName: pin.tokenName,
+      tokenAddress: pin.tokenAddress,
+      pinned: pin.pinned,
+      failureCount: pin.failureCount,
+      lastChecked: pin.lastChecked,
+      error: pin.error,
+      status: pinHealthStatus(pin.pinned, pin.failureCount),
+      createdAt: pin.createdAt,
+      updatedAt: pin.updatedAt,
+    }));
+
+    res.json(
+      successResponse({
+        pins: data,
+        total: data.length,
+      })
+    );
+  } catch (error) {
+    console.error("Error fetching IPFS pins:", error);
+    res.status(500).json(
+      errorResponse({
+        code: "INTERNAL_SERVER_ERROR",
+        message: "Failed to fetch IPFS pin status",
+      })
+    );
+  }
+});
+
+const rePinParamsSchema = z.object({
+  cid: z.string().min(1, "cid is required"),
+});
+
+// POST /api/admin/ipfs/re-pin/:cid - Trigger a re-pin attempt for a given CID
+router.post("/re-pin/:cid", authenticateAdmin, async (req, res) => {
+  const startedAt = Date.now();
+  try {
+    const { cid } = rePinParamsSchema.parse(req.params);
+
+    let apiKey: string;
+    let apiSecret: string;
+    try {
+      const creds = getActivePinataCredentials();
+      apiKey = creds.apiKey;
+      apiSecret = creds.apiSecret;
+    } catch (credError) {
+      return res.status(503).json(
+        errorResponse({
+          code: "PINATA_NOT_CONFIGURED",
+          message: "Pinata credentials are not configured",
+        })
+      );
+    }
+
+    // Re-pin by re-fetching/re-pinning the content via Pinata's pin-by-hash
+    // API, throttled through the shared queue used for all other Pinata calls.
+    const rePinResult = await pinataQueue.enqueue(async () => {
+      const res = await fetch("https://api.pinata.cloud/pinning/pinByHash", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          pinata_api_key: apiKey,
+          pinata_secret_api_key: apiSecret,
+        },
+        body: JSON.stringify({ hashToPin: cid }),
+        signal: AbortSignal.timeout(30_000),
+      });
+
+      if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        throw new Error(`Pinata pinByHash failed: HTTP ${res.status} ${text}`);
+      }
+
+      return res.json().catch(() => ({}));
+    });
+
+    // Verify the re-pin succeeded
+    const status = await checkPinStatus(cid, apiKey, apiSecret);
+
+    const durationSeconds = (Date.now() - startedAt) / 1000;
+    MetricsCollector.recordIPFSOperation(
+      "re-pin",
+      status.pinned ? "success" : "failure",
+      durationSeconds
+    );
+
+    const existing = await prisma.iPFSPin.findUnique({ where: { cid } });
+
+    const updated = await prisma.iPFSPin.upsert({
+      where: { cid },
+      create: {
+        cid,
+        pinned: status.pinned,
+        failureCount: status.pinned ? 0 : 1,
+        lastChecked: new Date(),
+        error: status.error ?? null,
+      },
+      update: {
+        pinned: status.pinned,
+        failureCount: status.pinned ? 0 : (existing?.failureCount ?? 0) + 1,
+        lastChecked: new Date(),
+        error: status.error ?? null,
+      },
+    });
+
+    res.json(
+      successResponse({
+        cid: updated.cid,
+        pinned: updated.pinned,
+        failureCount: updated.failureCount,
+        lastChecked: updated.lastChecked,
+        error: updated.error,
+        status: pinHealthStatus(updated.pinned, updated.failureCount),
+        pinataResponse: rePinResult,
+        message: status.pinned
+          ? "Re-pin successful"
+          : "Re-pin attempted but pin could not be verified",
+      })
+    );
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return res.status(400).json(
+        errorResponse({
+          code: "VALIDATION_ERROR",
+          message: "Invalid CID",
+          details: error.errors,
+        })
+      );
+    }
+
+    const durationSeconds = (Date.now() - startedAt) / 1000;
+    MetricsCollector.recordIPFSOperation("re-pin", "failure", durationSeconds);
+
+    console.error("Error re-pinning CID:", error);
+
+    // Best-effort: record the failed attempt so the dashboard reflects it.
+    try {
+      const { cid } = req.params;
+      const existing = await prisma.iPFSPin.findUnique({ where: { cid } });
+      await prisma.iPFSPin.upsert({
+        where: { cid },
+        create: {
+          cid,
+          pinned: false,
+          failureCount: 1,
+          lastChecked: new Date(),
+          error: error instanceof Error ? error.message : String(error),
+        },
+        update: {
+          pinned: false,
+          failureCount: (existing?.failureCount ?? 0) + 1,
+          lastChecked: new Date(),
+          error: error instanceof Error ? error.message : String(error),
+        },
+      });
+    } catch (trackingError) {
+      console.error("Error recording failed re-pin attempt:", trackingError);
+    }
+
+    res.status(500).json(
+      errorResponse({
+        code: "RE_PIN_FAILED",
+        message: "Failed to re-pin CID",
+      })
+    );
+  }
+});
+
+export default router;

--- a/frontend/src/components/Admin/FactoryAdminPanel.tsx
+++ b/frontend/src/components/Admin/FactoryAdminPanel.tsx
@@ -10,6 +10,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { StellarService } from '../../services/stellar.service';
 import { TreasuryPolicyCard } from './TreasuryPolicyCard';
 import { TimelockConfigCard } from './TimelockConfigCard';
+import { IPFSPinMonitor } from './IPFSPinMonitor';
 import type { AdminPanelLoadState, AdminPanelState } from '../../types/admin';
 
 interface Props {
@@ -272,6 +273,11 @@ export function FactoryAdminPanel({ network = 'testnet', onPrivilegedAction }: P
               />
             </div>
           )}
+
+          {/* IPFS pin monitor — backend-backed section, independent of on-chain load state */}
+          <div className="md:col-span-2">
+            <IPFSPinMonitor />
+          </div>
         </div>
       )}
     </div>

--- a/frontend/src/components/Admin/IPFSPinMonitor.tsx
+++ b/frontend/src/components/Admin/IPFSPinMonitor.tsx
@@ -1,0 +1,281 @@
+/**
+ * IPFSPinMonitor (#1403)
+ *
+ * Admin dashboard section showing the current pin status of every tracked
+ * IPFS CID: pin status, last checked time, and failure count. Rows are
+ * color-coded so operators can spot trouble at a glance, and a "Re-Pin"
+ * button lets an operator manually trigger a re-pin attempt for a failing
+ * CID. The table auto-refreshes every 30 seconds.
+ */
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { apiClient } from '../../services/apiClient';
+
+const AUTO_REFRESH_INTERVAL_MS = 30_000;
+
+export type PinHealthStatus = 'pinned' | 'warning' | 'failed';
+
+export interface IPFSPinRecord {
+  cid: string;
+  tokenName: string | null;
+  tokenAddress: string | null;
+  pinned: boolean;
+  failureCount: number;
+  lastChecked: string | null;
+  error: string | null;
+  status: PinHealthStatus;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface PinsResponse {
+  success: boolean;
+  data?: { pins: IPFSPinRecord[]; total: number };
+  error?: { code: string; message: string };
+}
+
+interface RePinResponse {
+  success: boolean;
+  data?: Partial<IPFSPinRecord> & { message?: string };
+  error?: { code: string; message: string };
+}
+
+type LoadState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'loaded'; pins: IPFSPinRecord[]; loadedAt: number }
+  | { status: 'error'; message: string };
+
+/** Row background/text classes per the failure-count thresholds in the issue. */
+function rowClasses(status: PinHealthStatus): string {
+  switch (status) {
+    case 'pinned':
+      return 'bg-green-50 hover:bg-green-100';
+    case 'warning':
+      return 'bg-yellow-50 hover:bg-yellow-100';
+    case 'failed':
+      return 'bg-red-50 hover:bg-red-100';
+    default:
+      return '';
+  }
+}
+
+function statusBadgeClasses(status: PinHealthStatus): string {
+  switch (status) {
+    case 'pinned':
+      return 'bg-green-100 text-green-800';
+    case 'warning':
+      return 'bg-yellow-100 text-yellow-800';
+    case 'failed':
+      return 'bg-red-100 text-red-800';
+    default:
+      return 'bg-gray-100 text-gray-700';
+  }
+}
+
+function statusLabel(status: PinHealthStatus): string {
+  switch (status) {
+    case 'pinned':
+      return 'Pinned';
+    case 'warning':
+      return 'Warning';
+    case 'failed':
+      return 'Failed';
+    default:
+      return 'Unknown';
+  }
+}
+
+function formatLastChecked(value: string | null): string {
+  if (!value) return 'Never';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return 'Never';
+  return date.toLocaleString();
+}
+
+interface Props {
+  /** Override the auto-refresh interval (mainly for tests). */
+  refreshIntervalMs?: number;
+}
+
+export function IPFSPinMonitor({ refreshIntervalMs = AUTO_REFRESH_INTERVAL_MS }: Props = {}) {
+  const [loadState, setLoadState] = useState<LoadState>({ status: 'idle' });
+  const [rePinningCid, setRePinningCid] = useState<string | null>(null);
+  const [rePinMessage, setRePinMessage] = useState<{ cid: string; text: string; isError: boolean } | null>(
+    null
+  );
+  const isMountedRef = useRef(true);
+
+  const loadPins = useCallback(async (showSpinner = true) => {
+    if (showSpinner) setLoadState({ status: 'loading' });
+    try {
+      const res = await apiClient.get<PinsResponse>('/api/admin/ipfs/pins');
+      if (!isMountedRef.current) return;
+      if (!res.success || !res.data) {
+        throw new Error(res.error?.message ?? 'Failed to load IPFS pin status');
+      }
+      setLoadState({ status: 'loaded', pins: res.data.pins, loadedAt: Date.now() });
+    } catch (err) {
+      if (!isMountedRef.current) return;
+      setLoadState({
+        status: 'error',
+        message: err instanceof Error ? err.message : 'Unknown error loading IPFS pin status',
+      });
+    }
+  }, []);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    loadPins();
+
+    const interval = setInterval(() => {
+      loadPins(false);
+    }, refreshIntervalMs);
+
+    return () => {
+      isMountedRef.current = false;
+      clearInterval(interval);
+    };
+  }, [loadPins, refreshIntervalMs]);
+
+  const handleRePin = useCallback(
+    async (cid: string) => {
+      setRePinningCid(cid);
+      setRePinMessage(null);
+      try {
+        const res = await apiClient.post<RePinResponse>(`/api/admin/ipfs/re-pin/${encodeURIComponent(cid)}`);
+        if (!res.success) {
+          throw new Error(res.error?.message ?? 'Re-pin failed');
+        }
+        setRePinMessage({
+          cid,
+          text: res.data?.message ?? 'Re-pin triggered successfully',
+          isError: false,
+        });
+        // Refresh the table to reflect the updated pin record.
+        await loadPins(false);
+      } catch (err) {
+        setRePinMessage({
+          cid,
+          text: err instanceof Error ? err.message : 'Re-pin failed',
+          isError: true,
+        });
+      } finally {
+        setRePinningCid(null);
+      }
+    },
+    [loadPins]
+  );
+
+  return (
+    <div className="bg-white rounded-lg shadow-md border border-gray-200">
+      <div className="px-6 py-4 border-b border-gray-200 flex items-center gap-2">
+        <span className="text-lg">📌</span>
+        <h3 className="text-lg font-semibold text-gray-900">IPFS Pins</h3>
+        <span className="ml-auto text-xs bg-blue-100 text-blue-700 px-2 py-0.5 rounded-full font-medium">
+          Auto-refreshes every 30s
+        </span>
+      </div>
+
+      <div className="p-6">
+        {loadState.status === 'loaded' && (
+          <p className="text-xs text-gray-400 mb-3">
+            Last refreshed: {new Date(loadState.loadedAt).toLocaleTimeString()}
+          </p>
+        )}
+
+        {loadState.status === 'loading' && (
+          <div className="animate-pulse space-y-2">
+            <div className="h-4 bg-gray-100 rounded w-full" />
+            <div className="h-4 bg-gray-100 rounded w-full" />
+            <div className="h-4 bg-gray-100 rounded w-3/4" />
+          </div>
+        )}
+
+        {loadState.status === 'error' && (
+          <div role="alert" className="rounded-lg border border-red-300 bg-red-50 px-5 py-4 flex items-start gap-3">
+            <span className="text-red-500 text-lg">⚠️</span>
+            <div>
+              <p className="text-sm font-semibold text-red-800">Failed to load IPFS pin status</p>
+              <p className="text-xs text-red-600 mt-1">{loadState.message}</p>
+              <button
+                onClick={() => loadPins()}
+                className="mt-2 text-xs text-red-700 underline hover:no-underline"
+              >
+                Try again
+              </button>
+            </div>
+          </div>
+        )}
+
+        {loadState.status === 'loaded' && (
+          <>
+            {loadState.pins.length === 0 ? (
+              <p className="text-sm text-gray-400 italic">No CIDs are currently tracked.</p>
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="min-w-full text-sm">
+                  <thead>
+                    <tr className="text-left text-xs font-medium text-gray-500 uppercase tracking-wide border-b border-gray-200">
+                      <th className="py-2 pr-4">CID</th>
+                      <th className="py-2 pr-4">Token</th>
+                      <th className="py-2 pr-4">Status</th>
+                      <th className="py-2 pr-4">Last Checked</th>
+                      <th className="py-2 pr-4">Failures</th>
+                      <th className="py-2 pr-4">Action</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {loadState.pins.map((pin) => (
+                      <tr
+                        key={pin.cid}
+                        data-testid={`pin-row-${pin.cid}`}
+                        data-status={pin.status}
+                        className={`border-b border-gray-100 ${rowClasses(pin.status)}`}
+                      >
+                        <td className="py-2 pr-4 font-mono text-xs break-all" title={pin.cid}>
+                          {pin.cid}
+                        </td>
+                        <td className="py-2 pr-4">{pin.tokenName ?? <span className="text-gray-400 italic">—</span>}</td>
+                        <td className="py-2 pr-4">
+                          <span
+                            className={`text-xs font-semibold px-2 py-0.5 rounded-full ${statusBadgeClasses(
+                              pin.status
+                            )}`}
+                          >
+                            {statusLabel(pin.status)}
+                          </span>
+                        </td>
+                        <td className="py-2 pr-4 text-xs text-gray-600">{formatLastChecked(pin.lastChecked)}</td>
+                        <td className="py-2 pr-4 text-xs font-mono">{pin.failureCount}</td>
+                        <td className="py-2 pr-4">
+                          <button
+                            onClick={() => handleRePin(pin.cid)}
+                            disabled={rePinningCid === pin.cid}
+                            className="text-xs px-3 py-1.5 rounded border border-blue-300 text-blue-700 bg-blue-50 hover:bg-blue-100 font-medium transition-colors disabled:opacity-50"
+                          >
+                            {rePinningCid === pin.cid ? 'Re-Pinning…' : 'Re-Pin'}
+                          </button>
+                          {rePinMessage && rePinMessage.cid === pin.cid && (
+                            <p
+                              className={`text-xs mt-1 ${
+                                rePinMessage.isError ? 'text-red-600' : 'text-green-700'
+                              }`}
+                            >
+                              {rePinMessage.text}
+                            </p>
+                          )}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default IPFSPinMonitor;

--- a/frontend/src/components/Admin/__tests__/IPFSPinMonitor.test.tsx
+++ b/frontend/src/components/Admin/__tests__/IPFSPinMonitor.test.tsx
@@ -1,0 +1,194 @@
+/**
+ * IPFSPinMonitor — Component Tests (#1403)
+ *
+ * Verifies:
+ *   1. Pins render with the correct color-coded status per row
+ *      (pinned=green, warning=yellow, failed=red)
+ *   2. The Re-Pin button calls the re-pin endpoint and refreshes the table
+ *   3. Auto-refresh polls the list endpoint every 30 seconds
+ *   4. Error and empty states render correctly
+ */
+import React from 'react';
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { IPFSPinMonitor } from '../IPFSPinMonitor';
+import { apiClient } from '../../../services/apiClient';
+
+vi.mock('../../../services/apiClient', () => ({
+  apiClient: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+}));
+
+const PINNED_RECORD = {
+  cid: 'QmPinned111',
+  tokenName: 'GoodToken',
+  tokenAddress: '0xabc',
+  pinned: true,
+  failureCount: 0,
+  lastChecked: '2026-06-25T10:00:00.000Z',
+  error: null,
+  status: 'pinned' as const,
+  createdAt: '2026-06-20T10:00:00.000Z',
+  updatedAt: '2026-06-25T10:00:00.000Z',
+};
+
+const WARNING_RECORD = {
+  cid: 'QmWarning222',
+  tokenName: 'WarnToken',
+  tokenAddress: '0xdef',
+  pinned: false,
+  failureCount: 2,
+  lastChecked: '2026-06-25T09:00:00.000Z',
+  error: 'timeout',
+  status: 'warning' as const,
+  createdAt: '2026-06-20T10:00:00.000Z',
+  updatedAt: '2026-06-25T09:00:00.000Z',
+};
+
+const FAILED_RECORD = {
+  cid: 'QmFailed333',
+  tokenName: 'FailToken',
+  tokenAddress: '0xghi',
+  pinned: false,
+  failureCount: 5,
+  lastChecked: '2026-06-25T08:00:00.000Z',
+  error: 'not found',
+  status: 'failed' as const,
+  createdAt: '2026-06-20T10:00:00.000Z',
+  updatedAt: '2026-06-25T08:00:00.000Z',
+};
+
+function mockPinsResponse(pins: unknown[]) {
+  return {
+    success: true,
+    data: { pins, total: pins.length },
+  };
+}
+
+describe('IPFSPinMonitor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders rows color-coded by pin health status', async () => {
+    vi.mocked(apiClient.get).mockResolvedValueOnce(
+      mockPinsResponse([PINNED_RECORD, WARNING_RECORD, FAILED_RECORD])
+    );
+
+    render(<IPFSPinMonitor />);
+
+    await waitFor(() => expect(apiClient.get).toHaveBeenCalledWith('/api/admin/ipfs/pins'));
+
+    const pinnedRow = await screen.findByTestId(`pin-row-${PINNED_RECORD.cid}`);
+    const warningRow = screen.getByTestId(`pin-row-${WARNING_RECORD.cid}`);
+    const failedRow = screen.getByTestId(`pin-row-${FAILED_RECORD.cid}`);
+
+    expect(pinnedRow.className).toMatch(/bg-green-50/);
+    expect(pinnedRow.getAttribute('data-status')).toBe('pinned');
+
+    expect(warningRow.className).toMatch(/bg-yellow-50/);
+    expect(warningRow.getAttribute('data-status')).toBe('warning');
+
+    expect(failedRow.className).toMatch(/bg-red-50/);
+    expect(failedRow.getAttribute('data-status')).toBe('failed');
+
+    expect(screen.getByText('Pinned')).toBeTruthy();
+    expect(screen.getByText('Warning')).toBeTruthy();
+    expect(screen.getByText('Failed')).toBeTruthy();
+  });
+
+  it('shows an empty state when no CIDs are tracked', async () => {
+    vi.mocked(apiClient.get).mockResolvedValueOnce(mockPinsResponse([]));
+
+    render(<IPFSPinMonitor />);
+
+    expect(await screen.findByText(/No CIDs are currently tracked/)).toBeTruthy();
+  });
+
+  it('shows an error state when the list request fails', async () => {
+    vi.mocked(apiClient.get).mockRejectedValueOnce(new Error('Network error'));
+
+    render(<IPFSPinMonitor />);
+
+    expect(await screen.findByText(/Failed to load IPFS pin status/)).toBeTruthy();
+    expect(screen.getByText('Network error')).toBeTruthy();
+  });
+
+  it('calls the re-pin endpoint when the Re-Pin button is clicked and refreshes the table', async () => {
+    vi.mocked(apiClient.get)
+      .mockResolvedValueOnce(mockPinsResponse([FAILED_RECORD]))
+      .mockResolvedValueOnce(
+        mockPinsResponse([{ ...FAILED_RECORD, pinned: true, failureCount: 0, status: 'pinned' }])
+      );
+    vi.mocked(apiClient.post).mockResolvedValueOnce({
+      success: true,
+      data: { cid: FAILED_RECORD.cid, pinned: true, message: 'Re-pin successful' },
+    });
+
+    render(<IPFSPinMonitor />);
+
+    const rePinButton = await screen.findByRole('button', { name: 'Re-Pin' });
+    fireEvent.click(rePinButton);
+
+    await waitFor(() =>
+      expect(apiClient.post).toHaveBeenCalledWith(`/api/admin/ipfs/re-pin/${FAILED_RECORD.cid}`)
+    );
+
+    expect(await screen.findByText('Re-pin successful')).toBeTruthy();
+    // Table reload triggered after a successful re-pin
+    await waitFor(() => expect(apiClient.get).toHaveBeenCalledTimes(2));
+  });
+
+  it('shows an error message when the re-pin request fails', async () => {
+    vi.mocked(apiClient.get).mockResolvedValueOnce(mockPinsResponse([FAILED_RECORD]));
+    vi.mocked(apiClient.post).mockRejectedValueOnce(new Error('Pinata unavailable'));
+
+    render(<IPFSPinMonitor />);
+
+    const rePinButton = await screen.findByRole('button', { name: 'Re-Pin' });
+    fireEvent.click(rePinButton);
+
+    expect(await screen.findByText('Pinata unavailable')).toBeTruthy();
+  });
+
+  it('auto-refreshes the pin list on the configured interval', async () => {
+    vi.useFakeTimers();
+    vi.mocked(apiClient.get).mockResolvedValue(mockPinsResponse([PINNED_RECORD]));
+
+    render(<IPFSPinMonitor refreshIntervalMs={30_000} />);
+
+    await waitFor(() => expect(apiClient.get).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000);
+    });
+    expect(apiClient.get).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000);
+    });
+    expect(apiClient.get).toHaveBeenCalledTimes(3);
+  });
+
+  it('clears the auto-refresh interval on unmount', async () => {
+    vi.useFakeTimers();
+    vi.mocked(apiClient.get).mockResolvedValue(mockPinsResponse([PINNED_RECORD]));
+
+    const { unmount } = render(<IPFSPinMonitor refreshIntervalMs={30_000} />);
+    await waitFor(() => expect(apiClient.get).toHaveBeenCalledTimes(1));
+
+    unmount();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+    // No further calls should have been made after unmount
+    expect(apiClient.get).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds an `IPFSPin` Prisma model to durably track pin status (cid, tokenName, tokenAddress, pinned, failureCount, lastChecked, error) so the admin dashboard doesn't need to re-query Pinata on every page load. Includes a hand-written migration (`backend/prisma/migrations/20260625000000_add_ipfs_pin/migration.sql`) following the existing migrations directory naming convention, since `prisma migrate dev` cannot be run against a live database in this environment — **please regenerate/verify this migration with `prisma migrate dev` against a real database before relying on it in production.**
- Adds `GET /api/admin/ipfs/pins` (lists all tracked CIDs with a derived health status: `pinned`/`warning`/`failed`) and `POST /api/admin/ipfs/re-pin/:cid` (re-pins via Pinata's `pinByHash` API through the existing `pinataQueue` throttle, verifies via `checkPinStatus`, persists the outcome, and records the attempt via `MetricsCollector.recordIPFSOperation`).
- Adds an "IPFS Pins" section (`IPFSPinMonitor.tsx`) to the admin panel, integrated into `FactoryAdminPanel.tsx`, showing CID, token name, pin status, last checked, and failure count per row. Rows are color-coded: green (pinned), yellow (warning, failureCount > 1), red (failed, failureCount > 3). Each row has a "Re-Pin" button calling the new endpoint via the shared `apiClient`. The table auto-refreshes every 30 seconds and cleans up the interval on unmount.
- Backend tests: `backend/src/routes/admin/__tests__/ipfs.test.ts` (list endpoint, re-pin success/failure/validation/auth paths).
- Frontend tests: `frontend/src/components/Admin/__tests__/IPFSPinMonitor.test.tsx` (color-coded states, re-pin button action, auto-refresh interval, cleanup on unmount, error/empty states).

Closes #1403

## Test plan

Automated tests were written but not executed per task instructions (no `npm test`/`npm run lint`/`npm run type-check` was run in this environment). Manual verification checklist for reviewers:

- [ ] Run `prisma migrate dev` (or `prisma db push` in a dev environment) to materialize the `IPFSPin` table from `backend/prisma/schema.prisma`.
- [ ] Run `npm test` in `backend/` — confirm `backend/src/routes/admin/__tests__/ipfs.test.ts` passes.
- [ ] Run `npm test` in `frontend/` — confirm `frontend/src/components/Admin/__tests__/IPFSPinMonitor.test.tsx` passes.
- [ ] Run `npm run type-check` / `tsc --noEmit` in both `backend/` and `frontend/` to confirm no type errors (e.g. the Prisma client's generated `iPFSPin` accessor name for the `IPFSPin` model).
- [ ] Seed at least one row in `IPFSPin` (or trigger a re-pin) and load the admin panel — confirm the "IPFS Pins" section renders with correct color-coding for pinned/warning/failed rows.
- [ ] Click "Re-Pin" on a row and confirm it calls `POST /api/admin/ipfs/re-pin/:cid`, shows a success/error message, and refreshes the table.
- [ ] Confirm the table re-fetches `GET /api/admin/ipfs/pins` every 30 seconds while the panel is mounted, and stops polling after navigating away/unmounting.
- [ ] Confirm `GET /api/admin/ipfs/pins` and `POST /api/admin/ipfs/re-pin/:cid` both require `authenticateAdmin` (return 401 without a valid admin token).

## Known limitations

- The Prisma migration was hand-written rather than generated by `prisma migrate dev`, because no live database is available in this development environment. The SQL closely mirrors the schema and follows the existing migration file format, but should be verified/regenerated before deploying.
- `pinMonitor.ts`'s in-memory `Set<string>` of monitored CIDs is not yet wired up to automatically populate the new `IPFSPin` table on startup — the table is populated as CIDs are checked/re-pinned through the new admin endpoints. A follow-up could have `startPinMonitor`'s `onUnpinned` callback upsert into `IPFSPin` directly so the dashboard reflects background monitor activity in addition to manual re-pin actions.