### PR TITLE
 feat(monitoring): Prometheus SLO burn-rate alert rules and Grafana dashboard

### DIFF
--- a/monitoring/Makefile
+++ b/monitoring/Makefile
@@ -1,0 +1,18 @@
+ALERTS_DIR := prometheus/alerts
+
+.PHONY: test-alerts lint-alerts help
+
+## test-alerts: validate all Prometheus alert rule files with promtool
+test-alerts:
+	@echo "==> Checking Prometheus alert rules..."
+	@for f in $(ALERTS_DIR)/*.yml; do \
+		echo "  promtool check rules $$f"; \
+		promtool check rules "$$f" || exit 1; \
+	done
+	@echo "==> All alert rules OK"
+
+## lint-alerts: alias for test-alerts
+lint-alerts: test-alerts
+
+help:
+	@grep -E '^## ' Makefile | sed 's/## //'

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -68,12 +68,76 @@ Disable with `METRICS_ENABLED=false` in the backend environment.
 
 ## Alert Rules
 
-| File                                   | Covers                                      |
-| -------------------------------------- | ------------------------------------------- |
-| `prometheus/alerts/api.yml`            | HTTP error rates, latency, backend down     |
-| `prometheus/alerts/blockchain.yml`     | RPC errors, ingestion lag, deployment fails |
-| `prometheus/alerts/infrastructure.yml` | CPU, memory, disk, Node.js heap, containers |
-| `prometheus/alerts/webhooks.yml`       | Webhook failures, retry storms, job queues  |
+| File                                        | Covers                                      |
+| ------------------------------------------- | ------------------------------------------- |
+| `prometheus/alerts/api.yml`                 | HTTP error rates, latency, backend down     |
+| `prometheus/alerts/blockchain.yml`          | RPC errors, ingestion lag, deployment fails |
+| `prometheus/alerts/infrastructure.yml`      | CPU, memory, disk, Node.js heap, containers |
+| `prometheus/alerts/webhooks.yml`            | Webhook failures, retry storms, job queues  |
+| `prometheus/alerts/slo-burn-rate.yml`       | SLO burn-rate alerts (P1/P2) — see below   |
+
+## SLO Burn-Rate Alerts
+
+Implements the **multi-window, multi-burn-rate** pattern from the
+[Google SRE Workbook](https://sre.google/workbook/alerting-on-slos/).
+
+### SLO Definitions
+
+| SLO                       | Target | Error Budget (30 days) |
+| ------------------------- | ------ | ---------------------- |
+| API Availability          | 99.9%  | 43.8 minutes           |
+| API p95 Latency < 500ms   | 99%    | 7.3 hours              |
+| Webhook Delivery Success  | 99%    | 7.3 hours              |
+
+### Alert Thresholds
+
+| Tier       | Window | Burn Rate | Severity | Meaning                              |
+| ---------- | ------ | --------- | -------- | ------------------------------------ |
+| Fast burn  | 5 min  | 14×       | critical (P1) | Budget exhausted in ~1 hour    |
+| Slow burn  | 1 h    | 2×        | warning  (P2) | Budget exhausted in ~3 days    |
+
+A **14× burn rate** means errors are arriving 14 times faster than the budget
+allows. For the availability SLO (budget = 0.1%), this fires when the 5-minute
+error rate exceeds **1.4%**.
+
+### Validating Alert Rules Locally
+
+Install `promtool` (ships with every Prometheus release):
+
+```bash
+# macOS
+brew install prometheus
+
+# Linux — download from https://github.com/prometheus/prometheus/releases
+# and put promtool on your PATH
+```
+
+Then run:
+
+```bash
+cd monitoring
+make test-alerts          # validates every file in prometheus/alerts/
+# or target a single file
+promtool check rules prometheus/alerts/slo-burn-rate.yml
+```
+
+A successful run prints `SUCCESS: N rules found` and exits 0.
+
+### SLO Dashboard
+
+The Grafana dashboard `grafana/dashboards/slo-dashboard.json` (UID `nova-slo-burn-rate`)
+is provisioned automatically on stack start. To import it manually:
+
+1. Open Grafana → **Dashboards → Import**
+2. Upload `monitoring/grafana/dashboards/slo-dashboard.json`
+3. Select the **Prometheus** datasource
+4. Click **Import**
+
+The dashboard provides:
+
+- **SLO Status row** — current availability/success rate for each SLO (colour-coded)
+- **Burn Rates row** — time-series graphs of fast (5m) and slow (1h) burn rates with threshold lines
+- **Error Budget Remaining row** — percentage of monthly budget still available
 
 ## Alertmanager Configuration
 
@@ -159,5 +223,6 @@ monitoring/
         ├── api.yml
         ├── blockchain.yml
         ├── infrastructure.yml
-        └── webhooks.yml
+        ├── webhooks.yml
+        └── slo-burn-rate.yml       # SLO burn-rate alerts (P1/P2)
 ```

--- a/monitoring/grafana/dashboards/slo-dashboard.json
+++ b/monitoring/grafana/dashboards/slo-dashboard.json
@@ -1,0 +1,358 @@
+{
+  "__inputs": [],
+  "__requires": [
+    { "type": "grafana", "id": "grafana", "name": "Grafana", "version": "10.0.0" },
+    { "type": "datasource", "id": "prometheus", "name": "Prometheus", "version": "1.0.0" }
+  ],
+  "annotations": { "list": [] },
+  "description": "Nova Launch — SLO Status & Burn-Rate Dashboard",
+  "editable": true,
+  "graphTooltip": 1,
+  "id": null,
+  "refresh": "1m",
+  "tags": ["slo", "burn-rate", "nova-launch"],
+  "title": "Nova Launch — SLO Burn Rate",
+  "uid": "nova-slo-burn-rate",
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 1,
+      "title": "🎯 SLO Status",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0.99,
+          "max": 1,
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red",    "value": null },
+              { "color": "orange", "value": 0.999 },
+              { "color": "green",  "value": 0.9995 }
+            ]
+          },
+          "mappings": []
+        }
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 1 },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      },
+      "title": "API Availability (target ≥ 99.9%)",
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "1 - job:http_error_ratio:rate1h",
+          "legendFormat": "availability"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0.95,
+          "max": 1,
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red",    "value": null },
+              { "color": "orange", "value": 0.98 },
+              { "color": "green",  "value": 0.99 }
+            ]
+          }
+        }
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 1 },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      },
+      "title": "Requests within 500ms p95 (target ≥ 99%)",
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "1 - job:http_latency_bad_ratio:rate1h",
+          "legendFormat": "within-slo"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0.95,
+          "max": 1,
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red",    "value": null },
+              { "color": "orange", "value": 0.98 },
+              { "color": "green",  "value": 0.99 }
+            ]
+          }
+        }
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 1 },
+      "id": 4,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      },
+      "title": "Webhook Delivery Success (target ≥ 99%)",
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "1 - job:webhook_error_ratio:rate1h",
+          "legendFormat": "success-rate"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 },
+      "id": 10,
+      "title": "🔥 Burn Rates",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": { "lineWidth": 2, "fillOpacity": 10 },
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "fast-burn (14×)" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "slow-burn threshold (2×)" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "orange", "mode": "fixed" } }]
+          }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "id": 11,
+      "options": { "tooltip": { "mode": "multi" } },
+      "title": "API Availability — Burn Rate",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "job:http_error_ratio:rate5m / 0.001",
+          "legendFormat": "fast (5m window)"
+        },
+        {
+          "expr": "job:http_error_ratio:rate1h / 0.001",
+          "legendFormat": "slow (1h window)"
+        },
+        {
+          "expr": "vector(14)",
+          "legendFormat": "fast-burn (14×)"
+        },
+        {
+          "expr": "vector(2)",
+          "legendFormat": "slow-burn threshold (2×)"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": { "lineWidth": 2, "fillOpacity": 10 },
+          "color": { "mode": "palette-classic" }
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+      "id": 12,
+      "options": { "tooltip": { "mode": "multi" } },
+      "title": "API Latency — Burn Rate",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "job:http_latency_bad_ratio:rate5m / 0.01",
+          "legendFormat": "fast (5m window)"
+        },
+        {
+          "expr": "job:http_latency_bad_ratio:rate1h / 0.01",
+          "legendFormat": "slow (1h window)"
+        },
+        {
+          "expr": "vector(14)",
+          "legendFormat": "fast-burn (14×)"
+        },
+        {
+          "expr": "vector(2)",
+          "legendFormat": "slow-burn threshold (2×)"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": { "lineWidth": 2, "fillOpacity": 10 },
+          "color": { "mode": "palette-classic" }
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 14 },
+      "id": 13,
+      "options": { "tooltip": { "mode": "multi" } },
+      "title": "Webhook Delivery — Burn Rate",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "job:webhook_error_ratio:rate5m / 0.01",
+          "legendFormat": "fast (5m window)"
+        },
+        {
+          "expr": "job:webhook_error_ratio:rate1h / 0.01",
+          "legendFormat": "slow (1h window)"
+        },
+        {
+          "expr": "vector(14)",
+          "legendFormat": "fast-burn (14×)"
+        },
+        {
+          "expr": "vector(2)",
+          "legendFormat": "slow-burn threshold (2×)"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 22 },
+      "id": 20,
+      "title": "💰 Error Budget Remaining (30-day rolling)",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red",    "value": null },
+              { "color": "orange", "value": 0.25 },
+              { "color": "green",  "value": 0.50 }
+            ]
+          }
+        }
+      },
+      "gridPos": { "h": 4, "w": 8, "x": 0, "y": 23 },
+      "id": 21,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      },
+      "title": "API Availability Budget Remaining",
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "1 - (job:http_error_ratio:rate1h / 0.001)",
+          "legendFormat": "budget %"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red",    "value": null },
+              { "color": "orange", "value": 0.25 },
+              { "color": "green",  "value": 0.50 }
+            ]
+          }
+        }
+      },
+      "gridPos": { "h": 4, "w": 8, "x": 8, "y": 23 },
+      "id": 22,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      },
+      "title": "API Latency Budget Remaining",
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "1 - (job:http_latency_bad_ratio:rate1h / 0.01)",
+          "legendFormat": "budget %"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red",    "value": null },
+              { "color": "orange", "value": 0.25 },
+              { "color": "green",  "value": 0.50 }
+            ]
+          }
+        }
+      },
+      "gridPos": { "h": 4, "w": 8, "x": 16, "y": 23 },
+      "id": 23,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      },
+      "title": "Webhook Delivery Budget Remaining",
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "1 - (job:webhook_error_ratio:rate1h / 0.01)",
+          "legendFormat": "budget %"
+        }
+      ]
+    }
+  ],
+  "schemaVersion": 38,
+  "time": { "from": "now-24h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "version": 1
+}

--- a/monitoring/prometheus/alerts/slo-burn-rate.yml
+++ b/monitoring/prometheus/alerts/slo-burn-rate.yml
@@ -1,0 +1,175 @@
+##############################################################################
+# Alert Rules — SLO Burn-Rate (Multi-Window, Multi-Burn-Rate)
+# Follows the Google SRE Workbook pattern.
+#
+# SLOs:
+#   - API Availability:        99.9%  (error budget: 0.1%)
+#   - API p95 Latency:         < 500ms
+#   - Webhook Delivery:        99%    (error budget: 1%)
+#
+# Burn-rate tiers:
+#   Fast burn  — 5 min window,  14× rate → exhausts budget in ~1 h  → P1/critical
+#   Slow burn  — 1 h  window,   2×  rate → exhausts budget in ~3 d  → P2/warning
+##############################################################################
+
+groups:
+  # --------------------------------------------------------------------------
+  # SLO 1 — API Availability (99.9%)
+  # error_ratio = 5xx / total
+  # --------------------------------------------------------------------------
+  - name: slo_api_availability
+    interval: 30s
+    rules:
+      # Convenience recording rules keep alert expressions readable
+      - record: job:http_error_ratio:rate5m
+        expr: |
+          sum(rate(http_requests_total{status_code=~"5.."}[5m]))
+          /
+          sum(rate(http_requests_total[5m]))
+
+      - record: job:http_error_ratio:rate1h
+        expr: |
+          sum(rate(http_requests_total{status_code=~"5.."}[1h]))
+          /
+          sum(rate(http_requests_total[1h]))
+
+      # Fast burn: 14× error budget (0.1%) over 5-minute window → P1
+      - alert: SLOAvailabilityFastBurn
+        expr: job:http_error_ratio:rate5m > (14 * 0.001)
+        for: 5m
+        labels:
+          severity: critical
+          team: backend
+          slo: api_availability
+          burn_rate: fast
+        annotations:
+          summary: "P1: API availability fast burn — SLO budget exhausting rapidly"
+          description: >
+            Error ratio is {{ $value | humanizePercentage }} (threshold: 1.4%).
+            At this rate the 30-day error budget will be exhausted in ~1 hour.
+          runbook_url: "https://github.com/Emmyt24/nova-launch/docs/runbooks/slo-availability.md"
+
+      # Slow burn: 2× error budget (0.1%) over 1-hour window → P2
+      - alert: SLOAvailabilitySlowBurn
+        expr: job:http_error_ratio:rate1h > (2 * 0.001)
+        for: 1h
+        labels:
+          severity: warning
+          team: backend
+          slo: api_availability
+          burn_rate: slow
+        annotations:
+          summary: "P2: API availability slow burn — SLO budget eroding"
+          description: >
+            Error ratio is {{ $value | humanizePercentage }} over the last hour (threshold: 0.2%).
+            At this rate the 30-day error budget will be exhausted in ~3 days.
+          runbook_url: "https://github.com/Emmyt24/nova-launch/docs/runbooks/slo-availability.md"
+
+  # --------------------------------------------------------------------------
+  # SLO 2 — API p95 Latency (< 500ms)
+  # bad_ratio = requests where latency > 500ms / total
+  # --------------------------------------------------------------------------
+  - name: slo_api_latency
+    interval: 30s
+    rules:
+      # Requests where p95 latency exceeds 500ms: approximated as the fraction
+      # of histogram observations above the 500ms bucket boundary.
+      - record: job:http_latency_bad_ratio:rate5m
+        expr: |
+          1 - (
+            sum(rate(http_request_duration_seconds_bucket{le="0.5"}[5m]))
+            /
+            sum(rate(http_request_duration_seconds_bucket{le="+Inf"}[5m]))
+          )
+
+      - record: job:http_latency_bad_ratio:rate1h
+        expr: |
+          1 - (
+            sum(rate(http_request_duration_seconds_bucket{le="0.5"}[1h]))
+            /
+            sum(rate(http_request_duration_seconds_bucket{le="+Inf"}[1h]))
+          )
+
+      # SLO target: 99% of requests within 500ms → error budget: 1%
+      # Fast burn: 14× budget (1%) over 5 minutes → P1
+      - alert: SLOLatencyFastBurn
+        expr: job:http_latency_bad_ratio:rate5m > (14 * 0.01)
+        for: 5m
+        labels:
+          severity: critical
+          team: backend
+          slo: api_latency
+          burn_rate: fast
+        annotations:
+          summary: "P1: API latency fast burn — p95 SLO budget exhausting rapidly"
+          description: >
+            {{ $value | humanizePercentage }} of requests exceed the 500ms p95 threshold
+            (fast-burn limit: 14%). Budget will be exhausted in ~1 hour.
+          runbook_url: "https://github.com/Emmyt24/nova-launch/docs/runbooks/slo-latency.md"
+
+      # Slow burn: 2× budget (1%) over 1 hour → P2
+      - alert: SLOLatencySlowBurn
+        expr: job:http_latency_bad_ratio:rate1h > (2 * 0.01)
+        for: 1h
+        labels:
+          severity: warning
+          team: backend
+          slo: api_latency
+          burn_rate: slow
+        annotations:
+          summary: "P2: API latency slow burn — p95 SLO budget eroding"
+          description: >
+            {{ $value | humanizePercentage }} of requests exceed the 500ms p95 threshold
+            over the last hour (slow-burn limit: 2%). Budget will be exhausted in ~3 days.
+          runbook_url: "https://github.com/Emmyt24/nova-launch/docs/runbooks/slo-latency.md"
+
+  # --------------------------------------------------------------------------
+  # SLO 3 — Webhook Delivery Success Rate (> 99%)
+  # error_ratio = failure deliveries / total deliveries
+  # --------------------------------------------------------------------------
+  - name: slo_webhook_delivery
+    interval: 30s
+    rules:
+      - record: job:webhook_error_ratio:rate5m
+        expr: |
+          sum(rate(webhook_deliveries_total{status="failure"}[5m]))
+          /
+          sum(rate(webhook_deliveries_total[5m]))
+
+      - record: job:webhook_error_ratio:rate1h
+        expr: |
+          sum(rate(webhook_deliveries_total{status="failure"}[1h]))
+          /
+          sum(rate(webhook_deliveries_total[1h]))
+
+      # Fast burn: 14× error budget (1%) over 5 minutes → P1
+      - alert: SLOWebhookDeliveryFastBurn
+        expr: job:webhook_error_ratio:rate5m > (14 * 0.01)
+        for: 5m
+        labels:
+          severity: critical
+          team: backend
+          slo: webhook_delivery
+          burn_rate: fast
+        annotations:
+          summary: "P1: Webhook delivery fast burn — SLO budget exhausting rapidly"
+          description: >
+            Webhook failure ratio is {{ $value | humanizePercentage }} (fast-burn limit: 14%).
+            At this rate the 30-day error budget will be exhausted in ~1 hour.
+          runbook_url: "https://github.com/Emmyt24/nova-launch/docs/runbooks/slo-webhooks.md"
+
+      # Slow burn: 2× error budget (1%) over 1 hour → P2
+      - alert: SLOWebhookDeliverySlowBurn
+        expr: job:webhook_error_ratio:rate1h > (2 * 0.01)
+        for: 1h
+        labels:
+          severity: warning
+          team: backend
+          slo: webhook_delivery
+          burn_rate: slow
+        annotations:
+          summary: "P2: Webhook delivery slow burn — SLO budget eroding"
+          description: >
+            Webhook failure ratio is {{ $value | humanizePercentage }} over the last hour
+            (slow-burn limit: 2%). Budget will be exhausted in ~3 days.
+          runbook_url: "https://github.com/Emmyt24/nova-launch/docs/runbooks/slo-webhooks.md"


### PR DESCRIPTION

  PR Description
  
  ## Summary
  
  Implements multi-window, multi-burn-rate SLO alerting for the Nova Launch monitoring stack, following the Google SRE Workbook pattern. Closes #1407
  
  ## Changes
  
  ### `monitoring/prometheus/alerts/slo-burn-rate.yml`
  Three alert groups covering all defined SLOs:
  
  | SLO | Target | Error Budget |
  |-----|--------|-------------|
  | API Availability | 99.9% | 0.1% |
  | API p95 Latency < 500ms | 99% | 1% |
  | Webhook Delivery Success | 99% | 1% |
  
  Each SLO has two burn-rate tiers:
  - **Fast burn** (5-min window, 14× rate) → `severity: critical` (P1) — budget exhausted in ~1 hour
  - **Slow burn** (1-hour window, 2× rate) → `severity: warning` (P2) — budget exhausted in ~3 days
  
  ### `monitoring/grafana/dashboards/slo-dashboard.json`
  New dashboard (UID: `nova-slo-burn-rate`) auto-provisioned with:
  - SLO status panels (colour-coded pass/warn/fail per SLO)
  - Burn rate time-series graphs with fast/slow threshold lines
  - Error budget remaining panels (% of monthly budget left)
  
  ### `monitoring/Makefile`
  ```bash
  make test-alerts  # runs promtool check rules on all alert files
  
  monitoring/README.md
  
  Added SLO definitions table, alert threshold reference, promtool validation instructions, and dashboard import guide.
  
  Testing
  
  promtool check rules monitoring/prometheus/alerts/slo-burn-rate.yml → SUCCESS: 12 rules found (0 errors)
  
  All existing alert files also re-validated clean (36 rules total).
  
  How to Review
  
  1. Check alert expressions in slo-burn-rate.yml match the SLO budgets in the table above
  2. Run cd monitoring && make test-alerts locally (requires promtool on PATH)
  3. Import grafana/dashboards/slo-dashboard.json to staging Grafana to verify panels load
  
  Closes #1407
  
