### PR TITLE
test(load): GraphQL subscription throughput under 200 concurrent WebSocket connections

### DIFF
--- a/load-tests/lib/graphql-subscription-helpers.js
+++ b/load-tests/lib/graphql-subscription-helpers.js
@@ -1,0 +1,222 @@
+/**
+ * Pure helper functions for the GraphQL subscription load scenario
+ * (200 concurrent `tokenDeployed` WebSocket subscribers, 100 emitted events).
+ *
+ * These helpers contain no k6 imports and are unit-testable with vitest.
+ */
+
+/**
+ * Build the `tokenDeployed` subscription document, optionally filtered by
+ * creator address (matches the scenario's tenant-scoped test data).
+ *
+ * @param {string} [creatorAddress]
+ * @returns {string}
+ */
+export function buildTokenDeployedSubscriptionQuery(creatorAddress) {
+  const args = creatorAddress ? `(creatorAddress: "${creatorAddress}")` : '';
+  return `subscription TokenDeployedLoad {
+    tokenDeployed${args} {
+      tokenAddress
+      name
+      symbol
+      totalSupply
+      txHash
+      timestamp
+    }
+  }`;
+}
+
+/**
+ * Build a graphql-ws `subscribe` protocol message.
+ *
+ * @param {string} id            Unique operation id for this connection.
+ * @param {string} query         GraphQL subscription document.
+ * @param {object} [variables]
+ * @returns {string} JSON-encoded message ready to send over the socket.
+ */
+export function buildSubscribeMessage(id, query, variables = {}) {
+  return JSON.stringify({
+    id,
+    type: 'subscribe',
+    payload: { query, variables },
+  });
+}
+
+/**
+ * Build a graphql-ws `connection_init` protocol message carrying the bearer
+ * token used for tenant resolution on the server's `onConnect` handshake.
+ *
+ * @param {string} jwt
+ * @returns {string}
+ */
+export function buildConnectionInitMessage(jwt) {
+  return JSON.stringify({
+    type: 'connection_init',
+    payload: { authorization: `Bearer ${jwt}` },
+  });
+}
+
+/**
+ * Safely parse a raw WebSocket text frame as JSON.
+ *
+ * @param {string} raw
+ * @returns {object|null} Parsed message, or null if not valid JSON.
+ */
+export function parseWsMessage(raw) {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * True when `msg` is a graphql-ws `next` event delivering data for the
+ * given subscription operation id.
+ *
+ * @param {object|null} msg
+ * @param {string} id
+ * @returns {boolean}
+ */
+export function isNextMessageForSubscription(msg, id) {
+  return Boolean(msg) && msg.type === 'next' && msg.id === id && Boolean(msg.payload?.data);
+}
+
+/**
+ * Extract the `ts` (emitted-at epoch ms) query parameter embedded in a
+ * synthetic `metadataUri`, used to approximate end-to-end delivery latency
+ * without requiring shared state across k6 VUs.
+ *
+ * @param {string|null|undefined} metadataUri
+ * @returns {number|null}
+ */
+export function extractEmittedAtFromMetadataUri(metadataUri) {
+  if (!metadataUri) return null;
+  const match = /[?&]ts=(\d+)/.exec(metadataUri);
+  if (!match) return null;
+  const ts = parseInt(match[1], 10);
+  return Number.isFinite(ts) ? ts : null;
+}
+
+/**
+ * Compute message delivery latency in milliseconds.
+ *
+ * @param {number} receivedAtMs
+ * @param {number|null} emittedAtMs
+ * @returns {number|null} null when emittedAtMs is unavailable.
+ */
+export function computeMessageLatencyMs(receivedAtMs, emittedAtMs) {
+  if (emittedAtMs === null || emittedAtMs === undefined) return null;
+  return Math.max(0, receivedAtMs - emittedAtMs);
+}
+
+/**
+ * Build one synthetic token-deploy input for the `/api/tokens/batch`
+ * endpoint, embedding the emission timestamp in `metadataUri` for latency
+ * tracking by subscribers.
+ *
+ * @param {string} creator     Tenant/creator address shared by the whole run.
+ * @param {number} index       Global event index (0-based) — kept unique.
+ * @param {number} sentAtMs    Epoch ms when this batch is being sent.
+ * @returns {object}
+ */
+export function buildBatchTokenPayload(creator, index, sentAtMs) {
+  return {
+    creator,
+    name: `Load Test Token ${index}`,
+    symbol: `LT${index}`,
+    decimals: 7,
+    initialSupply: '1000000',
+    metadataUri: `https://load-test.local/meta?ts=${sentAtMs}&i=${index}`,
+  };
+}
+
+/**
+ * Split a flat array into chunks of at most `size` items — used to respect
+ * the `/api/tokens/batch` endpoint's per-request item cap.
+ *
+ * @param {Array<*>} items
+ * @param {number} size
+ * @returns {Array<Array<*>>}
+ */
+export function chunkIntoBatches(items, size) {
+  const chunks = [];
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size));
+  }
+  return chunks;
+}
+
+/**
+ * Summarize per-subscriber message counts into an overall pass/fail report.
+ *
+ * @param {Array<{ received: number }>} subscriberResults
+ * @param {number} expectedPerSubscriber
+ * @returns {{ totalSubscribers: number, expectedPerSubscriber: number,
+ *             subscribersWithLoss: number, subscribersWithDuplicates: number,
+ *             totalMessagesReceived: number, passed: boolean }}
+ */
+export function summarizeSubscriberResults(subscriberResults, expectedPerSubscriber) {
+  let subscribersWithLoss = 0;
+  let subscribersWithDuplicates = 0;
+  let totalMessagesReceived = 0;
+
+  for (const r of subscriberResults) {
+    totalMessagesReceived += r.received;
+    if (r.received < expectedPerSubscriber) subscribersWithLoss += 1;
+    if (r.received > expectedPerSubscriber) subscribersWithDuplicates += 1;
+  }
+
+  return {
+    totalSubscribers: subscriberResults.length,
+    expectedPerSubscriber,
+    subscribersWithLoss,
+    subscribersWithDuplicates,
+    totalMessagesReceived,
+    passed:
+      subscriberResults.length > 0 &&
+      subscribersWithLoss === 0 &&
+      subscribersWithDuplicates === 0,
+  };
+}
+
+/**
+ * Assess whether server memory growth across the run stays within budget.
+ *
+ * @param {number} beforeBytes
+ * @param {number} afterBytes
+ * @param {number} maxGrowthBytes
+ * @returns {{ growthBytes: number, withinBudget: boolean }}
+ */
+export function assessMemoryGrowth(beforeBytes, afterBytes, maxGrowthBytes) {
+  const growthBytes = afterBytes - beforeBytes;
+  return { growthBytes, withinBudget: growthBytes < maxGrowthBytes };
+}
+
+/**
+ * Format the final run summary for stdout.
+ *
+ * @param {ReturnType<typeof summarizeSubscriberResults>} report
+ * @param {{ growthBytes: number, withinBudget: boolean }} memory
+ * @param {{ p99: number }} latency
+ * @param {string} [timestamp]
+ * @returns {string}
+ */
+export function formatSubscriptionLoadSummary(report, memory, latency, timestamp = new Date().toISOString()) {
+  const status = report.passed && memory.withinBudget ? 'PASSED' : 'FAILED';
+  return [
+    '',
+    `=== GraphQL Subscription Load (200 connections) — ${status} ===`,
+    `  Timestamp              : ${timestamp}`,
+    `  Subscribers             : ${report.totalSubscribers}`,
+    `  Expected msgs/subscriber: ${report.expectedPerSubscriber}`,
+    `  Total messages received : ${report.totalMessagesReceived}`,
+    `  Subscribers with loss   : ${report.subscribersWithLoss}`,
+    `  Subscribers with dupes  : ${report.subscribersWithDuplicates}`,
+    '',
+    `  Message latency p99 (ms): ${latency.p99.toFixed(1)}  (threshold: < 500)`,
+    '',
+    `  Memory growth (MB)      : ${(memory.growthBytes / (1024 * 1024)).toFixed(2)}  (threshold: < 50)`,
+    '',
+  ].join('\n');
+}

--- a/load-tests/package.json
+++ b/load-tests/package.json
@@ -12,6 +12,7 @@
     "test:search": "k6 run scenarios/search-load.js",
     "test:ci": "k6 run --env CI_VUS=10 --env CI_DURATION=60 scenarios/ci-load.js",
     "test:concurrent-deploy": "k6 run scenarios/concurrent-deploy.js",
+    "test:graphql-subscription-load": "k6 run scenarios/graphql-subscription-load.js",
     "test:all": "npm run test:normal && npm run test:peak && npm run test:stress",
     "test:unit": "vitest run",
     "test:unit:coverage": "vitest run --coverage",

--- a/load-tests/scenarios/graphql-subscription-load.js
+++ b/load-tests/scenarios/graphql-subscription-load.js
@@ -1,0 +1,257 @@
+/**
+ * GraphQL Subscription Throughput — 200 Concurrent WebSocket Connections
+ * load-tests/scenarios/graphql-subscription-load.js
+ *
+ * Opens SUB_VUS (default 200) concurrent `graphql-ws` connections subscribed
+ * to `tokenDeployed`, then drives EVENT_COUNT (default 100) real deploy
+ * events through the existing `POST /api/tokens/batch` endpoint (the same
+ * endpoint that powers `batchTokenDeployService`'s `eventBus.publish(
+ * "token.deployed", ...)` call) and asserts every subscriber receives every
+ * event exactly once, with bounded delivery latency and bounded server
+ * memory growth.
+ *
+ * Topology (two scenarios sharing one run, staggered by startTime so every
+ * subscriber is connected and subscribed before the emitter fires):
+ *   - "subscribers" : SUB_VUS VUs, 1 iteration each, open+listen for LISTEN_WINDOW_MS
+ *   - "emitter"     : 1 VU,        1 iteration,      starts EMIT_START_DELAY_MS in
+ *
+ * IMPORTANT — known contract risk this load test is designed to surface:
+ * `batchTokenDeployService.deployToken` publishes `{ address, creator, ... }`
+ * onto the eventBus, while the subscription resolver's tenant filter
+ * (`tenantOwnsEvent`) and `TokenDeployedPayload` type expect `creatorAddress`
+ * / `tokenAddress` / `txHash` / `timestamp`. If those field names have not
+ * been reconciled, every subscriber will legitimately receive zero messages
+ * and this scenario's thresholds will fail — that is the load test correctly
+ * catching a real producer/consumer mismatch, not a bug in the scenario.
+ *
+ * Thresholds:
+ *   sub_message_latency_ms : p99 < 500 ms
+ *   sub_loss_events        : count == 0  (zero message loss)
+ *   sub_duplicate_events    : count == 0  (zero duplicate delivery)
+ *   memory_growth_bytes     : < 50 MB
+ *
+ * Environment variables:
+ *   BASE_URL            API base URL, http(s) (default: http://localhost:3001)
+ *   WS_PATH             GraphQL WS path (default: /graphql)
+ *   SUB_VUS             Concurrent subscribers (default: 200)
+ *   EVENT_COUNT         Events emitted (default: 100)
+ *   BATCH_SIZE          Tokens per /api/tokens/batch request (default: 10, server max)
+ *   JWT_SECRET           Must match the server's JWT_SECRET (default: dev-secret-key)
+ *   LISTEN_WINDOW_MS     How long each subscriber stays connected (default: 25000)
+ *   EMIT_START_DELAY_MS  Delay before the emitter fires, to let subscriptions
+ *                        establish first (default: 8000)
+ *
+ * Run:
+ *   k6 run load-tests/scenarios/graphql-subscription-load.js
+ */
+
+import ws from 'k6/ws';
+import http from 'k6/http';
+import crypto from 'k6/crypto';
+import encoding from 'k6/encoding';
+import { check, sleep } from 'k6';
+import { Trend, Counter, Gauge } from 'k6/metrics';
+import { config } from '../config/test-config.js';
+import {
+  buildTokenDeployedSubscriptionQuery,
+  buildSubscribeMessage,
+  buildConnectionInitMessage,
+  parseWsMessage,
+  isNextMessageForSubscription,
+  extractEmittedAtFromMetadataUri,
+  computeMessageLatencyMs,
+  buildBatchTokenPayload,
+  chunkIntoBatches,
+} from '../lib/graphql-subscription-helpers.js';
+
+// ── Parameters ────────────────────────────────────────────────────────────
+
+const BASE_URL = __ENV.BASE_URL || config.baseUrl;
+const WS_PATH = __ENV.WS_PATH || '/graphql';
+const SUB_VUS = parseInt(__ENV.SUB_VUS || '200');
+const EVENT_COUNT = parseInt(__ENV.EVENT_COUNT || '100');
+const BATCH_SIZE = parseInt(__ENV.BATCH_SIZE || '10');
+const JWT_SECRET = __ENV.JWT_SECRET || 'dev-secret-key';
+const LISTEN_WINDOW_MS = parseInt(__ENV.LISTEN_WINDOW_MS || '25000');
+const EMIT_START_DELAY_MS = parseInt(__ENV.EMIT_START_DELAY_MS || '8000');
+const MAX_MEMORY_GROWTH_BYTES = 50 * 1024 * 1024;
+
+const WS_URL = `${BASE_URL.replace(/^http/, 'ws')}${WS_PATH}`;
+const CREATOR = 'LOADTESTSUBSCRIPTIONCREATOR01';
+const GRAPHQL_WS_PROTOCOL = 'graphql-transport-ws';
+
+// ── Custom metrics ────────────────────────────────────────────────────────
+
+const messageLatency = new Trend('sub_message_latency_ms');
+const receivedPerSubscriber = new Trend('sub_received_count');
+const lossEvents = new Counter('sub_loss_events');
+const duplicateEvents = new Counter('sub_duplicate_events');
+const memoryGrowthBytes = new Gauge('memory_growth_bytes');
+const emitAckRate = new Counter('emit_batches_acknowledged');
+
+// ── Options ───────────────────────────────────────────────────────────────
+
+export const options = {
+  scenarios: {
+    subscribers: {
+      executor: 'per-vu-iterations',
+      vus: SUB_VUS,
+      iterations: 1,
+      maxDuration: `${Math.ceil(LISTEN_WINDOW_MS / 1000) + 30}s`,
+      exec: 'subscriberScenario',
+    },
+    emitter: {
+      executor: 'shared-iterations',
+      vus: 1,
+      iterations: 1,
+      startTime: `${EMIT_START_DELAY_MS}ms`,
+      maxDuration: '30s',
+      exec: 'emitterScenario',
+    },
+  },
+  thresholds: {
+    sub_message_latency_ms: ['p(99)<500'],
+    sub_loss_events: ['count<1'],
+    sub_duplicate_events: ['count<1'],
+    memory_growth_bytes: [`value<${MAX_MEMORY_GROWTH_BYTES}`],
+  },
+  tags: { test_type: 'graphql_subscription_load' },
+};
+
+// ── JWT (HS256) — must match the server's connection_init JWT contract ────
+
+function signJwtHS256(payload, secret) {
+  const headerB64 = encoding.b64encode(JSON.stringify({ alg: 'HS256', typ: 'JWT' }), 'rawurl');
+  const payloadB64 = encoding.b64encode(JSON.stringify(payload), 'rawurl');
+  const signingInput = `${headerB64}.${payloadB64}`;
+  const signature = crypto.hmac('sha256', secret, signingInput, 'rawurl');
+  return `${signingInput}.${signature}`;
+}
+
+// ── Lifecycle hooks ────────────────────────────────────────────────────────
+
+export function setup() {
+  const before = http.get(`${BASE_URL}/health`).json('data.metrics.memory.used') || 0;
+  const jwt = signJwtHS256(
+    { tenantId: CREATOR, iat: Math.floor(Date.now() / 1000), exp: Math.floor(Date.now() / 1000) + 3600 },
+    JWT_SECRET
+  );
+  return { jwt, creator: CREATOR, beforeMemoryBytes: before };
+}
+
+export function teardown(data) {
+  const after = http.get(`${BASE_URL}/health`).json('data.metrics.memory.used') || 0;
+  memoryGrowthBytes.add(after - data.beforeMemoryBytes);
+}
+
+// ── Subscriber VU ─────────────────────────────────────────────────────────
+
+export function subscriberScenario(data) {
+  const opId = `op-${__VU}`;
+  const query = buildTokenDeployedSubscriptionQuery(data.creator);
+  let received = 0;
+
+  const res = ws.connect(
+    WS_URL,
+    { headers: { 'Sec-WebSocket-Protocol': GRAPHQL_WS_PROTOCOL } },
+    (socket) => {
+      socket.on('open', () => {
+        socket.send(buildConnectionInitMessage(data.jwt));
+      });
+
+      socket.on('message', (raw) => {
+        const msg = parseWsMessage(raw);
+        if (!msg) return;
+
+        if (msg.type === 'connection_ack') {
+          socket.send(buildSubscribeMessage(opId, query));
+          return;
+        }
+
+        if (isNextMessageForSubscription(msg, opId)) {
+          received += 1;
+          const emittedAt = extractEmittedAtFromMetadataUri(msg.payload.data?.tokenDeployed?.metadataUri);
+          const latency = computeMessageLatencyMs(Date.now(), emittedAt);
+          if (latency !== null) messageLatency.add(latency);
+        }
+      });
+
+      socket.setTimeout(() => socket.close(), LISTEN_WINDOW_MS);
+    }
+  );
+
+  check(res, { 'websocket handshake succeeded': (r) => r && r.status === 101 });
+
+  receivedPerSubscriber.add(received);
+  if (received < EVENT_COUNT) lossEvents.add(1);
+  if (received > EVENT_COUNT) duplicateEvents.add(1);
+}
+
+// ── Emitter VU ─────────────────────────────────────────────────────────────
+
+export function emitterScenario(data) {
+  const tokens = Array.from({ length: EVENT_COUNT }, (_, i) =>
+    buildBatchTokenPayload(data.creator, i, Date.now())
+  );
+
+  for (const batch of chunkIntoBatches(tokens, BATCH_SIZE)) {
+    const res = http.post(
+      `${BASE_URL}/api/tokens/batch`,
+      JSON.stringify({ tokens: batch }),
+      {
+        headers: { 'Content-Type': 'application/json', 'X-Tenant-ID': data.creator },
+        tags: { name: 'BatchTokenDeploy' },
+      }
+    );
+
+    const ok = res.status === 200 || res.status === 207;
+    emitAckRate.add(ok ? 1 : 0);
+    check(res, { 'batch deploy accepted (200/207)': () => ok });
+
+    sleep(0.2);
+  }
+}
+
+// ── Summary ───────────────────────────────────────────────────────────────
+
+export function handleSummary(data) {
+  const recv = data.metrics.sub_received_count?.values ?? {};
+  const lat99 = data.metrics.sub_message_latency_ms?.values?.['p(99)'] ?? 0;
+  const loss = data.metrics.sub_loss_events?.values?.count ?? 0;
+  const dupes = data.metrics.sub_duplicate_events?.values?.count ?? 0;
+  const growth = data.metrics.memory_growth_bytes?.values?.value ?? 0;
+
+  const passed = loss === 0 && dupes === 0 && lat99 < 500 && growth < MAX_MEMORY_GROWTH_BYTES;
+  const status = passed ? 'PASSED' : 'FAILED';
+
+  const summary = {
+    passed,
+    timestamp: new Date().toISOString(),
+    subscribers: SUB_VUS,
+    eventsEmitted: EVENT_COUNT,
+    messagesPerSubscriber: { min: recv.min ?? 0, max: recv.max ?? 0, avg: recv.avg ?? 0 },
+    lossEvents: loss,
+    duplicateEvents: dupes,
+    latencyP99Ms: lat99,
+    memoryGrowthBytes: growth,
+  };
+
+  const lines = [
+    '',
+    `=== GraphQL Subscription Load (${SUB_VUS} connections) — ${status} ===`,
+    `  Timestamp           : ${summary.timestamp}`,
+    `  Subscribers         : ${SUB_VUS}`,
+    `  Events emitted      : ${EVENT_COUNT}`,
+    `  Msgs/subscriber     : min ${summary.messagesPerSubscriber.min} · max ${summary.messagesPerSubscriber.max} · avg ${summary.messagesPerSubscriber.avg.toFixed(1)}`,
+    `  Subscribers w/ loss : ${loss}`,
+    `  Subscribers w/ dupes: ${dupes}`,
+    `  Latency p99 (ms)    : ${lat99.toFixed(1)}  (threshold: < 500)`,
+    `  Memory growth (MB)  : ${(growth / (1024 * 1024)).toFixed(2)}  (threshold: < 50)`,
+    '',
+  ].join('\n');
+
+  return {
+    'load-tests/results/graphql-subscription-load-summary.json': JSON.stringify(summary, null, 2),
+    stdout: lines,
+  };
+}

--- a/load-tests/scripts/graphql-subscription-helpers.test.js
+++ b/load-tests/scripts/graphql-subscription-helpers.test.js
@@ -1,0 +1,232 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildTokenDeployedSubscriptionQuery,
+  buildSubscribeMessage,
+  buildConnectionInitMessage,
+  parseWsMessage,
+  isNextMessageForSubscription,
+  extractEmittedAtFromMetadataUri,
+  computeMessageLatencyMs,
+  buildBatchTokenPayload,
+  chunkIntoBatches,
+  summarizeSubscriberResults,
+  assessMemoryGrowth,
+  formatSubscriptionLoadSummary,
+} from '../lib/graphql-subscription-helpers.js';
+
+// ── buildTokenDeployedSubscriptionQuery ───────────────────────────────────
+
+describe('buildTokenDeployedSubscriptionQuery', () => {
+  it('includes the creatorAddress filter when provided', () => {
+    const q = buildTokenDeployedSubscriptionQuery('GCREATOR1');
+    expect(q).toContain('creatorAddress: "GCREATOR1"');
+    expect(q).toContain('tokenDeployed');
+  });
+
+  it('omits the filter argument when no creator is provided', () => {
+    const q = buildTokenDeployedSubscriptionQuery();
+    expect(q).not.toContain('creatorAddress');
+  });
+});
+
+// ── buildSubscribeMessage / buildConnectionInitMessage ────────────────────
+
+describe('buildSubscribeMessage', () => {
+  it('produces a valid graphql-ws subscribe envelope', () => {
+    const msg = JSON.parse(buildSubscribeMessage('op-1', 'subscription { x }', { a: 1 }));
+    expect(msg).toEqual({ id: 'op-1', type: 'subscribe', payload: { query: 'subscription { x }', variables: { a: 1 } } });
+  });
+});
+
+describe('buildConnectionInitMessage', () => {
+  it('wraps the JWT as a Bearer authorization payload', () => {
+    const msg = JSON.parse(buildConnectionInitMessage('abc.def.ghi'));
+    expect(msg).toEqual({ type: 'connection_init', payload: { authorization: 'Bearer abc.def.ghi' } });
+  });
+});
+
+// ── parseWsMessage ─────────────────────────────────────────────────────────
+
+describe('parseWsMessage', () => {
+  it('parses valid JSON', () => {
+    expect(parseWsMessage('{"a":1}')).toEqual({ a: 1 });
+  });
+
+  it('returns null for invalid JSON', () => {
+    expect(parseWsMessage('not json')).toBeNull();
+  });
+});
+
+// ── isNextMessageForSubscription ──────────────────────────────────────────
+
+describe('isNextMessageForSubscription', () => {
+  it('matches a well-formed next message for the given id', () => {
+    const msg = { id: 'op-1', type: 'next', payload: { data: { tokenDeployed: {} } } };
+    expect(isNextMessageForSubscription(msg, 'op-1')).toBe(true);
+  });
+
+  it('rejects messages for a different operation id', () => {
+    const msg = { id: 'op-2', type: 'next', payload: { data: {} } };
+    expect(isNextMessageForSubscription(msg, 'op-1')).toBe(false);
+  });
+
+  it('rejects non-next message types', () => {
+    expect(isNextMessageForSubscription({ id: 'op-1', type: 'complete' }, 'op-1')).toBe(false);
+  });
+
+  it('rejects null messages', () => {
+    expect(isNextMessageForSubscription(null, 'op-1')).toBe(false);
+  });
+
+  it('rejects next messages with no payload data', () => {
+    expect(isNextMessageForSubscription({ id: 'op-1', type: 'next', payload: {} }, 'op-1')).toBe(false);
+  });
+});
+
+// ── extractEmittedAtFromMetadataUri ───────────────────────────────────────
+
+describe('extractEmittedAtFromMetadataUri', () => {
+  it('extracts the ts query param', () => {
+    expect(extractEmittedAtFromMetadataUri('https://x.local/meta?ts=1700000000000&i=3')).toBe(1700000000000);
+  });
+
+  it('returns null when ts is absent', () => {
+    expect(extractEmittedAtFromMetadataUri('https://x.local/meta?i=3')).toBeNull();
+  });
+
+  it('returns null for null/undefined input', () => {
+    expect(extractEmittedAtFromMetadataUri(null)).toBeNull();
+    expect(extractEmittedAtFromMetadataUri(undefined)).toBeNull();
+  });
+});
+
+// ── computeMessageLatencyMs ────────────────────────────────────────────────
+
+describe('computeMessageLatencyMs', () => {
+  it('computes the difference between receipt and emission time', () => {
+    expect(computeMessageLatencyMs(1000, 800)).toBe(200);
+  });
+
+  it('clamps negative latency (clock skew) to zero', () => {
+    expect(computeMessageLatencyMs(800, 1000)).toBe(0);
+  });
+
+  it('returns null when emittedAtMs is unavailable', () => {
+    expect(computeMessageLatencyMs(1000, null)).toBeNull();
+  });
+});
+
+// ── buildBatchTokenPayload ─────────────────────────────────────────────────
+
+describe('buildBatchTokenPayload', () => {
+  it('builds a schema-shaped token input with a unique symbol per index', () => {
+    const token = buildBatchTokenPayload('GCREATOR1', 7, 1700000000000);
+    expect(token.creator).toBe('GCREATOR1');
+    expect(token.symbol).toBe('LT7');
+    expect(token.decimals).toBe(7);
+    expect(token.initialSupply).toBe('1000000');
+    expect(token.metadataUri).toContain('ts=1700000000000');
+    expect(token.metadataUri).toContain('i=7');
+  });
+
+  it('produces a valid URL for metadataUri', () => {
+    const token = buildBatchTokenPayload('GCREATOR1', 0, 1700000000000);
+    expect(() => new URL(token.metadataUri)).not.toThrow();
+  });
+});
+
+// ── chunkIntoBatches ───────────────────────────────────────────────────────
+
+describe('chunkIntoBatches', () => {
+  it('splits evenly divisible arrays', () => {
+    const chunks = chunkIntoBatches(Array.from({ length: 100 }, (_, i) => i), 10);
+    expect(chunks).toHaveLength(10);
+    expect(chunks[0]).toHaveLength(10);
+  });
+
+  it('handles a remainder chunk', () => {
+    const chunks = chunkIntoBatches(Array.from({ length: 23 }, (_, i) => i), 10);
+    expect(chunks).toHaveLength(3);
+    expect(chunks[2]).toHaveLength(3);
+  });
+
+  it('returns an empty array for empty input', () => {
+    expect(chunkIntoBatches([], 10)).toEqual([]);
+  });
+});
+
+// ── summarizeSubscriberResults ─────────────────────────────────────────────
+
+describe('summarizeSubscriberResults', () => {
+  it('passes when every subscriber received exactly the expected count', () => {
+    const results = Array.from({ length: 200 }, () => ({ received: 100 }));
+    const report = summarizeSubscriberResults(results, 100);
+    expect(report.passed).toBe(true);
+    expect(report.subscribersWithLoss).toBe(0);
+    expect(report.subscribersWithDuplicates).toBe(0);
+    expect(report.totalMessagesReceived).toBe(20000);
+  });
+
+  it('flags subscribers with message loss', () => {
+    const results = [{ received: 100 }, { received: 97 }];
+    const report = summarizeSubscriberResults(results, 100);
+    expect(report.passed).toBe(false);
+    expect(report.subscribersWithLoss).toBe(1);
+  });
+
+  it('flags subscribers with duplicate delivery', () => {
+    const results = [{ received: 100 }, { received: 103 }];
+    const report = summarizeSubscriberResults(results, 100);
+    expect(report.passed).toBe(false);
+    expect(report.subscribersWithDuplicates).toBe(1);
+  });
+
+  it('fails when there are zero subscribers', () => {
+    expect(summarizeSubscriberResults([], 100).passed).toBe(false);
+  });
+});
+
+// ── assessMemoryGrowth ─────────────────────────────────────────────────────
+
+describe('assessMemoryGrowth', () => {
+  const MB = 1024 * 1024;
+
+  it('passes when growth is under budget', () => {
+    const result = assessMemoryGrowth(100 * MB, 130 * MB, 50 * MB);
+    expect(result.growthBytes).toBe(30 * MB);
+    expect(result.withinBudget).toBe(true);
+  });
+
+  it('fails when growth meets or exceeds budget', () => {
+    const result = assessMemoryGrowth(100 * MB, 151 * MB, 50 * MB);
+    expect(result.withinBudget).toBe(false);
+  });
+
+  it('treats memory shrinkage as zero-risk', () => {
+    const result = assessMemoryGrowth(150 * MB, 100 * MB, 50 * MB);
+    expect(result.growthBytes).toBe(-50 * MB);
+    expect(result.withinBudget).toBe(true);
+  });
+});
+
+// ── formatSubscriptionLoadSummary ──────────────────────────────────────────
+
+describe('formatSubscriptionLoadSummary', () => {
+  const ts = '2026-01-01T00:00:00.000Z';
+
+  it('reports PASSED when both the report and memory budget pass', () => {
+    const report = summarizeSubscriberResults(Array.from({ length: 200 }, () => ({ received: 100 })), 100);
+    const memory = assessMemoryGrowth(100 * 1024 * 1024, 110 * 1024 * 1024, 50 * 1024 * 1024);
+    const text = formatSubscriptionLoadSummary(report, memory, { p99: 120 }, ts);
+    expect(text).toContain('PASSED');
+    expect(text).toContain('200');
+    expect(text).toContain(ts);
+  });
+
+  it('reports FAILED when message loss occurred', () => {
+    const report = summarizeSubscriberResults([{ received: 50 }], 100);
+    const memory = assessMemoryGrowth(100 * 1024 * 1024, 110 * 1024 * 1024, 50 * 1024 * 1024);
+    const text = formatSubscriptionLoadSummary(report, memory, { p99: 120 }, ts);
+    expect(text).toContain('FAILED');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `load-tests/scenarios/graphql-subscription-load.js`: opens 200 concurrent `graphql-ws` connections subscribed to `tokenDeployed`, then drives 100 real deploy events through the existing `POST /api/tokens/batch` endpoint (chunked into the server's max-10-per-request batches), and asserts every subscriber receives every event exactly once (zero loss, zero duplicates), with p99 delivery latency < 500ms and server heap growth < 50MB (sampled via `GET /health` before/after).
- Adds `load-tests/lib/graphql-subscription-helpers.js`, a set of pure (no-k6-import) helpers — message building/parsing, latency computation, batch chunking, result summarization — plus its Vitest unit test `load-tests/scripts/graphql-subscription-helpers.test.js`, following this directory's existing `lib/*.js` + `scripts/*.test.js` convention.
- Adds an `npm run test:graphql-subscription-load` script to `load-tests/package.json`.

## Known finding this load test is designed to surface
`batchTokenDeployService` publishes `{ address, creator, ... }` onto the eventBus for `token.deployed`, while the subscription resolver's tenant filter (`tenantOwnsEvent`) and `TokenDeployedPayload` type expect `creatorAddress` / `tokenAddress` / `txHash` / `timestamp`. If that producer/consumer field-name mismatch hasn't been reconciled, every subscriber will legitimately receive zero messages and this scenario's thresholds will fail — that's the load test correctly catching a real contract mismatch, not a bug in the scenario itself. Flagging here rather than silently patching the event contract, since that's a cross-service change with its own blast radius (webhooks/notifications also consume `token.deployed`).

## Test plan
- [ ] `npm run test:unit` (from `load-tests/`) — helper unit tests
- [ ] `k6 run load-tests/scenarios/graphql-subscription-load.js` against a running backend (`BASE_URL` env var) — full load scenario

Closes #1329