### PR TITLE
feat(integration): wallet/JWT sync, GraphQL catchup, cascading health…

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -21,6 +21,7 @@ import versionRoutes from "./routes/version";
 import searchRoutes from "./routes/search";
 import exportRoutes from "./routes/export";
 import stellarRoutes from "./routes/stellar";
+import eventsRoutes from "./routes/events";
 import graphqlRouter, { attachGraphqlSubscriptions } from "./graphql";
 import openApiRouter from "./lib/openapi/router";
 import { Database } from "./config/database";
@@ -111,6 +112,7 @@ v1Router.use("/version", versionRoutes);
 v1Router.use("/search", searchRoutes);
 v1Router.use("/export", exportRoutes);
 v1Router.use("/stellar", limiter, stellarRoutes);
+v1Router.use("/events", eventsRoutes);
 v1Router.use("/graphql", graphqlRouter);
 v1Router.use("/docs", openApiRouter);
 

--- a/backend/src/lib/health/__tests__/cascading.test.ts
+++ b/backend/src/lib/health/__tests__/cascading.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Tests — cascading failure detection (#1373)
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { HealthService } from "../health.service";
+import { ServiceHealth, DEFAULT_DEPENDENCY_GRAPH } from "../health.types";
+
+vi.mock("../../prisma", () => ({
+  prisma: { $queryRaw: vi.fn().mockResolvedValue([{ count: 1n }]) },
+}));
+vi.mock("../circuitBreaker", () => ({
+  getCircuitBreakerRegistrySnapshot: () => ({}),
+}));
+
+const mockDispatchAlert = vi.fn().mockResolvedValue({ status: "ok" });
+// Path must match what health.service.ts imports (resolved from src/lib/health/)
+vi.mock(
+  new URL("../../../../../monitoring/pagerduty/incident-response.ts", import.meta.url).pathname,
+  () => ({ dispatchAlert: (...args: unknown[]) => mockDispatchAlert(...args) })
+);
+
+global.fetch = vi.fn().mockResolvedValue({ ok: true, status: 200 } as Response);
+
+function up(): ServiceHealth { return { status: "up" }; }
+function down(err = "connection refused"): ServiceHealth { return { status: "down", error: err }; }
+
+function freshService(): HealthService {
+  (HealthService as any).instance = undefined;
+  return HealthService.getInstance();
+}
+
+beforeEach(() => {
+  mockDispatchAlert.mockClear();
+  vi.mocked(global.fetch).mockResolvedValue({ ok: true, status: 200 } as Response);
+});
+
+// ---------------------------------------------------------------------------
+// Pure unit tests on applyCascadingFailures
+// ---------------------------------------------------------------------------
+
+describe("applyCascadingFailures", () => {
+  it("returns no root causes when all services healthy", () => {
+    const svc = freshService();
+    const services = {
+      database: up(), cache: up(),
+      stellarHorizon: up(), stellarSoroban: up(), ipfs: up(),
+    };
+    const roots = svc.applyCascadingFailures(services, DEFAULT_DEPENDENCY_GRAPH);
+    expect(roots).toHaveLength(0);
+    for (const s of Object.values(services)) expect(s.cascaded).toBeFalsy();
+  });
+
+  it("cache failure marks stellarHorizon, stellarSoroban, ipfs as cascaded", () => {
+    const svc = freshService();
+    const services = {
+      database: up(), cache: down(),
+      stellarHorizon: up(), stellarSoroban: up(), ipfs: up(),
+    };
+    const roots = svc.applyCascadingFailures(services, DEFAULT_DEPENDENCY_GRAPH);
+
+    expect(roots).toEqual(["cache"]);
+    expect(services.cache.cascaded).toBeFalsy();
+    expect(services.stellarHorizon.cascaded).toBe(true);
+    expect(services.stellarHorizon.rootCause).toBe("cache");
+    expect(services.stellarSoroban.cascaded).toBe(true);
+    expect(services.ipfs.cascaded).toBe(true);
+  });
+
+  it("database failure marks ipfs as cascaded, not stellarHorizon", () => {
+    const svc = freshService();
+    const services = {
+      database: down(), cache: up(),
+      stellarHorizon: up(), stellarSoroban: up(), ipfs: up(),
+    };
+    const roots = svc.applyCascadingFailures(services, DEFAULT_DEPENDENCY_GRAPH);
+
+    expect(roots).toContain("database");
+    expect(services.ipfs.cascaded).toBe(true);
+    expect(services.ipfs.rootCause).toBe("database");
+    expect(services.stellarHorizon.cascaded).toBeFalsy();
+  });
+
+  it("independently failing service with no upstream is its own root cause", () => {
+    const svc = freshService();
+    const services = {
+      database: up(), cache: up(),
+      stellarHorizon: down(), stellarSoroban: up(), ipfs: up(),
+    };
+    const roots = svc.applyCascadingFailures(services, DEFAULT_DEPENDENCY_GRAPH);
+    expect(roots).toContain("stellarHorizon");
+    expect(services.stellarHorizon.cascaded).toBeFalsy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration — PagerDuty fires exactly 1 alert per root cause
+// ---------------------------------------------------------------------------
+
+describe("checkDetailedHealth — PagerDuty alerting", () => {
+  it("fires no alerts when all services healthy", async () => {
+    const svc = freshService();
+    await svc.checkDetailedHealth();
+    expect(mockDispatchAlert).not.toHaveBeenCalled();
+  });
+
+  it("fires exactly 1 alert for cache failure, not 3 for cascaded dependents", async () => {
+    const svc = freshService();
+    vi.spyOn(svc as any, "checkCache")
+      .mockResolvedValue({ status: "down", error: "Redis unavailable" });
+
+    const result = await svc.checkDetailedHealth();
+
+    expect(result.rootCauses).toEqual(["cache"]);
+    expect(mockDispatchAlert).toHaveBeenCalledTimes(1);
+    expect(mockDispatchAlert.mock.calls[0][0]).toContain("cache");
+  });
+});

--- a/backend/src/lib/health/health.service.ts
+++ b/backend/src/lib/health/health.service.ts
@@ -5,9 +5,12 @@ import {
   HealthCheckResult,
   DetailedHealthCheckResult,
   HealthCheckOptions,
+  DEFAULT_DEPENDENCY_GRAPH,
+  ServiceDependencyGraph,
 } from "./health.types";
 import { validateEnv } from "../../config/env";
 import { getCircuitBreakerRegistrySnapshot } from "../circuitBreaker";
+import { dispatchAlert } from "../../../../monitoring/pagerduty/incident-response";
 
 const _env = validateEnv();
 
@@ -105,17 +108,80 @@ export class HealthService {
     }
 
     const basicHealth = await this.checkHealth(options);
+    const services = { ...basicHealth.services };
+    const rootCauses = this.applyCascadingFailures(services, DEFAULT_DEPENDENCY_GRAPH);
+
+    // Alert PagerDuty once per root cause (#1373)
+    for (const svcName of rootCauses) {
+      try {
+        await dispatchAlert(
+          `health.service.${svcName}`,
+          "critical",
+          { service: svcName, message: (services as any)[svcName]?.error ?? "service down" }
+        );
+      } catch {
+        // Non-fatal — alerting must not block the health response
+      }
+    }
+
     const metrics = await this.collectMetrics();
     const circuitBreakers = getCircuitBreakerRegistrySnapshot();
 
     const result: DetailedHealthCheckResult = {
       ...basicHealth,
+      services,
       metrics,
       circuitBreakers,
+      rootCauses,
     };
 
     this.cache.set<DetailedHealthCheckResult>(cacheKey, result);
     return result;
+  }
+
+  /**
+   * Traverse the dependency graph and mark downstream services as cascaded.
+   * Returns the list of root-cause service names (failed on their own).
+   */
+  applyCascadingFailures(
+    services: Record<string, ServiceHealth>,
+    graph: ServiceDependencyGraph = DEFAULT_DEPENDENCY_GRAPH
+  ): string[] {
+    const rootCauses: string[] = [];
+
+    for (const [upstream, dependents] of Object.entries(graph)) {
+      const upstreamHealth = services[upstream];
+      if (!upstreamHealth || upstreamHealth.status === "up") continue;
+
+      // This upstream service is a root cause
+      rootCauses.push(upstream);
+
+      for (const dep of dependents) {
+        const depHealth = services[dep];
+        if (!depHealth) continue;
+        // Only mark as cascaded if it hasn't already failed on its own
+        if (depHealth.status !== "up" && !depHealth.cascaded) {
+          depHealth.cascaded = true;
+          depHealth.rootCause = upstream;
+        } else if (depHealth.status === "up") {
+          // Cascade the failure down — this dependency is impacted even if
+          // its own check succeeded (the check may not reflect the runtime impact yet)
+          depHealth.status = "degraded";
+          depHealth.cascaded = true;
+          depHealth.rootCause = upstream;
+          depHealth.message = `Cascaded failure from ${upstream}`;
+        }
+      }
+    }
+
+    // Any failing service not already marked cascaded is a root cause
+    for (const [name, svc] of Object.entries(services)) {
+      if (svc.status !== "up" && !svc.cascaded && !rootCauses.includes(name)) {
+        rootCauses.push(name);
+      }
+    }
+
+    return [...new Set(rootCauses)];
   }
 
   /**

--- a/backend/src/lib/health/health.types.ts
+++ b/backend/src/lib/health/health.types.ts
@@ -11,7 +11,35 @@ export interface ServiceHealth {
   responseTime?: number;
   message?: string;
   error?: string;
+  /**
+   * When true this service failed because a dependency failed, not on its own.
+   * The name of the root-cause service is in `rootCause`. (#1373)
+   */
+  cascaded?: boolean;
+  /** Name of the upstream service that caused this failure, if cascaded. */
+  rootCause?: string | null;
 }
+
+/**
+ * Dependency graph for cascading failure detection (#1373).
+ * Key: service name. Value: list of service names that depend on it
+ * (i.e. if the key fails, the values are marked cascaded).
+ */
+export type ServiceDependencyGraph = Record<string, string[]>;
+
+/**
+ * Default dependency graph for Nova Launch services.
+ *
+ * Redis (cache) failure cascades to leaderboard, webhook delivery, and
+ * notifications.  Database failure cascades to all data-layer services.
+ */
+export const DEFAULT_DEPENDENCY_GRAPH: ServiceDependencyGraph = {
+  // cache = Redis
+  cache: ["stellarHorizon", "stellarSoroban", "ipfs"],
+  // database failure leaves ipfs/stellar still independently checkable,
+  // but data-layer reads fail
+  database: ["ipfs"],
+};
 
 export interface HealthCheckResult {
   status: HealthStatus;
@@ -64,6 +92,8 @@ export interface DetailedHealthCheckResult extends HealthCheckResult {
       timeSinceLastFailure: number;
     }
   >;
+  /** Root-cause service names (services that failed on their own). */
+  rootCauses: string[];
 }
 
 export interface HealthCheckOptions {

--- a/backend/src/routes/__tests__/events.catchup.test.ts
+++ b/backend/src/routes/__tests__/events.catchup.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Integration tests — GET /api/events/catchup (#1372)
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+// Mock the shared eventBus so tests control history
+vi.mock('../../services/eventBus', () => {
+  const history: any[] = [];
+  let seq = 0;
+  return {
+    eventBus: {
+      get currentSequence() { return seq; },
+      getHistory: () => [...history],
+      _setHistory: (evs: any[]) => { history.length = 0; history.push(...evs); },
+      _setSequence: (n: number) => { seq = n; },
+    },
+  };
+});
+
+import eventsRouter from '../../routes/events';
+import { eventBus } from '../../services/eventBus';
+
+const bus = eventBus as any;
+
+function makeApp() {
+  const app = express();
+  app.use('/api/events', eventsRouter);
+  return app;
+}
+
+function makeEvent(sequence: number, type = 'token.created') {
+  return { id: `evt-${sequence}`, type, payload: {}, timestamp: new Date().toISOString(), sequence };
+}
+
+beforeEach(() => {
+  bus._setHistory([]);
+  bus._setSequence(0);
+});
+
+describe('GET /api/events/catchup', () => {
+  it('returns 400 when since param is missing', async () => {
+    const res = await request(makeApp()).get('/api/events/catchup');
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when since is not a number', async () => {
+    const res = await request(makeApp()).get('/api/events/catchup?since=abc');
+    expect(res.status).toBe(400);
+  });
+
+  it('returns empty events when no events since given sequence', async () => {
+    bus._setSequence(5);
+    bus._setHistory([makeEvent(3), makeEvent(4), makeEvent(5)]);
+
+    const res = await request(makeApp()).get('/api/events/catchup?since=5');
+    expect(res.status).toBe(200);
+    expect(res.body.truncated).toBe(false);
+    expect(res.body.events).toHaveLength(0);
+  });
+
+  it('returns missed events in ascending sequence order', async () => {
+    bus._setSequence(5);
+    bus._setHistory([makeEvent(1), makeEvent(2), makeEvent(3), makeEvent(4), makeEvent(5)]);
+
+    const res = await request(makeApp()).get('/api/events/catchup?since=2');
+    expect(res.status).toBe(200);
+    expect(res.body.truncated).toBe(false);
+    const seqs = res.body.events.map((e: any) => e.sequence);
+    expect(seqs).toEqual([3, 4, 5]);
+  });
+
+  it('returns truncated:true when gap > 1000', async () => {
+    bus._setSequence(1002);
+    bus._setHistory([]);
+
+    const res = await request(makeApp()).get('/api/events/catchup?since=0');
+    expect(res.status).toBe(200);
+    expect(res.body.truncated).toBe(true);
+    expect(res.body.currentSequence).toBe(1002);
+    expect(res.body.events).toBeUndefined();
+  });
+
+  it('includes currentSequence in all responses', async () => {
+    bus._setSequence(7);
+    bus._setHistory([makeEvent(7)]);
+
+    const res = await request(makeApp()).get('/api/events/catchup?since=6');
+    expect(res.body.currentSequence).toBe(7);
+  });
+});

--- a/backend/src/routes/events.ts
+++ b/backend/src/routes/events.ts
@@ -1,0 +1,44 @@
+/**
+ * GET /api/events/catchup?since=<sequence>
+ *
+ * Returns events from the shared EventBus history that have a sequence
+ * number greater than `since`, ordered ascending.
+ *
+ * If the gap (currentSequence - since) exceeds CATCHUP_LIMIT (1000), returns
+ * { truncated: true, currentSequence } to tell the client to do a full REST
+ * refresh instead (#1372).
+ */
+
+import { Router, Request, Response } from "express";
+import { eventBus } from "../services/eventBus";
+
+export const CATCHUP_LIMIT = 1000;
+
+const router = Router();
+
+router.get("/catchup", (req: Request, res: Response) => {
+  const sinceRaw = req.query.since;
+  const since = sinceRaw !== undefined ? parseInt(String(sinceRaw), 10) : NaN;
+
+  if (isNaN(since) || since < 0) {
+    res.status(400).json({ error: "Query parameter 'since' must be a non-negative integer" });
+    return;
+  }
+
+  const currentSequence = eventBus.currentSequence;
+
+  // Truncation guard — tell client to do a full refresh
+  if (currentSequence - since > CATCHUP_LIMIT) {
+    res.json({ truncated: true, currentSequence });
+    return;
+  }
+
+  const missed = eventBus
+    .getHistory()
+    .filter((e) => e.sequence > since)
+    .sort((a, b) => a.sequence - b.sequence);
+
+  res.json({ truncated: false, events: missed, currentSequence });
+});
+
+export default router;

--- a/backend/src/services/eventBus.ts
+++ b/backend/src/services/eventBus.ts
@@ -39,6 +39,12 @@ export interface BusEvent<T = unknown> {
   timestamp: string;
   /** Optional correlation ID for distributed tracing */
   correlationId?: string;
+  /**
+   * Monotonically incrementing sequence number assigned at publish time.
+   * Used by the catchup endpoint so clients can request missed events
+   * after a WebSocket reconnect (#1372).
+   */
+  sequence: number;
 }
 
 export type EventHandler<T = unknown> = (
@@ -67,6 +73,9 @@ export class EventBus {
   private handlers = new Map<string, Map<string, EventHandler>>();
   private history: BusEvent[] = [];
   private deadLetterQueue: DeadLetterEntry[] = [];
+
+  /** Monotonically incrementing sequence counter (#1372). */
+  private _sequence = 0;
 
   /** Maximum events kept in history. 0 = unlimited. */
   private readonly maxHistory: number;
@@ -169,6 +178,7 @@ export class EventBus {
       payload,
       timestamp: new Date().toISOString(),
       correlationId: options.correlationId,
+      sequence: ++this._sequence,
     };
 
     this.recordHistory(event);
@@ -214,6 +224,12 @@ export class EventBus {
     this.handlers.clear();
     this.history = [];
     this.deadLetterQueue = [];
+    this._sequence = 0;
+  }
+
+  /** Current sequence counter value — highest sequence number emitted so far. */
+  get currentSequence(): number {
+    return this._sequence;
   }
 
   // ── Private helpers ───────────────────────────────────────────────────────

--- a/frontend/src/hooks/__tests__/useCampaignStepSubscription.catchup.test.ts
+++ b/frontend/src/hooks/__tests__/useCampaignStepSubscription.catchup.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Tests — useCampaignStepSubscription catchup flow (#1372)
+ *
+ * Covers:
+ *  1. Normal catchup: missed events delivered in order on reconnect
+ *  2. Truncation: gap > 1000 sets needsFullRefresh
+ *  3. No gap: catchup returns empty, live resumes immediately
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import {
+  useCampaignStepSubscription,
+  type CampaignStepExecutedEvent,
+} from '../useCampaignStepSubscription';
+
+// ---------------------------------------------------------------------------
+// FakeWebSocket (same pattern as existing tests)
+// ---------------------------------------------------------------------------
+class FakeWebSocket {
+  static OPEN = 1;
+  static instances: FakeWebSocket[] = [];
+  readyState = FakeWebSocket.OPEN;
+  sent: string[] = [];
+  onopen: (() => void) | null = null;
+  onmessage: ((e: { data: string }) => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  constructor(public url: string, public protocol: string) {
+    FakeWebSocket.instances.push(this);
+  }
+  send(data: string) { this.sent.push(data); }
+  close() { this.onclose?.(); }
+  emit(msg: Record<string, unknown>) {
+    this.onmessage?.({ data: JSON.stringify(msg) });
+  }
+}
+
+beforeEach(() => { FakeWebSocket.instances = []; });
+const latest = () => FakeWebSocket.instances[FakeWebSocket.instances.length - 1];
+
+const BASE_EVENT: CampaignStepExecutedEvent = {
+  campaignId: 1, stepNumber: 1, amount: '100', status: 'COMPLETED',
+  txHash: 'h1', executedAt: '2026-01-01T00:00:00Z',
+  totalSteps: 3, executedAmount: '100', campaignStatus: 'ACTIVE',
+};
+
+function mockFetch(response: object, ok = true) {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok,
+    json: async () => response,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 1 — Normal catchup: missed events delivered on reconnect
+// ---------------------------------------------------------------------------
+describe('catchup — normal gap', () => {
+  it('replays missed events in order on reconnect', async () => {
+    const missed = [
+      { ...BASE_EVENT, stepNumber: 2, sequence: 2 },
+      { ...BASE_EVENT, stepNumber: 3, sequence: 3 },
+    ];
+    mockFetch({ truncated: false, events: missed.map(e => ({ sequence: e.sequence, payload: e })), currentSequence: 3 });
+
+    const onStepExecuted = vi.fn();
+    const { result } = renderHook(() =>
+      useCampaignStepSubscription({
+        campaignId: 1,
+        onStepExecuted,
+        wsUrl: 'ws://test/graphql',
+        restBaseUrl: 'http://test',
+        WebSocketImpl: FakeWebSocket as unknown as typeof WebSocket,
+      })
+    );
+
+    const sock = latest();
+    sock.onopen?.();
+    // Simulate first connection: set lastSequence to 1 via a live event
+    sock.emit({ type: 'connection_ack' });
+
+    // After ack, catchup is called (since=0 on first connect, skipped)
+    await waitFor(() => expect(result.current.connected).toBe(true));
+
+    // Simulate disconnect + reconnect to trigger catchup with non-zero lastSequence
+    // First: deliver a live event to bump lastSequence
+    sock.emit({
+      type: 'next',
+      payload: { data: { campaignStepExecuted: { ...BASE_EVENT, stepNumber: 1, sequence: 1 } } },
+    });
+
+    expect(onStepExecuted).toHaveBeenCalledTimes(1);
+    expect((onStepExecuted.mock.calls[0][0] as any).stepNumber).toBe(1);
+
+    // Now disconnect
+    act(() => { sock.close(); });
+    await waitFor(() => expect(result.current.connected).toBe(false));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 2 — Truncation: gap > 1000 → needsFullRefresh
+// ---------------------------------------------------------------------------
+describe('catchup — truncation', () => {
+  it('sets needsFullRefresh when server responds truncated:true', async () => {
+    mockFetch({ truncated: true, currentSequence: 1500 });
+
+    const onStepExecuted = vi.fn();
+    const { result } = renderHook(() =>
+      useCampaignStepSubscription({
+        campaignId: 1,
+        onStepExecuted,
+        wsUrl: 'ws://test/graphql',
+        restBaseUrl: 'http://test',
+        WebSocketImpl: FakeWebSocket as unknown as typeof WebSocket,
+        reconnectDelayMs: 50,
+      })
+    );
+
+    const sock = latest();
+    sock.onopen?.();
+
+    // Bump lastSequence by delivering a live event, then force reconnect
+    sock.emit({ type: 'connection_ack' });
+    await waitFor(() => expect(result.current.connected).toBe(true));
+    sock.emit({
+      type: 'next',
+      payload: { data: { campaignStepExecuted: { ...BASE_EVENT, sequence: 1 } } },
+    });
+
+    // Disconnect to trigger reconnect + catchup
+    act(() => { sock.close(); });
+
+    // Wait for reconnect and catchup to run
+    await waitFor(() => FakeWebSocket.instances.length >= 2);
+    const sock2 = latest();
+    sock2.onopen?.();
+    sock2.emit({ type: 'connection_ack' });
+
+    await waitFor(() => expect(result.current.needsFullRefresh).toBe(true));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 3 — No gap: catchup returns empty, live resumes immediately
+// ---------------------------------------------------------------------------
+describe('catchup — no gap', () => {
+  it('returns connected without replaying any events when no gap', async () => {
+    mockFetch({ truncated: false, events: [], currentSequence: 5 });
+
+    const onStepExecuted = vi.fn();
+    const { result } = renderHook(() =>
+      useCampaignStepSubscription({
+        campaignId: 1,
+        onStepExecuted,
+        wsUrl: 'ws://test/graphql',
+        restBaseUrl: 'http://test',
+        WebSocketImpl: FakeWebSocket as unknown as typeof WebSocket,
+      })
+    );
+
+    const sock = latest();
+    sock.onopen?.();
+    sock.emit({ type: 'connection_ack' });
+
+    await waitFor(() => expect(result.current.connected).toBe(true));
+    expect(result.current.needsFullRefresh).toBe(false);
+    // No catchup events replayed
+    expect(onStepExecuted).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/useCampaignStepSubscription.ts
+++ b/frontend/src/hooks/useCampaignStepSubscription.ts
@@ -44,11 +44,15 @@ export interface UseCampaignStepSubscriptionOptions {
   WebSocketImpl?: typeof WebSocket;
   /** Reconnect backoff in ms — default 2000. */
   reconnectDelayMs?: number;
+  /** Override the REST base URL for catchup calls — primarily for tests. */
+  restBaseUrl?: string;
 }
 
 export interface UseCampaignStepSubscriptionReturn {
   /** True once the connection_ack handshake has completed. */
   connected: boolean;
+  /** True when the server signalled truncation and a full refresh is needed. */
+  needsFullRefresh: boolean;
 }
 
 const SUBSCRIPTION_QUERY = /* GraphQL */ `
@@ -83,15 +87,18 @@ export function useCampaignStepSubscription({
   wsUrl,
   WebSocketImpl,
   reconnectDelayMs = 2_000,
+  restBaseUrl,
 }: UseCampaignStepSubscriptionOptions): UseCampaignStepSubscriptionReturn {
   const [connected, setConnected] = useState(false);
+  const [needsFullRefresh, setNeedsFullRefresh] = useState(false);
 
-  // Stable refs so the socket's event handlers always see the latest callback
-  // / props without having to tear down and reconnect on every render.
   const onStepExecutedRef = useRef(onStepExecuted);
   onStepExecutedRef.current = onStepExecuted;
   const authTokenRef = useRef(authToken);
   authTokenRef.current = authToken;
+
+  /** Last received event sequence number — persists across reconnects. */
+  const lastSequenceRef = useRef<number>(0);
 
   useEffect(() => {
     if (campaignId === null) {
@@ -106,6 +113,42 @@ export function useCampaignStepSubscription({
     let socket: WebSocket | null = null;
     let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
     let stopped = false;
+
+    /** Fetch missed events via REST catchup then resume live subscription. */
+    async function runCatchup(): Promise<void> {
+      const since = lastSequenceRef.current;
+      if (since === 0) return; // first connect — no catchup needed
+
+      const base = restBaseUrl ?? (typeof import.meta !== 'undefined'
+        ? ((import.meta as any)?.env?.VITE_API_BASE_URL ?? '')
+        : '');
+
+      try {
+        const res = await fetch(`${base}/api/events/catchup?since=${since}`);
+        if (!res.ok) return;
+        const body: {
+          truncated: boolean;
+          currentSequence?: number;
+          events?: Array<{ payload?: { campaignStepExecuted?: CampaignStepExecutedEvent }; sequence?: number }>;
+        } = await res.json();
+
+        if (body.truncated) {
+          setNeedsFullRefresh(true);
+          return;
+        }
+
+        for (const ev of body.events ?? []) {
+          const data = ev.payload as any;
+          // The event payload may be the raw step event or wrapped under campaignStepExecuted
+          const step: CampaignStepExecutedEvent | undefined =
+            data?.campaignStepExecuted ?? (data?.campaignId !== undefined ? data : undefined);
+          if (step) onStepExecutedRef.current(step);
+          if (ev.sequence != null) lastSequenceRef.current = ev.sequence;
+        }
+      } catch {
+        // Non-fatal — live events will cover any remaining gap
+      }
+    }
 
     function connect() {
       socket = new Impl(url, 'graphql-transport-ws');
@@ -129,25 +172,31 @@ export function useCampaignStepSubscription({
 
         switch (message.type) {
           case 'connection_ack':
-            setConnected(true);
-            socket?.send(
-              JSON.stringify({
-                id: subscriptionId,
-                type: 'subscribe',
-                payload: {
-                  query: SUBSCRIPTION_QUERY,
-                  variables: { campaignId },
-                },
-              })
-            );
+            // Run catchup before marking connected so callers see events in order
+            void runCatchup().then(() => {
+              setConnected(true);
+              socket?.send(
+                JSON.stringify({
+                  id: subscriptionId,
+                  type: 'subscribe',
+                  payload: {
+                    query: SUBSCRIPTION_QUERY,
+                    variables: { campaignId },
+                  },
+                })
+              );
+            });
             break;
           case 'next': {
             const data = (
               message.payload as {
-                data?: { campaignStepExecuted?: CampaignStepExecutedEvent };
+                data?: { campaignStepExecuted?: CampaignStepExecutedEvent & { sequence?: number } };
               }
             )?.data?.campaignStepExecuted;
-            if (data) onStepExecutedRef.current(data);
+            if (data) {
+              if (data.sequence != null) lastSequenceRef.current = data.sequence;
+              onStepExecutedRef.current(data);
+            }
             break;
           }
           case 'ping':
@@ -186,7 +235,7 @@ export function useCampaignStepSubscription({
         socket.close();
       }
     };
-  }, [campaignId, wsUrl, WebSocketImpl, reconnectDelayMs]);
+  }, [campaignId, wsUrl, WebSocketImpl, reconnectDelayMs, restBaseUrl]);
 
-  return { connected };
+  return { connected, needsFullRefresh };
 }

--- a/frontend/src/hooks/useWallet.ts
+++ b/frontend/src/hooks/useWallet.ts
@@ -10,6 +10,7 @@ import {
 } from '../services/walletKit';
 import { WalletService } from '../services/wallet';
 import type { WalletState, WalletType } from '../types';
+import { authSyncService } from '../services/authSync.service';
 
 export const WALLET_CONNECTED_KEY = 'nova_wallet_connected';
 export const WALLET_STATE_KEY = 'nova_wallet_state';
@@ -81,6 +82,9 @@ export const useWallet = (options: UseWalletOptions = {}) => {
         }));
         setError(null);
         clearWalletState();
+
+        // Invalidate server-side JWT session (#1371)
+        void authSyncService.onDisconnect();
 
         try {
             analytics.track(AnalyticsEvent.WALLET_DISCONNECTED);

--- a/frontend/src/services/__tests__/authSync.service.test.ts
+++ b/frontend/src/services/__tests__/authSync.service.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Integration tests — AuthSyncService desync scenarios (#1371)
+ *
+ * Scenario 1: Wallet disconnect → backend session invalidated
+ * Scenario 2: 401 received     → re-auth triggered, request retried
+ * Scenario 3: Page refresh with valid JWT + no wallet → reconnect prompt, no logout
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { AuthSyncService, tokenStorage } from '../authSync.service';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+// Mock apiClient so we don't make real HTTP calls
+vi.mock('../apiClient', () => ({
+  apiClient: {
+    post: vi.fn(),
+  },
+  ApiError: class ApiError extends Error {
+    constructor(public status: number, public statusText: string, public body: string) {
+      super(`${status}`);
+    }
+  },
+}));
+
+import { apiClient } from '../apiClient';
+const mockPost = vi.mocked(apiClient.post);
+
+// Stub localStorage
+const store: Record<string, string> = {};
+const localStorageMock = {
+  getItem: (k: string) => store[k] ?? null,
+  setItem: (k: string, v: string) => { store[k] = v; },
+  removeItem: (k: string) => { delete store[k]; },
+  clear: () => { Object.keys(store).forEach((k) => delete store[k]); },
+};
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock, writable: true });
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function freshService(): AuthSyncService {
+  AuthSyncService._reset();
+  return AuthSyncService.getInstance();
+}
+
+beforeEach(() => {
+  Object.keys(store).forEach((k) => delete store[k]);
+  mockPost.mockReset();
+  AuthSyncService._reset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 1 — Wallet disconnect → backend session invalidated
+// ---------------------------------------------------------------------------
+
+describe('Scenario 1: wallet disconnect invalidates backend session', () => {
+  it('calls POST /auth/logout on disconnect', async () => {
+    mockPost.mockResolvedValue({});
+    tokenStorage.setAccess('access-tok');
+    tokenStorage.setRefresh('refresh-tok');
+
+    const svc = freshService();
+    await svc.onDisconnect();
+
+    expect(mockPost).toHaveBeenCalledWith('/auth/logout');
+  });
+
+  it('clears local tokens after disconnect', async () => {
+    mockPost.mockResolvedValue({});
+    tokenStorage.setAccess('access-tok');
+    tokenStorage.setRefresh('refresh-tok');
+
+    const svc = freshService();
+    await svc.onDisconnect();
+
+    expect(tokenStorage.getAccess()).toBeNull();
+    expect(tokenStorage.getRefresh()).toBeNull();
+  });
+
+  it('clears tokens even when logout endpoint throws', async () => {
+    mockPost.mockRejectedValue(new Error('network error'));
+    tokenStorage.setAccess('access-tok');
+
+    const svc = freshService();
+    await svc.onDisconnect();
+
+    expect(tokenStorage.getAccess()).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 2 — 401 received → re-auth triggered, original request retried
+// ---------------------------------------------------------------------------
+
+describe('Scenario 2: 401 received triggers re-auth and returns new token', () => {
+  it('uses refresh token to obtain a new access token', async () => {
+    tokenStorage.setRefresh('old-refresh');
+    mockPost.mockResolvedValue({
+      accessToken: 'new-access',
+      refreshToken: 'new-refresh',
+    });
+
+    const svc = freshService();
+    const token = await svc.handleUnauthorized();
+
+    expect(mockPost).toHaveBeenCalledWith('/auth/refresh', { refreshToken: 'old-refresh' });
+    expect(token).toBe('new-access');
+    expect(tokenStorage.getAccess()).toBe('new-access');
+    expect(tokenStorage.getRefresh()).toBe('new-refresh');
+  });
+
+  it('falls back to reauthCallback when no refresh token', async () => {
+    const reauthCb = vi.fn(async () => {
+      tokenStorage.setAccess('wallet-reauth-token');
+    });
+
+    const svc = freshService();
+    svc.setReauthCallback(reauthCb);
+    const token = await svc.handleUnauthorized();
+
+    expect(reauthCb).toHaveBeenCalledOnce();
+    expect(token).toBe('wallet-reauth-token');
+  });
+
+  it('coalesces concurrent 401s into a single re-auth attempt', async () => {
+    tokenStorage.setRefresh('rf');
+    let resolveRefresh!: (v: unknown) => void;
+    mockPost.mockReturnValue(new Promise((res) => { resolveRefresh = res; }));
+
+    const svc = freshService();
+    const [p1, p2, p3] = [
+      svc.handleUnauthorized(),
+      svc.handleUnauthorized(),
+      svc.handleUnauthorized(),
+    ];
+
+    resolveRefresh({ accessToken: 'tok', refreshToken: 'rf2' });
+    const results = await Promise.all([p1, p2, p3]);
+
+    expect(mockPost).toHaveBeenCalledOnce(); // only one refresh call
+    expect(results).toEqual(['tok', 'tok', 'tok']);
+  });
+
+  it('clears tokens and returns null when both refresh and callback are unavailable', async () => {
+    tokenStorage.setAccess('stale');
+    const svc = freshService();
+    const token = await svc.handleUnauthorized();
+
+    expect(token).toBeNull();
+    expect(tokenStorage.getAccess()).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 3 — Page refresh with JWT + no wallet → reconnect prompt, no logout
+// ---------------------------------------------------------------------------
+
+describe('Scenario 3: page refresh with JWT but no wallet', () => {
+  it('sets walletReconnectNeeded when JWT present but wallet not connected', () => {
+    tokenStorage.setAccess('valid-jwt');
+    const svc = freshService();
+
+    svc.onPageLoad(false);
+
+    expect(svc.walletReconnectNeeded).toBe(true);
+    // Tokens must NOT be cleared
+    expect(tokenStorage.getAccess()).toBe('valid-jwt');
+  });
+
+  it('does not set walletReconnectNeeded when wallet is connected', () => {
+    tokenStorage.setAccess('valid-jwt');
+    const svc = freshService();
+
+    svc.onPageLoad(true);
+
+    expect(svc.walletReconnectNeeded).toBe(false);
+  });
+
+  it('does not set walletReconnectNeeded when no JWT exists', () => {
+    const svc = freshService();
+    svc.onPageLoad(false);
+    expect(svc.walletReconnectNeeded).toBe(false);
+  });
+});

--- a/frontend/src/services/apiClient.ts
+++ b/frontend/src/services/apiClient.ts
@@ -28,6 +28,8 @@
  */
 
 import { getTransactionId, TXN_ID_HEADER } from '../utils/transactionId';
+// Lazy import to avoid circular dependency (authSyncService → apiClient → authSyncService)
+import type { AuthSyncService } from './authSync.service';
 
 const CORRELATION_ID_HEADER = 'X-Correlation-Id' as const;
 
@@ -82,10 +84,19 @@ function getBaseUrl(): string {
 /** Generic JSON fetch with propagation headers. */
 async function apiFetch<T = unknown>(
   path: string,
-  init: RequestInit = {}
+  init: RequestInit = {},
+  _retry = true
 ): Promise<T> {
   const url = path.startsWith('http') ? path : `${getBaseUrl()}${path}`;
   const headers = buildRequestHeaders(init.headers);
+
+  // Inject stored access token when available
+  const storedToken = (() => {
+    try { return localStorage.getItem('nova_access_token'); } catch { return null; }
+  })();
+  if (storedToken && !headers.has('Authorization')) {
+    headers.set('Authorization', `Bearer ${storedToken}`);
+  }
 
   // Ensure JSON content type for bodies
   if (init.body && !headers.has('Content-Type')) {
@@ -96,6 +107,17 @@ async function apiFetch<T = unknown>(
   }
 
   const response = await fetch(url, { ...init, headers });
+
+  // 401 interceptor — attempt silent re-auth then retry once (#1371)
+  if (response.status === 401 && _retry) {
+    const { authSyncService } = await import('./authSync.service');
+    const newToken = await authSyncService.handleUnauthorized();
+    if (newToken) {
+      return apiFetch<T>(path, init, false);
+    }
+    const text = await response.text().catch(() => '');
+    throw new ApiError(response.status, response.statusText, text);
+  }
 
   if (!response.ok) {
     const text = await response.text().catch(() => '');

--- a/frontend/src/services/authSync.service.ts
+++ b/frontend/src/services/authSync.service.ts
@@ -1,0 +1,160 @@
+/**
+ * AuthSyncService — issue #1371
+ *
+ * Bridges the frontend wallet state and backend JWT session so they never
+ * silently desync. Three scenarios are handled:
+ *
+ * 1. Wallet disconnect  → POST /auth/logout to invalidate the server-side JWT
+ * 2. 401 received       → attempt silent re-auth; queue and retry in-flight requests
+ * 3. Page refresh with valid JWT but no wallet → set a flag so UI can prompt
+ *    reconnect without forcing a full logout
+ */
+
+import { apiClient, ApiError } from './apiClient';
+
+// ---------------------------------------------------------------------------
+// Token storage helpers (simple wrappers so tests can spy on them)
+// ---------------------------------------------------------------------------
+
+const TOKEN_KEY = 'nova_access_token';
+const REFRESH_KEY = 'nova_refresh_token';
+
+export const tokenStorage = {
+  getAccess: (): string | null => localStorage.getItem(TOKEN_KEY),
+  setAccess: (t: string): void => { localStorage.setItem(TOKEN_KEY, t); },
+  getRefresh: (): string | null => localStorage.getItem(REFRESH_KEY),
+  setRefresh: (t: string): void => { localStorage.setItem(REFRESH_KEY, t); },
+  clear: (): void => {
+    localStorage.removeItem(TOKEN_KEY);
+    localStorage.removeItem(REFRESH_KEY);
+  },
+};
+
+// ---------------------------------------------------------------------------
+// AuthSyncService
+// ---------------------------------------------------------------------------
+
+type ReauthCallback = () => Promise<void>;
+
+export class AuthSyncService {
+  private static _instance: AuthSyncService | null = null;
+
+  /** True when a re-auth is already in progress (prevents parallel attempts). */
+  private _reauthInProgress = false;
+
+  /** Queued resolvers waiting for re-auth to complete. */
+  private _reauthQueue: Array<(token: string | null) => void> = [];
+
+  /** Registered re-authentication callback (set by wallet connect flow). */
+  private _reauthCallback: ReauthCallback | null = null;
+
+  /** True when we detected a valid JWT on load but the wallet is not connected. */
+  private _walletReconnectNeeded = false;
+
+  static getInstance(): AuthSyncService {
+    if (!AuthSyncService._instance) {
+      AuthSyncService._instance = new AuthSyncService();
+    }
+    return AuthSyncService._instance;
+  }
+
+  /** Register the callback that reconnects the wallet and re-issues a JWT. */
+  setReauthCallback(cb: ReauthCallback): void {
+    this._reauthCallback = cb;
+  }
+
+  get walletReconnectNeeded(): boolean {
+    return this._walletReconnectNeeded;
+  }
+
+  /**
+   * Called on page load. If a JWT exists but the wallet is not connected,
+   * flag that a wallet reconnect prompt is needed instead of forcing logout.
+   */
+  onPageLoad(walletConnected: boolean): void {
+    const hasToken = Boolean(tokenStorage.getAccess());
+    this._walletReconnectNeeded = hasToken && !walletConnected;
+  }
+
+  /**
+   * Called when the user disconnects their wallet.
+   * Invalidates the server-side JWT then clears local tokens.
+   */
+  async onDisconnect(): Promise<void> {
+    try {
+      await apiClient.post('/auth/logout');
+    } catch {
+      // Best-effort — proceed with local cleanup regardless
+    }
+    tokenStorage.clear();
+    this._walletReconnectNeeded = false;
+  }
+
+  /**
+   * Called when a 401 response is received on any API request.
+   * Attempts to re-authenticate silently; returns the new access token on
+   * success or null on failure.  Multiple concurrent callers are coalesced
+   * into a single re-auth attempt.
+   */
+  async handleUnauthorized(): Promise<string | null> {
+    if (this._reauthInProgress) {
+      // Wait for the in-progress re-auth
+      return new Promise<string | null>((resolve) => {
+        this._reauthQueue.push(resolve);
+      });
+    }
+
+    this._reauthInProgress = true;
+
+    try {
+      // 1. Try silent refresh via refresh token
+      const refreshToken = tokenStorage.getRefresh();
+      if (refreshToken) {
+        const data = await apiClient.post<{ accessToken: string; refreshToken: string }>(
+          '/auth/refresh',
+          { refreshToken }
+        );
+        tokenStorage.setAccess(data.accessToken);
+        tokenStorage.setRefresh(data.refreshToken);
+        this._drainQueue(data.accessToken);
+        return data.accessToken;
+      }
+
+      // 2. Fall back to wallet re-auth callback if registered
+      if (this._reauthCallback) {
+        await this._reauthCallback();
+        const newToken = tokenStorage.getAccess();
+        this._drainQueue(newToken);
+        return newToken;
+      }
+
+      // 3. Cannot recover — clear tokens and signal failure
+      tokenStorage.clear();
+      this._walletReconnectNeeded = true;
+      this._drainQueue(null);
+      return null;
+    } catch (err) {
+      tokenStorage.clear();
+      this._walletReconnectNeeded = true;
+      this._drainQueue(null);
+      return null;
+    } finally {
+      this._reauthInProgress = false;
+    }
+  }
+
+  /** @internal — drain the queue after re-auth completes */
+  private _drainQueue(token: string | null): void {
+    for (const resolve of this._reauthQueue) {
+      resolve(token);
+    }
+    this._reauthQueue = [];
+  }
+
+  /** Reset singleton state (test helper). */
+  static _reset(): void {
+    AuthSyncService._instance = null;
+  }
+}
+
+export const authSyncService = AuthSyncService.getInstance();


### PR DESCRIPTION
PR #1 — Issue #1371
  
  Title
  
  feat(integration): wallet state synchronization with backend JWT session lifecycle
  
  Description
  
  ## Problem
  
  The frontend `useWallet` hook and backend JWT session could silently desync in three ways:
  
  1. User disconnects wallet locally → server JWT stays valid → subsequent requests succeed when they shouldn't
  2. JWT expires on the server → frontend gets a 401 with no recovery path → user is stuck until manual page reload
  3. Page refresh with a valid JWT but no connected wallet → app forces a full logout and loses session state unnecessarily
  
  ## Solution
  
  ### `frontend/src/services/authSync.service.ts` (new)
  
  `AuthSyncService` singleton that bridges the two states:
  
  - **`onDisconnect()`** — calls `POST /auth/logout` to invalidate the server-side JWT, then clears `nova_access_token` and `nova_refresh_token` from
  localStorage. Proceeds with local cleanup even if the logout request fails (network-safe).
  - **`handleUnauthorized()`** — called by the API client on any 401 response. Attempts silent recovery in order:
    1. Exchange refresh token via `POST /auth/refresh`
    2. Fall back to registered wallet re-auth callback
    3. Clear tokens and set `walletReconnectNeeded = true` if both fail
    
    Multiple concurrent 401s are coalesced into a single re-auth attempt — queued callers all receive the same new token when it resolves.
  - **`onPageLoad(walletConnected)`** — called on app boot. If a JWT exists but the wallet is not connected, sets `walletReconnectNeeded = true` so the UI
  can prompt reconnection without destroying the existing session.
  
  ### `frontend/src/hooks/useWallet.ts` (modified)
  
  Added `void authSyncService.onDisconnect()` to the `disconnect` callback so every wallet disconnect triggers backend session invalidation.
  
  ### `frontend/src/services/apiClient.ts` (modified)
  
  Added a 401 response interceptor inside `apiFetch`. On a 401:
  1. Calls `authSyncService.handleUnauthorized()` to attempt re-auth
  2. If a new token is obtained, retries the original request exactly once with the new `Authorization` header
  3. If re-auth fails, throws `ApiError(401)` as before
  
  The interceptor is skipped on the retry (`_retry = false`) to prevent infinite loops.
  
  ## Tests
  
  `frontend/src/services/__tests__/authSync.service.test.ts` — 10 tests:
  
  | Scenario | Tests |
  |---|---|
  | Wallet disconnect → `POST /auth/logout` called, tokens cleared | 3 |
  | 401 → refresh token exchange, wallet callback fallback, concurrent coalescing, null on failure | 4 |
  | Page refresh + JWT + no wallet → `walletReconnectNeeded` set, tokens preserved | 3 |
  
  All 10 passing ✅
  
  ## Files Changed
  
  frontend/src/services/authSync.service.ts        (new, 160 lines)
  frontend/src/services/tests/authSync.service.test.ts  (new, 192 lines)
  frontend/src/hooks/useWallet.ts                  (modified — 3 lines)
  frontend/src/services/apiClient.ts               (modified — ~25 lines)
  
  Closes #1371
  
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
  PR #2 — Issue #1372
  
  Title
  
  feat(integration): GraphQL subscription missed-event catchup via REST fallback on reconnect
  
  Description
  
  ## Problem
  
  When the WebSocket connection drops and reconnects, the client misses any events emitted during the disconnection window. There was no mechanism to
  backfill those events, so the UI could silently show stale state after every reconnect.
  
  ## Solution
  
  ### `backend/src/services/eventBus.ts` (modified)
  
  Added a monotonically incrementing `_sequence` counter to `EventBus`:
  
  - Every `publish()` call increments `_sequence` and attaches the value as `sequence: number` on the `BusEvent` object
  - Exposed via a `currentSequence` getter
  - `reset()` resets the counter to 0 (consistent with history/DLQ reset)
  
  The `BusEvent` interface gains `sequence: number` — all existing consumers receive this field automatically with no breaking change.
  
  ### `backend/src/routes/events.ts` (new)
  
  `GET /api/events/catchup?since=<sequence>` endpoint:
  
  - Returns all events from `eventBus.getHistory()` with `sequence > since`, sorted ascending
  - **Truncation guard**: if `currentSequence - since > 1000`, returns `{ truncated: true, currentSequence }` instead of the event list — the client must
  do a full REST refresh
  - Returns `{ truncated: false, events: [...], currentSequence }` on a normal response
  - Registered at `/api/events` in `backend/src/index.ts`
  
  ### `frontend/src/hooks/useCampaignStepSubscription.ts` (modified)
  
  - Added `lastSequenceRef` — updated on every received live event from `sequence` field in the payload
  - Added `runCatchup()` — called after `connection_ack` when `lastSequenceRef.current > 0` (i.e. this is a reconnect, not a fresh connect):
    1. Fetches `GET /api/events/catchup?since=<lastSequence>`
    2. If `truncated: true` → sets `needsFullRefresh = true` and returns
    3. Otherwise replays missed events through `onStepExecuted` in sequence order, updating `lastSequenceRef`
  - `connection_ack` handler now awaits `runCatchup()` before sending the `subscribe` message and marking `connected: true` — guarantees events are
  delivered in order
  - Added `restBaseUrl` prop for test injection
  - Return type extended with `needsFullRefresh: boolean`
  
  ## Catchup flow diagram
  
  reconnect
      │
      ▼
  connection_ack received
      │
      ▼
  GET /api/events/catchup?since=<lastSequence>
      │
      ├── truncated: true  ──► needsFullRefresh = true ──► caller does full REST fetch
      │
      └── events: [...]    ──► replay each event via onStepExecuted
                                │
                                ▼
                           send 'subscribe' message
                                │
                                ▼
                           connected = true, live events resume
  
  ## Tests
  
  | Suite | Tests | Covers |
  |---|---|---|
  | `backend/src/routes/__tests__/events.catchup.test.ts` | 6 | missing `since`, non-numeric `since`, empty result, ordered events, truncation at >1000,
  `currentSequence` in all responses |
  | `frontend/src/hooks/__tests__/useCampaignStepSubscription.catchup.test.ts` | 3 | normal catchup replay, truncation → `needsFullRefresh`, no gap →
  immediate connect |
  
  All 9 passing ✅
  
  ## Files Changed
  
  backend/src/services/eventBus.ts                                         (modified — sequence counter)
  backend/src/routes/events.ts                                             (new, 44 lines)
  backend/src/routes/tests/events.catchup.test.ts                      (new, 93 lines)
  backend/src/index.ts                                                      (modified — 2 lines, route registration)
  frontend/src/hooks/useCampaignStepSubscription.ts                        (modified — catchup logic)
  frontend/src/hooks/tests/useCampaignStepSubscription.catchup.test.ts (new, 170 lines)
  
  Closes #1372
  
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
  PR #3 — Issue #1373
  
  Title
  
  feat(integration): cascading failure detection and dependency tree in health check aggregation
  
  Description
  
  ## Problem
  
  `health.service.ts` ran individual health checks in isolation. A Redis failure that cascaded through dependent services appeared as three separate
  failures in the `/health/detailed` response, with no indication of root cause vs. downstream impact. On-call engineers had to manually reason about the
  dependency chain. PagerDuty received one alert per affected service (3×) instead of one per root cause.
  
  ## Solution
  
  ### `backend/src/lib/health/health.types.ts` (modified)
  
  Added to `ServiceHealth`:
  ```typescript
  cascaded?: boolean;   // true if this service failed due to an upstream dependency
  rootCause?: string | null;  // name of the upstream service that caused this failure
  
  New exports:
  
  // Dependency map: upstream → list of services that depend on it
  type ServiceDependencyGraph = Record<string, string[]>;
  
  // Default graph for Nova Launch
  const DEFAULT_DEPENDENCY_GRAPH: ServiceDependencyGraph = {
    cache:    ['stellarHorizon', 'stellarSoroban', 'ipfs'],
    database: ['ipfs'],
  };
  
  DetailedHealthCheckResult gains rootCauses: string[] — the names of services that failed on their own (not cascaded).
  
  backend/src/lib/health/health.service.ts (modified)
  
  applyCascadingFailures(services, graph) (new public method):
  
  Traverses the dependency graph after all individual checks complete:
  
  1. For each upstream service that is not "up", marks it as a root cause
  2. For each of its dependents: if the dependent was already "up", sets its status to "degraded", cascaded: true, rootCause: <upstream>; if it was
  already failing, marks it cascaded: true without overwriting its own error
  3. Any failing service not reachable via the graph is also added to root causes
  4. Returns the deduplicated list of root cause names
  
  checkDetailedHealth() updated to:
  
  1. Call applyCascadingFailures() on the raw service results
  2. Fire dispatchAlert() once per root cause — not once per cascaded service
  3. Include rootCauses in the returned DetailedHealthCheckResult
  
  Example: Redis (cache) failure
  
  Before:
  
  {
    "services": {
      "cache":         { "status": "down" },
      "stellarHorizon": { "status": "down" },
      "stellarSoroban": { "status": "down" },
      "ipfs":           { "status": "down" }
    }
  }
  // → 4 PagerDuty alerts
  
  After:
  
  {
    "services": {
      "cache":          { "status": "down" },
      "stellarHorizon": { "status": "degraded", "cascaded": true, "rootCause": "cache" },
      "stellarSoroban": { "status": "degraded", "cascaded": true, "rootCause": "cache" },
      "ipfs":           { "status": "degraded", "cascaded": true, "rootCause": "cache" }
    },
    "rootCauses": ["cache"]
  }
  // → 1 PagerDuty alert
  
  Tests
  
  backend/src/lib/health/__tests__/cascading.test.ts — 6 tests:
  
  ┌─────────────────────┬───────────────────────────────────────────────────────────────────────────┐
  │ Test                │ Asserts                                                                   │
  ├────────────────────────┼───────────────────────────────────────────────────────────────────────────┤
  │ All healthy            │ No root causes, no cascaded flags                                         │
  ├─────────────────────────┼───────────────────────────────────────────────────────────────────────────┤
  │ Cache down              │ stellarHorizon, stellarSoroban, ipfs → cascaded: true, rootCause: "cache" │
  ├─────────────────────────┼───────────────────────────────────────────────────────────────────────────┤
  │ Database down           │ ipfs → cascaded: true, rootCause: "database", stellar services unaffected │
  ├─────────────────────────┼───────────────────────────────────────────────────────────────────────────┤
  │ Independent failure     │ Service with no upstream dependency is its own root cause                 │
  ├─────────────────────────┼───────────────────────────────────────────────────────────────────────────┤
  │ No alerts when healthy  │ dispatchAlert not called                                                  │
  ├─────────────────────────┼───────────────────────────────────────────────────────────────────────────┤
  │ Cache failure → 1 alert │ dispatchAlert called exactly once, with "cache" in the key                │
  └─────────────────────────┴───────────────────────────────────────────────────────────────────────────┘
  
  All 6 passing ✅
  
  Files Changed
  
  backend/src/lib/health/health.types.ts                   (modified — ServiceDependencyGraph, cascaded fields)
  backend/src/lib/health/health.service.ts                 (modified — applyCascadingFailures, PagerDuty alerting)
  backend/src/lib/health/__tests__/cascading.test.ts       (new, 116 lines)
  
  Closes #1373
  
