### PR TITLE
test(backend): governance event parser malformed-payload coverage

### DIFF
--- a/backend/src/__tests__/__snapshots__/governanceEventParser.snapshot.test.ts.snap
+++ b/backend/src/__tests__/__snapshots__/governanceEventParser.snapshot.test.ts.snap
@@ -1,0 +1,105 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`GovernanceEventParser — snapshot regression suite > snapshot: Cancelled — proposal.update payload shape 1`] = `
+{
+  "data": {
+    "cancelReason": "Proposal no longer needed",
+    "cancelledAt": 2024-01-16T09:00:00.000Z,
+    "canceller": "GCANCELLER1234567890ABCDEFGHIJKLMNOPQRSTUV",
+    "status": "CANCELLED",
+  },
+  "where": {
+    "id": "proposal-uuid-1",
+  },
+}
+`;
+
+exports[`GovernanceEventParser — snapshot regression suite > snapshot: Created — proposal.upsert payload shape 1`] = `
+{
+  "create": {
+    "createdAt": 2024-01-15T12:00:00.000Z,
+    "description": "Proposal to increase the protocol fee from 1% to 2%",
+    "endTime": 2024-01-22T12:00:00.000Z,
+    "metadata": "{"category":"fee_adjustment"}",
+    "proposalId": 1,
+    "proposalType": "PARAMETER_CHANGE",
+    "proposer": "GABC1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ12345",
+    "quorum": 1000000000000n,
+    "startTime": 2024-01-15T12:00:00.000Z,
+    "status": "ACTIVE",
+    "threshold": 500000000000n,
+    "title": "Increase Protocol Fee",
+    "tokenId": "CTOKEN1234567890ABCDEFGHIJKLMN",
+    "txHash": "deadbeef0001000000000000000000000000000000000000000000000000cafe",
+  },
+  "update": {},
+  "where": {
+    "proposalId": 1,
+  },
+}
+`;
+
+exports[`GovernanceEventParser — snapshot regression suite > snapshot: Executed — proposalExecution.create + proposal.update payload shapes 1`] = `
+{
+  "executionCreate": {
+    "data": {
+      "executedAt": 2024-01-23T10:00:00.000Z,
+      "executor": "GEXECUTOR1234567890ABCDEFGHIJKLMNOPQRSTUV",
+      "gasUsed": 50000n,
+      "proposalId": "proposal-uuid-1",
+      "returnData": "0x01",
+      "success": true,
+      "txHash": "deadbeef0004000000000000000000000000000000000000000000000000cafe",
+    },
+  },
+  "proposalUpdate": {
+    "data": {
+      "executedAt": 2024-01-23T10:00:00.000Z,
+      "status": "EXECUTED",
+    },
+    "where": {
+      "id": "proposal-uuid-1",
+    },
+  },
+}
+`;
+
+exports[`GovernanceEventParser — snapshot regression suite > snapshot: Expired — proposal.update payload shape (status → EXPIRED) 1`] = `
+{
+  "data": {
+    "status": "EXPIRED",
+  },
+  "where": {
+    "id": "proposal-uuid-1",
+  },
+}
+`;
+
+exports[`GovernanceEventParser — snapshot regression suite > snapshot: Queued — proposal.update payload shape (status → QUEUED) 1`] = `
+{
+  "data": {
+    "status": "QUEUED",
+  },
+  "where": {
+    "id": "proposal-uuid-1",
+  },
+}
+`;
+
+exports[`GovernanceEventParser — snapshot regression suite > snapshot: Voted — vote.upsert payload shape 1`] = `
+{
+  "create": {
+    "proposalId": "proposal-uuid-1",
+    "reason": "I support this proposal for better tokenomics",
+    "support": true,
+    "timestamp": 2024-01-15T13:00:00.000Z,
+    "txHash": "deadbeef0002000000000000000000000000000000000000000000000000cafe",
+    "voter": "GVOTER12345678901234567890ABCDEFGHIJKLMNOPQR",
+    "weight": 250000000000n,
+  },
+  "update": {},
+  "where": {
+    "txHash": "deadbeef0002000000000000000000000000000000000000000000000000cafe",
+  },
+}
+`;

--- a/backend/src/__tests__/governanceEventParser.test.ts
+++ b/backend/src/__tests__/governanceEventParser.test.ts
@@ -1,0 +1,362 @@
+/**
+ * Table-driven validation tests for GovernanceEventParser.
+ *
+ * Closes the gap for malformed proposal/vote event payloads by asserting
+ * that the parser rejects bad data with a typed GovernanceEventValidationError
+ * (instead of letting raw Prisma/BigInt errors leak).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PrismaClient, ProposalStatus, ProposalType } from '@prisma/client';
+import {
+  GovernanceEventParser,
+  GovernanceEventValidationError,
+} from '../services/governanceEventParser';
+import type {
+  ProposalCreatedEvent,
+  VoteCastEvent,
+  ProposalExecutedEvent,
+  ProposalCancelledEvent,
+  ProposalStatusChangedEvent,
+  ProposalStateSnapshotEvent,
+} from '../types/governance';
+
+// ---------------------------------------------------------------------------
+// Shared constants
+// ---------------------------------------------------------------------------
+
+const BASE_TIMESTAMP = new Date('2024-01-15T12:00:00.000Z');
+const END_TIMESTAMP = new Date('2024-01-22T12:00:00.000Z');
+const CONTRACT_ID = 'CGOVCONTRACT1234567890ABCDEF';
+
+// ---------------------------------------------------------------------------
+// Prisma mock
+// ---------------------------------------------------------------------------
+
+const mockProposal = {
+  id: 'proposal-uuid-1',
+  proposalId: 1,
+  status: ProposalStatus.ACTIVE,
+};
+
+const mockPrisma = {
+  proposal: {
+    upsert: vi.fn().mockResolvedValue(mockProposal),
+    findUnique: vi.fn().mockResolvedValue(mockProposal),
+    update: vi.fn().mockResolvedValue(mockProposal),
+  },
+  vote: {
+    upsert: vi.fn().mockResolvedValue({}),
+  },
+  proposalExecution: {
+    create: vi.fn().mockResolvedValue({}),
+  },
+} as unknown as PrismaClient;
+
+// ---------------------------------------------------------------------------
+// Baseline fixtures (valid)
+// ---------------------------------------------------------------------------
+
+const baseCreatedEvent: ProposalCreatedEvent = {
+  type: 'proposal_created',
+  txHash: 'tx-create-valid',
+  ledger: 1_000_000,
+  timestamp: BASE_TIMESTAMP,
+  contractId: CONTRACT_ID,
+  proposalId: 1,
+  tokenAddress: 'CTOKEN1234567890ABCDEFGHIJKLMN',
+  proposer: 'GPROPOSER1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ12345',
+  title: 'Increase Protocol Fee',
+  description: 'Valid proposal description',
+  proposalType: ProposalType.PARAMETER_CHANGE,
+  startTime: BASE_TIMESTAMP,
+  endTime: END_TIMESTAMP,
+  quorum: '1000000000000',
+  threshold: '500000000000',
+  metadata: '{}',
+};
+
+const baseVoteEvent: VoteCastEvent = {
+  type: 'vote_cast',
+  txHash: 'tx-vote-valid',
+  ledger: 1_000_100,
+  timestamp: new Date('2024-01-15T13:00:00.000Z'),
+  contractId: CONTRACT_ID,
+  proposalId: 1,
+  voter: 'GVOTER1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ12345',
+  support: true,
+  weight: '250000000000',
+  reason: 'Valid vote reason',
+};
+
+const baseExecutedEvent: ProposalExecutedEvent = {
+  type: 'proposal_executed',
+  txHash: 'tx-exec-valid',
+  ledger: 1_000_300,
+  timestamp: new Date('2024-01-23T10:00:00.000Z'),
+  contractId: CONTRACT_ID,
+  proposalId: 1,
+  executor: 'GEXECUTOR1234567890ABCDEFGHIJKLMNOPQRSTUV',
+  success: true,
+  returnData: '0x01',
+  gasUsed: '50000',
+};
+
+const baseCancelledEvent: ProposalCancelledEvent = {
+  type: 'proposal_cancelled',
+  txHash: 'tx-cancel-valid',
+  ledger: 1_000_400,
+  timestamp: new Date('2024-01-16T09:00:00.000Z'),
+  contractId: CONTRACT_ID,
+  proposalId: 2,
+  canceller: 'GCANCELLER1234567890ABCDEFGHIJKLMNOPQRSTUV',
+  reason: 'Proposal no longer needed',
+};
+
+const baseStatusChangedEvent: ProposalStatusChangedEvent = {
+  type: 'proposal_status_changed',
+  txHash: 'tx-status-valid',
+  ledger: 1_000_200,
+  timestamp: new Date('2024-01-22T12:30:00.000Z'),
+  contractId: CONTRACT_ID,
+  proposalId: 1,
+  oldStatus: ProposalStatus.ACTIVE,
+  newStatus: ProposalStatus.PASSED,
+};
+
+const baseSnapshotEvent: ProposalStateSnapshotEvent = {
+  type: 'proposal_state_snapshot',
+  txHash: 'tx-snap-valid',
+  ledger: 1_000_500,
+  timestamp: new Date('2024-01-24T08:00:00.000Z'),
+  contractId: CONTRACT_ID,
+  proposalId: 1,
+  status: ProposalStatus.PASSED,
+  yesVotes: '300000000000',
+  noVotes: '100000000000',
+  quorumRequired: '1000000000000',
+  snapshotLedger: 1_000_500,
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('GovernanceEventParser — malformed payload validation', () => {
+  let parser: GovernanceEventParser;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    parser = new GovernanceEventParser(mockPrisma);
+  });
+
+  // =========================================================================
+  // proposal_created
+  // =========================================================================
+
+  describe('proposal_created', () => {
+    type Case = {
+      label: string;
+      event: ProposalCreatedEvent;
+      expected?: string;
+    }
+
+    const cases: Case[] = [
+      { label: 'valid baseline', event: baseCreatedEvent },
+      {
+        label: 'malformed quorum — not-a-number',
+        event: { ...baseCreatedEvent, quorum: 'not-a-number' },
+        expected: 'Invalid quorum: not-a-number',
+      },
+      {
+        label: 'malformed threshold — not-a-number',
+        event: { ...baseCreatedEvent, threshold: 'not-a-number' },
+        expected: 'Invalid threshold: not-a-number',
+      },
+      {
+        label: 'empty quorum',
+        event: { ...baseCreatedEvent, quorum: '' },
+        expected: 'Invalid quorum: ',
+      },
+    ];
+
+    it.each(cases)('$label — returns typed error', async ({ event, expected }) => {
+      if (expected) {
+        await expect(parser.parseProposalCreatedEvent(event)).rejects.toThrow(
+          GovernanceEventValidationError,
+        );
+        await expect(parser.parseProposalCreatedEvent(event)).rejects.toThrow(expected);
+      } else {
+        await expect(parser.parseProposalCreatedEvent(event)).resolves.toBeUndefined();
+      }
+    });
+  });
+
+  // =========================================================================
+  // vote_cast
+  // =========================================================================
+
+  describe('vote_cast', () => {
+    type Case = {
+      label: string;
+      event: VoteCastEvent;
+      expected?: string;
+    }
+
+    const cases: Case[] = [
+      { label: 'valid baseline', event: baseVoteEvent },
+      {
+        label: 'malformed weight — not-a-number',
+        event: { ...baseVoteEvent, weight: 'not-a-number' },
+        expected: 'Invalid vote weight: not-a-number',
+      },
+      {
+        label: 'malformed weight — empty',
+        event: { ...baseVoteEvent, weight: '' },
+        expected: 'Invalid vote weight: ',
+      },
+      {
+        label: 'malformed weight — decimal',
+        event: { ...baseVoteEvent, weight: '1.5' },
+        expected: 'Invalid vote weight: 1.5',
+      },
+    ];
+
+    it.each(cases)('$label — returns typed error', async ({ event, expected }) => {
+      if (expected) {
+        await expect(parser.parseVoteCastEvent(event)).rejects.toThrow(
+          GovernanceEventValidationError,
+        );
+        await expect(parser.parseVoteCastEvent(event)).rejects.toThrow(expected);
+      } else {
+        await expect(parser.parseVoteCastEvent(event)).resolves.toBeUndefined();
+      }
+    });
+  });
+
+  // =========================================================================
+  // proposal_status_changed — unknown state transitions
+  // =========================================================================
+
+  describe('proposal_status_changed', () => {
+    type Case = {
+      label: string;
+      event: ProposalStatusChangedEvent;
+      expected?: string;
+    }
+
+    const cases: Case[] = [
+      { label: 'valid baseline', event: baseStatusChangedEvent },
+      {
+        label: 'unknown new status string',
+        event: { ...baseStatusChangedEvent, newStatus: 'UNKNOWN' as any },
+        expected: 'Unknown proposal status: UNKNOWN',
+      },
+      {
+        label: 'unknown new status number',
+        event: { ...baseStatusChangedEvent, newStatus: 99 as any },
+        expected: 'Unknown proposal status: 99',
+      },
+      {
+        label: 'empty new status string',
+        event: { ...baseStatusChangedEvent, newStatus: '' as any },
+        expected: 'Unknown proposal status: ',
+      },
+    ];
+
+    it.each(cases)('$label — returns typed error', async ({ event, expected }) => {
+      if (expected) {
+        await expect(parser.parseProposalStatusChangedEvent(event)).rejects.toThrow(
+          GovernanceEventValidationError,
+        );
+        await expect(parser.parseProposalStatusChangedEvent(event)).rejects.toThrow(expected);
+      } else {
+        await expect(parser.parseProposalStatusChangedEvent(event)).resolves.toBeUndefined();
+      }
+    });
+  });
+
+  // =========================================================================
+  // proposal_state_snapshot — missing/invalid quorum snapshot data
+  // =========================================================================
+
+  describe('proposal_state_snapshot', () => {
+    type Case = {
+      label: string;
+      event: ProposalStateSnapshotEvent;
+      expected?: string;
+    }
+
+    const cases: Case[] = [
+      { label: 'valid baseline', event: baseSnapshotEvent },
+      {
+        label: 'unknown snapshot status',
+        event: { ...baseSnapshotEvent, status: 'BOGUS' as any },
+        expected: 'Unknown snapshot status: BOGUS',
+      },
+      {
+        label: 'missing quorumRequired',
+        event: { ...baseSnapshotEvent, quorumRequired: '' },
+        expected: 'Invalid snapshot quorumRequired: ',
+      },
+      {
+        label: 'malformed yesVotes',
+        event: { ...baseSnapshotEvent, yesVotes: 'not-a-number' as any },
+        expected: 'Invalid snapshot yesVotes: not-a-number',
+      },
+      {
+        label: 'malformed noVotes',
+        event: { ...baseSnapshotEvent, noVotes: 'xyz' as any },
+        expected: 'Invalid snapshot noVotes: xyz',
+      },
+      {
+        label: 'missing quorumRequired — empty string',
+        event: { ...baseSnapshotEvent, quorumRequired: '   ' },
+        expected: 'Invalid snapshot quorumRequired:    ',
+      },
+    ];
+
+    it.each(cases)('$label — returns typed error', async ({ event, expected }) => {
+      (mockPrisma.proposal.findUnique as ReturnType<typeof vi.fn>).mockResolvedValueOnce(mockProposal);
+      if (expected) {
+        await expect(parser.parseProposalStateSnapshotEvent(event)).rejects.toThrow(
+          GovernanceEventValidationError,
+        );
+        await expect(parser.parseProposalStateSnapshotEvent(event)).rejects.toThrow(expected);
+      } else {
+        await expect(parser.parseProposalStateSnapshotEvent(event)).resolves.toBeUndefined();
+      }
+    });
+  });
+
+  // =========================================================================
+  // Valid baseline regression — each event type resolves without error
+  // =========================================================================
+
+  describe('valid baseline regression', () => {
+    it('proposal_created resolves', async () => {
+      await expect(parser.parseProposalCreatedEvent(baseCreatedEvent)).resolves.toBeUndefined();
+    });
+
+    it('vote_cast resolves', async () => {
+      await expect(parser.parseVoteCastEvent(baseVoteEvent)).resolves.toBeUndefined();
+    });
+
+    it('proposal_executed resolves', async () => {
+      await expect(parser.parseProposalExecutedEvent(baseExecutedEvent)).resolves.toBeUndefined();
+    });
+
+    it('proposal_cancelled resolves', async () => {
+      await expect(parser.parseProposalCancelledEvent(baseCancelledEvent)).resolves.toBeUndefined();
+    });
+
+    it('proposal_status_changed resolves', async () => {
+      await expect(parser.parseProposalStatusChangedEvent(baseStatusChangedEvent)).resolves.toBeUndefined();
+    });
+
+    it('proposal_state_snapshot resolves', async () => {
+      (mockPrisma.proposal.findUnique as ReturnType<typeof vi.fn>).mockResolvedValueOnce(mockProposal);
+      await expect(parser.parseProposalStateSnapshotEvent(baseSnapshotEvent)).resolves.toBeUndefined();
+    });
+  });
+});

--- a/backend/src/services/governanceEventParser.ts
+++ b/backend/src/services/governanceEventParser.ts
@@ -67,6 +67,16 @@ export interface ContractErrorDetails {
 }
 
 /**
+ * Validation error thrown when a governance event payload is malformed.
+ */
+export class GovernanceEventValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'GovernanceEventValidationError';
+  }
+}
+
+/**
  * Known contract error codes from CONTRACT_ERROR_MATRIX.md
  */
 const KNOWN_CONTRACT_ERRORS = new Set([
@@ -90,30 +100,60 @@ const KNOWN_CONTRACT_ERRORS = new Set([
   'CONTRACT_PAUSED',
 ]);
 
-/**
- * Governance Event Parser
- * 
- * Parses and persists governance events from the blockchain
- * into the database for analytics and tracking.
- * 
- * Preserves structured error details aligned with frontend error semantics.
- */
-export class GovernanceEventParser {
-  private readonly mapper: GovernanceEventMapper;
-  private readonly cursorStore: EventCursorStore;
-  private readonly transport: GovernanceCatchupTransport;
+  /**
+   * Governance Event Parser
+   * 
+   * Parses and persists governance events from the blockchain
+   * into the database for analytics and tracking.
+   * 
+   * Preserves structured error details aligned with frontend error semantics.
+   */
+  export class GovernanceEventParser {
+    private readonly mapper: GovernanceEventMapper;
+    private readonly cursorStore: EventCursorStore;
+    private readonly transport: GovernanceCatchupTransport;
 
-  constructor(
-    private prisma: PrismaClient,
-    opts?: {
-      transport?: GovernanceCatchupTransport;
-      cursorStore?: EventCursorStore;
-    },
-  ) {
-    this.mapper = new GovernanceEventMapper();
-    this.cursorStore = opts?.cursorStore ?? new EventCursorStore(prisma);
-    this.transport = opts?.transport ?? new DefaultGovernanceCatchupTransport();
-  }
+    constructor(
+      private prisma: PrismaClient,
+      opts?: {
+        transport?: GovernanceCatchupTransport;
+        cursorStore?: EventCursorStore;
+      },
+    ) {
+      this.mapper = new GovernanceEventMapper();
+      this.cursorStore = opts?.cursorStore ?? new EventCursorStore(prisma);
+      this.transport = opts?.transport ?? new DefaultGovernanceCatchupTransport();
+    }
+
+    private validateBigIntString(value: unknown, field: string): string {
+      const str = typeof value === 'string' ? value : String(value ?? '');
+      if (!/^-?\d+$/.test(str)) {
+        throw new GovernanceEventValidationError(`Invalid ${field}: ${str}`);
+      }
+      return str;
+    }
+
+    private validateProposalStatus(status: unknown, field: string): ProposalStatus {
+      const str = typeof status === 'string' ? status.toLowerCase() : String(status ?? '').toLowerCase();
+      const statusMap: Record<string, ProposalStatus> = {
+        'active': ProposalStatus.ACTIVE,
+        'passed': ProposalStatus.PASSED,
+        'rejected': ProposalStatus.REJECTED,
+        'queued': ProposalStatus.QUEUED,
+        'executed': ProposalStatus.EXECUTED,
+        'cancelled': ProposalStatus.CANCELLED,
+        'expired': ProposalStatus.EXPIRED,
+        'created': ProposalStatus.ACTIVE,
+        'succeeded': ProposalStatus.PASSED,
+        'defeated': ProposalStatus.REJECTED,
+        'failed': ProposalStatus.REJECTED,
+      };
+      const mapped = statusMap[str];
+      if (!mapped) {
+        throw new GovernanceEventValidationError(`Unknown ${field}: ${String(status)}`);
+      }
+      return mapped;
+    }
 
   /**
    * Parse contract error from error response
@@ -199,6 +239,9 @@ export class GovernanceEventParser {
    */
   async parseProposalCreatedEvent(event: ProposalCreatedEvent): Promise<void> {
     try {
+      const quorum = this.validateBigIntString(event.quorum, 'quorum');
+      const threshold = this.validateBigIntString(event.threshold, 'threshold');
+
       await this.prisma.proposal.upsert({
         where: { proposalId: event.proposalId },
         create: {
@@ -211,8 +254,8 @@ export class GovernanceEventParser {
           status: ProposalStatus.ACTIVE,
           startTime: event.startTime,
           endTime: event.endTime,
-          quorum: BigInt(event.quorum),
-          threshold: BigInt(event.threshold),
+          quorum: BigInt(quorum),
+          threshold: BigInt(threshold),
           metadata: event.metadata,
           txHash: event.txHash,
           createdAt: event.timestamp,
@@ -232,6 +275,8 @@ export class GovernanceEventParser {
    */
   async parseVoteCastEvent(event: VoteCastEvent): Promise<void> {
     try {
+      const weight = this.validateBigIntString(event.weight, 'vote weight');
+
       const proposal = await this.prisma.proposal.findUnique({
         where: { proposalId: event.proposalId },
       });
@@ -246,7 +291,7 @@ export class GovernanceEventParser {
           proposalId: proposal.id,
           voter: event.voter,
           support: event.support,
-          weight: BigInt(event.weight),
+          weight: BigInt(weight),
           reason: event.reason,
           txHash: event.txHash,
           timestamp: event.timestamp,
@@ -367,10 +412,12 @@ export class GovernanceEventParser {
         throw new Error(`Proposal ${event.proposalId} not found`);
       }
 
+      const newStatus = this.validateProposalStatus(event.newStatus, 'proposal status');
+
       await this.prisma.proposal.update({
         where: { id: proposal.id },
         data: {
-          status: event.newStatus as ProposalStatus,
+          status: newStatus,
         },
       });
 
@@ -417,10 +464,15 @@ export class GovernanceEventParser {
         return;
       }
 
+      const status = this.validateProposalStatus(event.status, 'snapshot status');
+      this.validateBigIntString(event.yesVotes, 'snapshot yesVotes');
+      this.validateBigIntString(event.noVotes, 'snapshot noVotes');
+      this.validateBigIntString(event.quorumRequired, 'snapshot quorumRequired');
+
       await this.prisma.proposal.update({
         where: { id: proposal.id },
         data: {
-          status: event.status as ProposalStatus,
+          status,
         },
       });
 


### PR DESCRIPTION
## Summary
Adds malformed payload validation and table-driven regression tests for `GovernanceEventParser`, closing the governance-side gap identified in the campaign parser issue.

## Changes

### `src/services/governanceEventParser.ts`
- Exports `GovernanceEventValidationError` (typed error).
- Adds `validateBigIntString()` — rejects non-integer strings for `quorum`, `threshold`, `vote weight`, and snapshot numeric fields.
- Adds `validateProposalStatus()` — rejects unknown `newStatus` / `status` values in `proposal_status_changed` and `proposal_state_snapshot`.
- Hooked into:
  - `parseProposalCreatedEvent` — validates `quorum` + `threshold`
  - `parseVoteCastEvent` — validates `weight`
  - `parseProposalStatusChangedEvent` — validates `newStatus`
  - `parseProposalStateSnapshotEvent` — validates `status`, `yesVotes`, `noVotes`, `quorumRequired`

### `src/__tests__/governanceEventParser.test.ts` (new)
- Table-driven fixtures for all 6 event types.
- Malformed cases assert **typed** `GovernanceEventValidationError`, not a raw throw.
- Valid baseline regression for each event type confirming normal resolution.

## Risk
Low — validation only tightens input handling; existing valid payloads pass unchanged.


closes #1543 