### PR TITLE
test(backend): tenant webhook rate limiter isolation coverage

### DIFF
--- a/backend/src/__tests__/tenantWebhookRateLimiter.test.ts
+++ b/backend/src/__tests__/tenantWebhookRateLimiter.test.ts
@@ -163,6 +163,57 @@ describe("TenantWebhookRateLimiter", () => {
       await Promise.all(promises);
       limiter.destroy();
     });
+
+    it("exact boundary: the Nth request (= burstCapacity) resolves immediately; the (N+1)th is queued", async () => {
+      // Precisely validates the boundary between "within burst" and "over
+      // burst" at the token-bucket level. Request N uses the last token and
+      // must resolve without queuing; request N+1 finds the bucket empty and
+      // must be queued — never dropped.
+      vi.useFakeTimers();
+      const BURST = 5;
+      const limiter = new TenantWebhookRateLimiter({
+        ratePerMinute: 60, // 1 token/sec — easy math
+        burstCapacity: BURST,
+      });
+      const tenant = "boundary-tenant";
+
+      // Requests 1 … N: all must resolve immediately (consume each token).
+      const immediateResults: boolean[] = [];
+      for (let i = 0; i < BURST; i++) {
+        let resolved = false;
+        // These resolve in the same microtask checkpoint because the bucket
+        // still has tokens at the point acquire() is called.
+        await limiter.acquire(tenant).then(() => {
+          resolved = true;
+        });
+        immediateResults.push(resolved);
+      }
+      expect(immediateResults).toHaveLength(BURST);
+      expect(immediateResults.every(Boolean)).toBe(true);
+
+      // Bucket must now be empty.
+      expect(limiter.getAvailableTokens(tenant)).toBeLessThan(1);
+
+      // Request N+1: the bucket is empty — this must be queued, not resolved.
+      let nPlusOneResolved = false;
+      const nPlusOne = limiter.acquire(tenant).then(() => {
+        nPlusOneResolved = true;
+      });
+
+      // Flush microtasks — the promise should still be pending.
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(nPlusOneResolved).toBe(false);
+      expect(limiter.getQueueLength(tenant)).toBe(1);
+
+      // Advance time to allow one token to refill and the drain to fire.
+      await vi.advanceTimersByTimeAsync(1100);
+      expect(nPlusOneResolved).toBe(true);
+      expect(limiter.getQueueLength(tenant)).toBe(0);
+
+      await nPlusOne;
+      limiter.destroy();
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -196,6 +247,273 @@ describe("TenantWebhookRateLimiter", () => {
       });
       expect(bResolved).toBe(true);
       expect(limiter.getQueueLength("tenant-b")).toBe(0);
+
+      limiter.destroy();
+    });
+
+    it("interleaved A/B/A/B calls maintain fully independent per-tenant counters", async () => {
+      // This is the core per-tenant isolation proof: drive the limiter with
+      // interleaved calls from two different tenant IDs in the pattern
+      // A, B, A, B, A, B … and assert that each tenant's token count
+      // decrements independently — exhausting A never borrows from B and
+      // vice versa.
+      vi.useFakeTimers();
+      const limiter = new TenantWebhookRateLimiter({
+        ratePerMinute: 60, // 1 token/sec
+        burstCapacity: 3,
+      });
+      const A = "interleaved-tenant-a";
+      const B = "interleaved-tenant-b";
+
+      // Interleaved pattern: A, B, A, B, A, B
+      // Each tenant sees 3 calls. With burst=3 every call should resolve
+      // immediately; neither tenant's bucket should affect the other.
+      const resolvedA: number[] = [];
+      const resolvedB: number[] = [];
+
+      // Call 1-A
+      await limiter.acquire(A);
+      resolvedA.push(Date.now());
+      // Call 1-B
+      await limiter.acquire(B);
+      resolvedB.push(Date.now());
+      // Call 2-A
+      await limiter.acquire(A);
+      resolvedA.push(Date.now());
+      // Call 2-B
+      await limiter.acquire(B);
+      resolvedB.push(Date.now());
+      // Call 3-A — uses the last of A's burst tokens
+      await limiter.acquire(A);
+      resolvedA.push(Date.now());
+      // Call 3-B — uses the last of B's burst tokens
+      await limiter.acquire(B);
+      resolvedB.push(Date.now());
+
+      // All six calls resolved without any timer advance — purely from burst.
+      expect(resolvedA).toHaveLength(3);
+      expect(resolvedB).toHaveLength(3);
+
+      // Both buckets are now exhausted.
+      expect(limiter.getAvailableTokens(A)).toBeLessThan(1);
+      expect(limiter.getAvailableTokens(B)).toBeLessThan(1);
+
+      // Now issue one more call to each. Both must be queued independently.
+      let aExtra = false;
+      let bExtra = false;
+      const pendingA = limiter.acquire(A).then(() => {
+        aExtra = true;
+      });
+      const pendingB = limiter.acquire(B).then(() => {
+        bExtra = true;
+      });
+
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(aExtra).toBe(false);
+      expect(bExtra).toBe(false);
+      expect(limiter.getQueueLength(A)).toBe(1);
+      expect(limiter.getQueueLength(B)).toBe(1);
+
+      // Advance time to refill exactly one token for each tenant (1 token = 1000 ms
+      // at 60/min) plus a little buffer for the drain interval.
+      await vi.advanceTimersByTimeAsync(1100);
+
+      expect(aExtra).toBe(true);
+      expect(bExtra).toBe(true);
+      expect(limiter.getQueueLength(A)).toBe(0);
+      expect(limiter.getQueueLength(B)).toBe(0);
+
+      await Promise.all([pendingA, pendingB]);
+      limiter.destroy();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Window reset — tokens refill after full window elapses
+  // -------------------------------------------------------------------------
+
+  describe("window reset behavior", () => {
+    it("tokens fully refill after a complete rate window has elapsed", async () => {
+      // Configure 60/min (1 token/sec) with burst=3.
+      // Exhaust all burst tokens, then advance a full minute (60 000 ms).
+      // The bucket must be back at burstCapacity (capped) so a new burst
+      // of requests can all resolve immediately without queuing.
+      vi.useFakeTimers();
+      const limiter = new TenantWebhookRateLimiter({
+        ratePerMinute: 60,
+        burstCapacity: 3,
+      });
+      const tenant = "window-reset-tenant";
+
+      // Drain all 3 burst tokens.
+      await limiter.acquire(tenant);
+      await limiter.acquire(tenant);
+      await limiter.acquire(tenant);
+      expect(limiter.getAvailableTokens(tenant)).toBeLessThan(1);
+
+      // Advance by one full minute — the bucket must fully refill, capped
+      // at burstCapacity (3), not at ratePerMinute (60).
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      // After the window the bucket should be replenished to burstCapacity.
+      expect(limiter.getAvailableTokens(tenant)).toBeGreaterThanOrEqual(3);
+      // getAvailableTokens applies refill lazily; it must be capped at burst.
+      expect(limiter.getAvailableTokens(tenant)).toBeLessThanOrEqual(3);
+
+      // All three new acquisitions must resolve immediately (no queuing).
+      let resolvedCount = 0;
+      const p1 = limiter.acquire(tenant).then(() => resolvedCount++);
+      const p2 = limiter.acquire(tenant).then(() => resolvedCount++);
+      const p3 = limiter.acquire(tenant).then(() => resolvedCount++);
+
+      await Promise.resolve();
+      await Promise.resolve();
+      // All should have resolved without any additional timer advance.
+      await Promise.all([p1, p2, p3]);
+      expect(resolvedCount).toBe(3);
+      // Queue must still be empty — none were held back.
+      expect(limiter.getQueueLength(tenant)).toBe(0);
+
+      limiter.destroy();
+    });
+
+    it("partial window refill grants only the proportional fraction of tokens", async () => {
+      // At 60/min (1 token/sec, burst=2) advancing 500 ms should add ~0.5
+      // tokens, which is not enough to immediately satisfy a new acquire.
+      vi.useFakeTimers();
+      const limiter = new TenantWebhookRateLimiter({
+        ratePerMinute: 60, // 1 token/sec
+        burstCapacity: 2,
+      });
+      const tenant = "partial-window-tenant";
+
+      // Drain the bucket completely.
+      await limiter.acquire(tenant);
+      await limiter.acquire(tenant);
+      expect(limiter.getAvailableTokens(tenant)).toBeLessThan(1);
+
+      // Advance only half a token's worth of time.
+      await vi.advanceTimersByTimeAsync(500);
+
+      // Less than 1 full token has refilled — the next acquire should queue.
+      let partialResolved = false;
+      const pending = limiter.acquire(tenant).then(() => {
+        partialResolved = true;
+      });
+      await Promise.resolve();
+      expect(partialResolved).toBe(false);
+      expect(limiter.getQueueLength(tenant)).toBe(1);
+
+      // Now advance the remaining time to complete one full token (total 1000 ms).
+      await vi.advanceTimersByTimeAsync(600);
+      expect(partialResolved).toBe(true);
+
+      await pending;
+      limiter.destroy();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Burst-then-idle recovery
+  // -------------------------------------------------------------------------
+
+  describe("burst-then-idle recovery", () => {
+    it("after exhausting burst capacity, idling long enough restores full burst", async () => {
+      // Pattern: exhaust all burst tokens → idle until fully refilled →
+      // burst again. This proves the token bucket truly resets after idle
+      // time, so a tenant that was noisy, then quiets down, can burst freely
+      // again later without being permanently penalized.
+      vi.useFakeTimers();
+      const limiter = new TenantWebhookRateLimiter({
+        ratePerMinute: 60, // 1 token/sec
+        burstCapacity: 4,
+      });
+      const tenant = "burst-idle-recovery-tenant";
+
+      // --- First burst: consume all 4 tokens immediately ---
+      await limiter.acquire(tenant);
+      await limiter.acquire(tenant);
+      await limiter.acquire(tenant);
+      await limiter.acquire(tenant);
+      expect(limiter.getAvailableTokens(tenant)).toBeLessThan(1);
+
+      // Verify the 5th request queues (no idle yet).
+      let fifthResolved = false;
+      const pendingFifth = limiter.acquire(tenant).then(() => {
+        fifthResolved = true;
+      });
+      await Promise.resolve();
+      expect(fifthResolved).toBe(false);
+
+      // Drain the queue so we're back to a clean state for the idle window.
+      await vi.advanceTimersByTimeAsync(1100); // refills 1 token → drains queue
+      expect(fifthResolved).toBe(true);
+      await pendingFifth;
+
+      // --- Idle period: advance enough time to fully refill burst (4 tokens
+      //     at 1/sec = 4000 ms), capped by burstCapacity ---
+      await vi.advanceTimersByTimeAsync(4000);
+
+      expect(limiter.getAvailableTokens(tenant)).toBeGreaterThanOrEqual(4);
+      expect(limiter.getAvailableTokens(tenant)).toBeLessThanOrEqual(4);
+
+      // --- Second burst: all 4 tokens available again immediately ---
+      let secondBurstCount = 0;
+      const burst2 = [
+        limiter.acquire(tenant).then(() => secondBurstCount++),
+        limiter.acquire(tenant).then(() => secondBurstCount++),
+        limiter.acquire(tenant).then(() => secondBurstCount++),
+        limiter.acquire(tenant).then(() => secondBurstCount++),
+      ];
+      // None of these should require a timer advance — they must resolve
+      // from the refilled bucket.
+      await Promise.all(burst2);
+      expect(secondBurstCount).toBe(4);
+      expect(limiter.getQueueLength(tenant)).toBe(0);
+
+      limiter.destroy();
+    });
+
+    it("a second burst after idle does not starve other tenants that were not idle", async () => {
+      // Tenant A bursts, idles, then bursts again.
+      // Tenant B makes steady non-bursting calls throughout.
+      // Tenant A's recovery must not borrow from or delay Tenant B.
+      vi.useFakeTimers();
+      const limiter = new TenantWebhookRateLimiter({
+        ratePerMinute: 60,
+        burstCapacity: 3,
+      });
+      const A = "burst-idle-a";
+      const B = "burst-idle-b";
+
+      // A drains its bucket.
+      await limiter.acquire(A);
+      await limiter.acquire(A);
+      await limiter.acquire(A);
+
+      // B uses one token — still has 2 left.
+      await limiter.acquire(B);
+      expect(limiter.getAvailableTokens(B)).toBeGreaterThanOrEqual(2);
+
+      // A idles and refills.
+      await vi.advanceTimersByTimeAsync(4000);
+      expect(limiter.getAvailableTokens(A)).toBeGreaterThanOrEqual(3);
+      expect(limiter.getAvailableTokens(A)).toBeLessThanOrEqual(3);
+
+      // B's tokens also naturally refill (it only used 1, now back at 3).
+      expect(limiter.getAvailableTokens(B)).toBeGreaterThanOrEqual(3);
+      expect(limiter.getAvailableTokens(B)).toBeLessThanOrEqual(3);
+
+      // A bursts again — must not affect B's available tokens.
+      await limiter.acquire(A);
+      await limiter.acquire(A);
+      await limiter.acquire(A);
+
+      // B's bucket is untouched by A's second burst.
+      expect(limiter.getAvailableTokens(B)).toBeGreaterThanOrEqual(3);
+      expect(limiter.getQueueLength(A)).toBe(0);
+      expect(limiter.getQueueLength(B)).toBe(0);
 
       limiter.destroy();
     });


### PR DESCRIPTION
  Summary
  
  TenantWebhookRateLimiter had no tests proving the token bucket is keyed per-tenant rather than globally. A noisy tenant could theoretically starve another
  tenant's webhook delivery and the limiter's window reset and burst recovery behavior were entirely untested.
  
  Changes
  
  Added five new test cases to src/__tests__/tenantWebhookRateLimiter.test.ts:
  
  - Interleaved tenant isolation — drives the limiter with an A/B/A/B call pattern across two tenant IDs and asserts each tenant's token counter decrements
  independently; exhausting one bucket never borrows from or blocks the other.
  - Full window reset — advances fake time by a complete rate window (60 000 ms) after draining a bucket and asserts tokens refill up to burstCapacity (not
  unbounded), then confirms the next burst resolves immediately without queuing.
  - Partial window refill — advances only half a token's worth of time and asserts the next acquire is still queued, proving the refill is proportional and not
  binary.
  - Burst-then-idle recovery — exhausts burst capacity, drains the queue, idles long enough for full refill, then fires a second burst; asserts all second-burst
  requests resolve immediately and no other tenant is affected.
  - Exact boundary (N allowed, N+1 queued) — issues exactly burstCapacity requests (all must resolve immediately consuming one token each) then issues one more,
  asserts it is queued rather than dropped, and confirms it resolves once a token refills.
  
  Testing
  
  All new tests use vi.useFakeTimers() / vi.advanceTimersByTimeAsync() — no real sleeps, fully deterministic. No new dependencies.
  
  src/__tests__/tenantWebhookRateLimiter.test.ts
  
  What was not changed
  
  The TenantWebhookRateLimiter implementation (src/services/tenantWebhookRateLimiter.ts) is unchanged — all existing behavior was already correct; these tests are
  the missing proof.


closes #1556 