### PR TITLE
test: E2E governance lifecycle, HMAC timing-attack, token search load, and burnValidation property tests

### DIFF
--- a/backend/src/__tests__/inbound-webhook-hmac.integration.test.ts
+++ b/backend/src/__tests__/inbound-webhook-hmac.integration.test.ts
@@ -1,8 +1,10 @@
 /**
- * Integration tests for inbound webhook HMAC verification (#1157).
+ * Integration tests for inbound webhook HMAC verification (#1157, #1300).
+ * Extended with timing-attack vector coverage per issue #1300.
  */
 
 import { describe, it, expect, vi } from "vitest";
+import crypto from "crypto";
 import { Request, Response, NextFunction } from "express";
 import {
   verifyInboundWebhookSignature,
@@ -140,4 +142,95 @@ describe("verifyInboundWebhookSignature (#1157)", () => {
     expect(mock.statusCode).toBe(401);
     expect(next).not.toHaveBeenCalled();
   });
+});
+
+// ---------------------------------------------------------------------------
+// Timing-attack vector coverage (#1300)
+// ---------------------------------------------------------------------------
+
+describe("HMAC timing-attack vector coverage (#1300)", () => {
+  const secret = generateWebhookSecret();
+  const payload = JSON.stringify({ event: "token.burned", data: { id: "t1" } });
+
+  // Helper: run the middleware and return elapsed nanoseconds
+  async function measureVerification(signatureHeader: string): Promise<bigint> {
+    const req = makeReq(payload, signatureHeader);
+    const mock = makeRes();
+    const next = vi.fn() as unknown as NextFunction;
+    const middleware = verifyInboundWebhookSignature(async () => secret);
+
+    const start = process.hrtime.bigint();
+    await middleware(req as Request, mock.res as Response, next);
+    return process.hrtime.bigint() - start;
+  }
+
+  it("crypto.timingSafeEqual is invoked for every valid-format verification", async () => {
+    const spy = vi.spyOn(crypto, "timingSafeEqual");
+    spy.mockClear();
+
+    const signature = generateWebhookSignature(payload, secret);
+    const req = makeReq(payload, signature);
+    const mock = makeRes();
+    const next = vi.fn() as unknown as NextFunction;
+
+    const middleware = verifyInboundWebhookSignature(async () => secret);
+    await middleware(req as Request, mock.res as Response, next);
+
+    // timingSafeEqual must have been called at least once
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it("truncated signature is rejected", async () => {
+    const full = generateWebhookSignature(payload, secret);
+    const truncated = full.slice(0, full.length - 8); // strip last 8 hex chars
+    const req = makeReq(payload, truncated);
+    const mock = makeRes();
+    const next = vi.fn() as unknown as NextFunction;
+
+    const middleware = verifyInboundWebhookSignature(async () => secret);
+    await middleware(req as Request, mock.res as Response, next);
+
+    expect(mock.statusCode).toBe(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("replay attack: timestamp older than 5 minutes is rejected", async () => {
+    const staleTimestamp = Math.floor(Date.now() / 1000) - 301; // 5 min 1 sec ago
+    const signature = generateWebhookSignature(payload, secret, staleTimestamp);
+    const req = makeReq(payload, signature);
+    const mock = makeRes();
+    const next = vi.fn() as unknown as NextFunction;
+
+    const middleware = verifyInboundWebhookSignature(async () => secret);
+    await middleware(req as Request, mock.res as Response, next);
+
+    expect(mock.statusCode).toBe(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("p95 response-time variance between valid and invalid signatures is < 5 ms", async () => {
+    const TRIALS = 100;
+    const validSig = generateWebhookSignature(payload, secret);
+    const invalidSig = generateWebhookSignature(payload, "wrong-secret-key-value");
+
+    const validTimes: bigint[] = [];
+    const invalidTimes: bigint[] = [];
+
+    for (let i = 0; i < TRIALS; i++) {
+      validTimes.push(await measureVerification(validSig));
+      invalidTimes.push(await measureVerification(invalidSig));
+    }
+
+    const p95 = (times: bigint[]): number => {
+      const sorted = [...times].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+      const idx = Math.floor(sorted.length * 0.95);
+      return Number(sorted[idx]) / 1_000_000; // ns → ms
+    };
+
+    const diff = Math.abs(p95(validTimes) - p95(invalidTimes));
+
+    // p95 timing difference must stay under 5 ms to be timing-safe
+    expect(diff).toBeLessThan(5);
+  }, 30_000); // allow 30s for 200 sequential async calls
 });

--- a/e2e/governance-lifecycle.spec.ts
+++ b/e2e/governance-lifecycle.spec.ts
@@ -1,0 +1,233 @@
+/**
+ * E2E: Full Governance Proposal Lifecycle
+ *
+ * Covers proposal creation → vote submission → queue → execute,
+ * asserting UI state at each step via Playwright against the dev stack.
+ *
+ * Requires STELLAR_NETWORK=testnet and a funded disposable test account.
+ * The testnet-faucet helper seeds XLM before the suite runs.
+ *
+ * Closes #1299
+ */
+
+import { test, expect, Page } from "@playwright/test";
+
+// ---------------------------------------------------------------------------
+// Selectors — kept in one place so breakage is easy to fix
+// ---------------------------------------------------------------------------
+const SEL = {
+  connectWalletBtn: '[data-testid="connect-wallet"]',
+  createProposalBtn: '[data-testid="create-proposal-btn"]',
+  proposalTitleInput: '[data-testid="proposal-title-input"]',
+  proposalDescInput: '[data-testid="proposal-description-input"]',
+  submitProposalBtn: '[data-testid="submit-proposal-btn"]',
+  proposalStatusChip: '[data-testid="proposal-status-chip"]',
+  voteForBtn: '[data-testid="vote-for-btn"]',
+  voteAgainstBtn: '[data-testid="vote-against-btn"]',
+  queueProposalBtn: '[data-testid="queue-proposal-btn"]',
+  executeProposalBtn: '[data-testid="execute-proposal-btn"]',
+  toastSuccess: '[data-testid="toast-success"]',
+  proposalCard: '[data-testid="proposal-card"]',
+};
+
+const BASE = "http://localhost:5173";
+const GOVERNANCE_URL = `${BASE}/governance`;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function navigateToGovernance(page: Page): Promise<void> {
+  await page.goto(GOVERNANCE_URL);
+  await page.waitForLoadState("networkidle");
+}
+
+async function waitForStatusChip(page: Page, status: string): Promise<void> {
+  await page.waitForFunction(
+    ({ sel, expected }: { sel: string; expected: string }) => {
+      const chip = document.querySelector(sel);
+      return chip?.textContent?.toLowerCase().includes(expected.toLowerCase());
+    },
+    { sel: SEL.proposalStatusChip, expected: status },
+    { timeout: 15_000 }
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+test.describe("Governance Proposal Lifecycle (#1299)", () => {
+  test.beforeEach(async ({ page }) => {
+    // Stub the Stellar wallet so tests run without a real browser extension
+    await page.addInitScript(() => {
+      (window as any).__STELLAR_WALLET_STUB__ = {
+        isConnected: () => true,
+        getPublicKey: () =>
+          "GTEST000000000000000000000000000000000000000000000000000001",
+        signTransaction: (xdr: string) => Promise.resolve(xdr),
+      };
+    });
+
+    await navigateToGovernance(page);
+  });
+
+  // -- 1. Proposal creation --------------------------------------------------
+
+  test("user can submit a governance proposal and see it listed", async ({
+    page,
+  }) => {
+    const title = `E2E Proposal ${Date.now()}`;
+
+    await page.click(SEL.createProposalBtn);
+    await page.fill(SEL.proposalTitleInput, title);
+    await page.fill(
+      SEL.proposalDescInput,
+      "Automated E2E test proposal — verifies the creation flow end-to-end."
+    );
+    await page.click(SEL.submitProposalBtn);
+
+    // Optimistic UI: status chip should show "active" without page refresh
+    await waitForStatusChip(page, "active");
+
+    // The new proposal card should appear in the list
+    const cards = page.locator(SEL.proposalCard);
+    await expect(cards.filter({ hasText: title })).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+
+  // -- 2. Vote submission ----------------------------------------------------
+
+  test("user can cast a vote and the tally updates without page refresh", async ({
+    page,
+  }) => {
+    // Assume at least one active proposal is visible (seeded or created above)
+    const firstCard = page.locator(SEL.proposalCard).first();
+    await firstCard.waitFor({ timeout: 10_000 });
+    await firstCard.click();
+
+    await page.click(SEL.voteForBtn);
+
+    // Vote count or status must update via WebSocket — assert without reload
+    await expect(
+      page.locator('[data-testid="vote-for-count"]')
+    ).not.toHaveText("0", { timeout: 10_000 });
+
+    await expect(page.locator(SEL.toastSuccess)).toBeVisible({
+      timeout: 8_000,
+    });
+  });
+
+  test("user can cast a vote against and status remains 'active'", async ({
+    page,
+  }) => {
+    const firstCard = page.locator(SEL.proposalCard).first();
+    await firstCard.waitFor({ timeout: 10_000 });
+    await firstCard.click();
+
+    await page.click(SEL.voteAgainstBtn);
+    await expect(page.locator(SEL.toastSuccess)).toBeVisible({
+      timeout: 8_000,
+    });
+
+    // Proposal stays active — quorum not yet reached
+    await waitForStatusChip(page, "active");
+  });
+
+  // -- 3. Queue --------------------------------------------------------------
+
+  test("passed proposal can be queued and status chip updates to 'queued'", async ({
+    page,
+  }) => {
+    // Navigate directly to a proposal that is in "passed" state (seeded)
+    await page.goto(`${GOVERNANCE_URL}?status=passed`);
+    await page.waitForLoadState("networkidle");
+
+    const passedCard = page.locator(SEL.proposalCard).first();
+    await passedCard.waitFor({ timeout: 10_000 });
+    await passedCard.click();
+
+    const queueBtn = page.locator(SEL.queueProposalBtn);
+    // Only present for eligible proposals — skip if not rendered
+    if (await queueBtn.isVisible()) {
+      await queueBtn.click();
+      await waitForStatusChip(page, "queued");
+      await expect(page.locator(SEL.toastSuccess)).toBeVisible({
+        timeout: 8_000,
+      });
+    } else {
+      test.skip(); // no passed proposal seeded in this environment
+    }
+  });
+
+  // -- 4. Execute ------------------------------------------------------------
+
+  test("queued proposal can be executed and status chip updates to 'executed'", async ({
+    page,
+  }) => {
+    await page.goto(`${GOVERNANCE_URL}?status=queued`);
+    await page.waitForLoadState("networkidle");
+
+    const queuedCard = page.locator(SEL.proposalCard).first();
+    await queuedCard.waitFor({ timeout: 10_000 });
+    await queuedCard.click();
+
+    const executeBtn = page.locator(SEL.executeProposalBtn);
+    if (await executeBtn.isVisible()) {
+      await executeBtn.click();
+      await waitForStatusChip(page, "executed");
+      await expect(page.locator(SEL.toastSuccess)).toBeVisible({
+        timeout: 8_000,
+      });
+    } else {
+      test.skip();
+    }
+  });
+
+  // -- 5. Real-time update via WebSocket/subscription -----------------------
+
+  test("proposal status chip refreshes automatically without manual reload", async ({
+    page,
+    context,
+  }) => {
+    // Open a second page to simulate another user changing the state
+    const secondPage = await context.newPage();
+    await secondPage.addInitScript(() => {
+      (window as any).__STELLAR_WALLET_STUB__ = {
+        isConnected: () => true,
+        getPublicKey: () =>
+          "GTEST000000000000000000000000000000000000000000000000000002",
+        signTransaction: (xdr: string) => Promise.resolve(xdr),
+      };
+    });
+
+    await secondPage.goto(GOVERNANCE_URL);
+    await secondPage.waitForLoadState("networkidle");
+
+    const firstCard = page.locator(SEL.proposalCard).first();
+    await firstCard.waitFor({ timeout: 10_000 });
+    await firstCard.click();
+
+    const initialStatus = await page
+      .locator(SEL.proposalStatusChip)
+      .textContent();
+
+    // Vote from second page — should push a WS event to the first page
+    await secondPage.locator(SEL.proposalCard).first().click();
+    await secondPage.click(SEL.voteForBtn);
+    await secondPage.locator(SEL.toastSuccess).waitFor({ timeout: 8_000 });
+
+    // First page must reflect the change without reload
+    await page.waitForFunction(
+      ({ sel, prev }: { sel: string; prev: string | null }) => {
+        const el = document.querySelector(sel);
+        return el?.textContent !== prev;
+      },
+      { sel: SEL.proposalStatusChip, prev: initialStatus },
+      { timeout: 12_000 }
+    );
+
+    await secondPage.close();
+  });
+});

--- a/frontend/src/utils/__tests__/burnValidation.property.test.ts
+++ b/frontend/src/utils/__tests__/burnValidation.property.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Property-based tests for burnValidation BigInt overflow/underflow scenarios.
+ *
+ * Uses fast-check with fc.bigInt generators to assert four core properties:
+ *  1. burn > supply   → always rejected
+ *  2. zero amount     → always rejected
+ *  3. burn = supply   → accepted (full burn)
+ *  4. negative amount → always rejected
+ *
+ * Also includes explicit edge-case fixtures for boundary values.
+ *
+ * Run: npx vitest run src/utils/__tests__/burnValidation.property.test.ts
+ *
+ * Closes #1302
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as fc from 'fast-check';
+
+// ---------------------------------------------------------------------------
+// The functions under test work with numeric strings (the existing API).
+// We convert BigInt test values to string to feed them in.
+// ---------------------------------------------------------------------------
+import {
+  validateBurnAmount,
+  isValidBurnAmount,
+} from '../burnValidation';
+
+// ---------------------------------------------------------------------------
+// Valid address stubs (required by validateBurnAmount)
+// ---------------------------------------------------------------------------
+const USER_ADDRESS = `G${'A'.repeat(55)}`;
+const TOKEN_ADDRESS = `C${'A'.repeat(55)}`;
+
+function makeParams(amount: string, balance: string) {
+  return {
+    amount,
+    balance,
+    decimals: 7,
+    userAddress: USER_ADDRESS,
+    tokenAddress: TOKEN_ADDRESS,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// BigInt arbitrary helpers
+// ---------------------------------------------------------------------------
+
+// Positive supply in range [1, 2^63-1] — avoids floats losing precision
+const positiveSupply = () =>
+  fc.bigInt({ min: 1n, max: 9_223_372_036_854_775_807n });
+
+// Amount strictly greater than supply
+const amountExceedingSupply = (supply: bigint) =>
+  fc.bigInt({ min: supply + 1n, max: supply * 2n + 1n });
+
+// Amount in range [1, supply]
+const validBurnAmount = (supply: bigint) =>
+  fc.bigInt({ min: 1n, max: supply });
+
+// ---------------------------------------------------------------------------
+// Property 1: burn amount > supply → always rejected
+// ---------------------------------------------------------------------------
+describe('burnValidation property tests (#1302)', () => {
+  it('P1: amount > supply is always rejected', () => {
+    fc.assert(
+      fc.property(
+        positiveSupply().chain((supply) =>
+          amountExceedingSupply(supply).map((amount) => ({ supply, amount }))
+        ),
+        ({ supply, amount }) => {
+          const result = validateBurnAmount(
+            makeParams(amount.toString(), supply.toString())
+          );
+          expect(result.valid).toBe(false);
+          expect(result.errors.amount).toBeTruthy();
+        }
+      ),
+      { numRuns: 500 }
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // Property 2: zero amount → always rejected
+  // ---------------------------------------------------------------------------
+  it('P2: zero amount is always rejected regardless of supply', () => {
+    fc.assert(
+      fc.property(positiveSupply(), (supply) => {
+        const result = validateBurnAmount(makeParams('0', supply.toString()));
+        expect(result.valid).toBe(false);
+        expect(result.errors.amount).toBeTruthy();
+        expect(result.errors.amount).toMatch(/greater than zero/i);
+      }),
+      { numRuns: 500 }
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // Property 3: amount = supply → accepted (full burn is valid)
+  // ---------------------------------------------------------------------------
+  it('P3: amount equal to supply is accepted (full burn)', () => {
+    fc.assert(
+      fc.property(positiveSupply(), (supply) => {
+        const result = validateBurnAmount(
+          makeParams(supply.toString(), supply.toString())
+        );
+        // Only amount/address errors matter — a full burn should be valid
+        expect(result.errors.amount).toBeUndefined();
+      }),
+      { numRuns: 500 }
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // Property 4: negative amount → always rejected
+  // ---------------------------------------------------------------------------
+  it('P4: negative amount is always rejected', () => {
+    fc.assert(
+      fc.property(
+        fc.bigInt({ min: -9_223_372_036_854_775_807n, max: -1n }),
+        positiveSupply(),
+        (negativeAmount, supply) => {
+          const result = validateBurnAmount(
+            makeParams(negativeAmount.toString(), supply.toString())
+          );
+          expect(result.valid).toBe(false);
+          expect(result.errors.amount).toBeTruthy();
+        }
+      ),
+      { numRuns: 500 }
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // Property 5 (bonus): valid [1, supply] amounts produce human-readable errors
+  //   for OTHER fields (address) but no amount error
+  // ---------------------------------------------------------------------------
+  it('P5: any amount in [1, supply] produces no amount validation error', () => {
+    fc.assert(
+      fc.property(
+        positiveSupply().chain((supply) =>
+          validBurnAmount(supply).map((amount) => ({ supply, amount }))
+        ),
+        ({ supply, amount }) => {
+          const params = makeParams(amount.toString(), supply.toString());
+          const result = validateBurnAmount(params);
+          expect(result.errors.amount).toBeUndefined();
+        }
+      ),
+      { numRuns: 500 }
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // Explicit edge-case fixtures
+  // ---------------------------------------------------------------------------
+  describe('edge-case fixtures', () => {
+    const SUPPLY = '1000000';
+
+    it('BigInt(0) is rejected with a human-readable message', () => {
+      const result = validateBurnAmount(makeParams('0', SUPPLY));
+      expect(result.valid).toBe(false);
+      expect(result.errors.amount).toMatch(/greater than zero/i);
+    });
+
+    it('BigInt(-1) is rejected with a human-readable message', () => {
+      const result = validateBurnAmount(makeParams('-1', SUPPLY));
+      expect(result.valid).toBe(false);
+      expect(result.errors.amount).toBeTruthy();
+    });
+
+    it('supply + BigInt(1) is rejected with an insufficient-balance message', () => {
+      const overAmount = (BigInt(SUPPLY) + 1n).toString();
+      const result = validateBurnAmount(makeParams(overAmount, SUPPLY));
+      expect(result.valid).toBe(false);
+      expect(result.errors.amount).toMatch(/insufficient balance/i);
+    });
+
+    it('near Number.MAX_SAFE_INTEGER: amount === supply is accepted', () => {
+      const near = BigInt(Number.MAX_SAFE_INTEGER).toString();
+      const result = validateBurnAmount(makeParams(near, near));
+      expect(result.errors.amount).toBeUndefined();
+    });
+
+    it('near Number.MAX_SAFE_INTEGER: amount > supply is rejected', () => {
+      const supply = BigInt(Number.MAX_SAFE_INTEGER);
+      const over = (supply + 1n).toString();
+      const result = validateBurnAmount(makeParams(over, supply.toString()));
+      expect(result.valid).toBe(false);
+      expect(result.errors.amount).toMatch(/insufficient balance/i);
+    });
+
+    it('amount = supply = 1 is the smallest valid full burn', () => {
+      const result = validateBurnAmount(makeParams('1', '1'));
+      expect(result.errors.amount).toBeUndefined();
+    });
+
+    it('empty string amount is rejected', () => {
+      const result = validateBurnAmount(makeParams('', SUPPLY));
+      expect(result.valid).toBe(false);
+      expect(result.errors.amount).toBeTruthy();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // isValidBurnAmount: quick helper parity checks
+  // ---------------------------------------------------------------------------
+  describe('isValidBurnAmount parity', () => {
+    it('returns false for zero amount', () => {
+      expect(isValidBurnAmount('0', '1000')).toBe(false);
+    });
+
+    it('returns false for negative amount', () => {
+      expect(isValidBurnAmount('-1', '1000')).toBe(false);
+    });
+
+    it('returns false when amount exceeds balance', () => {
+      expect(isValidBurnAmount('1001', '1000')).toBe(false);
+    });
+
+    it('returns true for amount equal to balance', () => {
+      expect(isValidBurnAmount('1000', '1000')).toBe(true);
+    });
+
+    it('returns true for a valid partial amount', () => {
+      expect(isValidBurnAmount('500', '1000')).toBe(true);
+    });
+  });
+});

--- a/load-tests/scenarios/token-search-load.js
+++ b/load-tests/scenarios/token-search-load.js
@@ -1,0 +1,166 @@
+/**
+ * Load test: Token full-text search under high-concurrency read pressure.
+ *
+ * Target: 50 concurrent users, 60-second sustained load.
+ * SLOs:   p95 response time < 500 ms, error rate < 0.1%.
+ *
+ * Query terms are randomised from a 200-term dictionary to avoid cache hits
+ * masking real index performance.
+ *
+ * Run: k6 run load-tests/scenarios/token-search-load.js
+ *
+ * Closes #1301
+ */
+
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Rate, Trend, Counter } from 'k6/metrics';
+import { config } from '../config/test-config.js';
+
+// ---------------------------------------------------------------------------
+// Custom metrics
+// ---------------------------------------------------------------------------
+const searchErrorRate = new Rate('token_search_errors');
+const searchDuration = new Trend('token_search_duration_ms', true);
+const totalRequests = new Counter('token_search_total_requests');
+
+// ---------------------------------------------------------------------------
+// Test options
+// ---------------------------------------------------------------------------
+export const options = {
+  scenarios: {
+    sustained_load: {
+      executor: 'constant-vus',
+      vus: 50,
+      duration: '60s',
+    },
+  },
+  thresholds: {
+    // Core SLOs from issue #1301
+    token_search_duration_ms: ['p(95)<500'],
+    token_search_errors: ['rate<0.001'],
+    // Stdlib fallback
+    http_req_duration: ['p(95)<500'],
+    http_req_failed: ['rate<0.001'],
+  },
+};
+
+// ---------------------------------------------------------------------------
+// 200-term dictionary of realistic token name/symbol search terms
+// ---------------------------------------------------------------------------
+const SEARCH_TERMS = [
+  // Stellar ecosystem tokens
+  'XLM', 'USDC', 'yXLM', 'AQUA', 'SHX', 'LOBSTR', 'WHL', 'MOBI',
+  'RMT', 'ETH', 'BTC', 'LINK', 'MATIC', 'SOL', 'AVAX', 'DOT',
+  'ADA', 'ALGO', 'XRP', 'BNB', 'DOGE', 'SHIB', 'UNI', 'AAVE',
+  'COMP', 'CRV', 'MKR', 'SNX', 'SUSHI', 'YFI', 'BAL', 'REN',
+  // Token name fragments
+  'stellar', 'nova', 'launch', 'token', 'coin', 'crypto', 'defi',
+  'swap', 'pool', 'yield', 'stake', 'farm', 'bridge', 'wrap',
+  'liquid', 'governance', 'vote', 'dao', 'protocol', 'network',
+  // Partial symbol matches (tests prefix search efficiency)
+  'US', 'US D', 'Ste', 'Nov', 'Lau', 'Tok', 'Co', 'De',
+  'Sw', 'Po', 'Yi', 'St', 'Fa', 'Br', 'Wr', 'Li',
+  // Edge cases: mixed case, numbers
+  'Token1', 'Coin2', 'Swap3', 'Pool4', 'Yield5', 'Stake6', 'Farm7',
+  'uSDC', 'xLM', 'bTC', 'eTH', 'sOL', 'aVAX', 'dOT', 'aDA',
+  // Short queries (high cardinality)
+  'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j',
+  'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't',
+  // Multi-word / descriptive names
+  'stellar lumens', 'usd coin', 'wrapped bitcoin', 'ether token',
+  'nova launch', 'governance token', 'liquidity pool', 'yield farm',
+  'staking reward', 'bridge asset', 'wrapped eth', 'liquid stake',
+  // Project-specific tokens (seeded in staging DB)
+  'NOVA', 'NVL', 'NLCH', 'NVLT', 'NLT', 'NVLX', 'NVLA', 'NLX',
+  'NLA', 'NLB', 'NLC', 'NLD', 'NLE', 'NLF', 'NLG', 'NLH',
+  // Longer descriptive queries
+  'decentralised finance', 'automated market maker', 'constant product',
+  'flash loan', 'arbitrage bot', 'price oracle', 'collateral ratio',
+  'liquidation penalty', 'interest rate model', 'total value locked',
+  // Numbers and alphanumerics
+  '2023', '2024', '2025', 'v1', 'v2', 'v3', 'beta', 'alpha',
+  'test', 'demo', 'dev', 'prod', 'main', 'core', 'base', 'root',
+  // More realistic token symbols
+  'WBTC', 'WETH', 'WBNB', 'WSOL', 'WAVAX', 'WDOT', 'WADA', 'WALGO',
+  'stUSD', 'stXLM', 'stETH', 'stBTC', 'stSOL', 'stAVAX', 'stDOT',
+  'lUSD', 'lXLM', 'lETH', 'lBTC', 'lSOL', 'lAVAX', 'lDOT', 'lADA',
+  // Fiat-pegged stablecoins
+  'USDT', 'BUSD', 'TUSD', 'USDP', 'GUSD', 'LUSD', 'FRAX', 'MIM',
+  'DAI', 'SUSD', 'CUSD', 'HUSD', 'EURS', 'EURT', 'EURC', 'AGEUR',
+  // Additional symbols to reach 200
+  'FTT', 'RAY', 'SRM', 'MAPS', 'OXY', 'MEDIA', 'LIKE', 'COPE',
+  'STEP', 'NINJA', 'SLIM', 'SAMO', 'ATLAS', 'POLIS', 'GRAPE', 'TULIP',
+  'PORT', 'MNGO', 'FIDA', 'KIN', 'CRP', 'LIQ', 'SUNNY', 'SBR',
+  'CASH', 'LARIX', 'PAI', 'ORCA', 'MERC', 'SNY', 'SLND', 'SOL',
+];
+
+// ---------------------------------------------------------------------------
+// VU entrypoint
+// ---------------------------------------------------------------------------
+export default function () {
+  const baseUrl = config.baseUrl;
+
+  // Pick a random term; different VUs diverge naturally across iterations
+  const term = SEARCH_TERMS[Math.floor(Math.random() * SEARCH_TERMS.length)];
+
+  const url = `${baseUrl}/api/tokens/search?q=${encodeURIComponent(term)}&limit=20`;
+
+  const start = Date.now();
+  const res = http.get(url, {
+    headers: { Accept: 'application/json' },
+    tags: { endpoint: 'token-search' },
+  });
+  const elapsed = Date.now() - start;
+
+  searchDuration.add(elapsed);
+  totalRequests.add(1);
+
+  const ok = check(res, {
+    'status is 200': (r) => r.status === 200,
+    'response is JSON': (r) => {
+      try {
+        JSON.parse(r.body);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    'p95 < 500 ms': () => elapsed < 500,
+  });
+
+  searchErrorRate.add(!ok);
+
+  // Short think time between requests (realistic user pacing)
+  sleep(Math.random() * 0.5 + 0.1);
+}
+
+// ---------------------------------------------------------------------------
+// Summary artifact for CI reporting
+// ---------------------------------------------------------------------------
+export function handleSummary(data) {
+  const p95 = data.metrics.token_search_duration_ms?.values?.['p(95)'] ?? null;
+  const errRate = data.metrics.token_search_errors?.values?.rate ?? null;
+  const total = data.metrics.token_search_total_requests?.values?.count ?? null;
+
+  const summary = {
+    scenario: 'token-search-load',
+    timestamp: new Date().toISOString(),
+    vus: 50,
+    duration: '60s',
+    totalRequests: total,
+    p95ResponseTimeMs: p95 !== null ? Math.round(p95) : null,
+    errorRate: errRate !== null ? parseFloat((errRate * 100).toFixed(4)) : null,
+    sloP95Passed: p95 !== null ? p95 < 500 : null,
+    sloErrorRatePassed: errRate !== null ? errRate < 0.001 : null,
+  };
+
+  return {
+    'load-tests/results/token-search-load-summary.json': JSON.stringify(
+      summary,
+      null,
+      2
+    ),
+    stdout: JSON.stringify(summary, null, 2),
+  };
+}


### PR DESCRIPTION
## Summary

- **#1299** — `e2e/governance-lifecycle.spec.ts`: Playwright E2E suite covering the full governance proposal lifecycle (creation → vote → queue → execute), asserting UI status chip updates via WebSocket without manual page refresh
- **#1300** — Extended `backend/src/__tests__/inbound-webhook-hmac.integration.test.ts`: adds timing-attack vector coverage — spies on `crypto.timingSafeEqual`, tests truncated signature rejection, replay (>5 min) rejection, and asserts p95 timing variance between valid/invalid requests is < 5 ms across 100 trials
- **#1301** — `load-tests/scenarios/token-search-load.js`: k6 load test for `/api/tokens/search` at 50 concurrent VUs for 60 seconds; uses a 200-term dictionary to avoid cache hits; asserts p95 < 500 ms and error rate < 0.1%; emits a summary JSON artifact for CI reporting
- **#1302** — `frontend/src/utils/__tests__/burnValidation.property.test.ts`: fast-check property-based tests with `fc.bigInt` generators over 500+ cases for all four invariants (burn > supply rejected, zero rejected, full burn accepted, negative rejected), plus explicit `BigInt(0)`, `BigInt(-1)`, `supply + 1n`, and `Number.MAX_SAFE_INTEGER` edge-case fixtures

## Test plan

- [ ] `npx playwright test e2e/governance-lifecycle.spec.ts` passes against running dev stack
- [ ] `npx vitest run src/__tests__/inbound-webhook-hmac.integration.test.ts` — all assertions pass, timing test documented
- [ ] `k6 run load-tests/scenarios/token-search-load.js` against staging DB with 10k seeded tokens — thresholds pass
- [ ] `npx vitest run src/utils/__tests__/burnValidation.property.test.ts` — all properties hold, no shrink failures

Closes #1299
Closes #1300
Closes #1301
Closes #1302