### PR TITLE
feat: cover stream event parser

### DIFF
--- a/backend/src/__tests__/streamEventParser.test.ts
+++ b/backend/src/__tests__/streamEventParser.test.ts
@@ -1,8 +1,295 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { PrismaClient, StreamStatus } from '@prisma/client';
 import { StreamEventParser } from '../services/streamEventParser';
 import { streamEventFixtures } from './fixtures/streamEvents';
 import claimFixtures from './fixtures/streamClaimDifferential.json';
+
+// ---------------------------------------------------------------------------
+// Malformed-payload guard tests — pure unit tests, no real DB required.
+//
+// These verify that StreamEventParser.parseEvent rejects or throws on inputs
+// that are structurally invalid (missing required fields, wrong types, etc.)
+// without relying on a live Prisma connection.
+// ---------------------------------------------------------------------------
+
+describe('StreamEventParser — malformed-payload guard', () => {
+  type MalformedFixture = {
+    label: string;
+    event: any;
+    expectRejection: boolean;
+  };
+
+  // Build a minimal mock for Prisma that records calls but never actually writes.
+  const upsertMock = vi.fn().mockResolvedValue({});
+  const updateMock = vi.fn().mockResolvedValue({});
+
+  const mockPrisma = {
+    stream: {
+      upsert: upsertMock,
+      update: updateMock,
+    },
+  } as unknown as PrismaClient;
+
+  const parser = new StreamEventParser(mockPrisma);
+
+  beforeEach(() => {
+    upsertMock.mockClear();
+    updateMock.mockClear();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Table of malformed payloads
+  // ---------------------------------------------------------------------------
+  const malformedFixtures: MalformedFixture[] = [
+    {
+      label: 'missing type field',
+      event: {
+        // no `type`
+        streamId: 99,
+        creator: 'GCREATOR',
+        recipient: 'GRECIPIENT',
+        amount: '1000',
+        txHash: '0xabc',
+        timestamp: new Date(),
+      },
+      expectRejection: true,
+    },
+    {
+      label: 'unknown event type string',
+      event: {
+        type: 'unknown_event_xyz',
+        streamId: 99,
+        txHash: '0xabc',
+        timestamp: new Date(),
+      },
+      expectRejection: false, // parseEvent has no default branch → silently no-ops
+    },
+    {
+      label: 'created event with null streamId',
+      event: {
+        type: 'created',
+        streamId: null,
+        creator: 'GCREATOR',
+        recipient: 'GRECIPIENT',
+        amount: '1000',
+        txHash: '0xabc',
+        timestamp: new Date(),
+      },
+      expectRejection: true,
+    },
+    {
+      label: 'created event with negative amount string (should store as-is)',
+      event: {
+        type: 'created',
+        streamId: 200,
+        creator: 'GCREATOR',
+        recipient: 'GRECIPIENT',
+        amount: '-999',
+        hasMetadata: false,
+        metadata: null,
+        txHash: '0xneg',
+        timestamp: new Date(),
+      },
+      // BigInt('-999') is valid — Prisma would receive it; we just verify no
+      // exception is thrown by the parser layer itself.
+      expectRejection: false,
+    },
+    {
+      label: 'created event with missing timestamp',
+      event: {
+        type: 'created',
+        streamId: 201,
+        creator: 'GCREATOR',
+        recipient: 'GRECIPIENT',
+        amount: '500',
+        hasMetadata: false,
+        metadata: null,
+        txHash: '0xnotimestamp',
+        // timestamp intentionally omitted
+      },
+      expectRejection: true,
+    },
+    {
+      label: 'claimed event with missing streamId',
+      event: {
+        type: 'claimed',
+        recipient: 'GRECIPIENT',
+        amount: '500',
+        txHash: '0xabc',
+        timestamp: new Date(),
+        // streamId intentionally omitted
+      },
+      expectRejection: true,
+    },
+    {
+      label: 'claimed event with non-string amount',
+      event: {
+        type: 'claimed',
+        streamId: 202,
+        recipient: 'GRECIPIENT',
+        amount: 12345, // number, not string
+        txHash: '0xabc',
+        timestamp: new Date(),
+      },
+      // Parser passes amount through to Prisma; type coercion depends on Prisma
+      // layer. Parser itself does not throw.
+      expectRejection: false,
+    },
+    {
+      label: 'cancelled event with missing creator',
+      event: {
+        type: 'cancelled',
+        streamId: 203,
+        // creator omitted
+        refundAmount: '0',
+        txHash: '0xabc',
+        timestamp: new Date(),
+      },
+      expectRejection: false, // parser doesn't validate creator presence
+    },
+    {
+      label: 'metadata_updated event with completely empty object',
+      event: {},
+      expectRejection: true,
+    },
+    {
+      label: 'event is null',
+      event: null,
+      expectRejection: true,
+    },
+    {
+      label: 'event is a plain string',
+      event: 'not_an_object',
+      expectRejection: true,
+    },
+    {
+      label: 'event is a number',
+      event: 42,
+      expectRejection: true,
+    },
+  ];
+
+  for (const fixture of malformedFixtures) {
+    if (fixture.expectRejection) {
+      it(`rejects: ${fixture.label}`, async () => {
+        await expect(parser.parseEvent(fixture.event)).rejects.toThrow();
+      });
+    } else {
+      it(`does not throw: ${fixture.label}`, async () => {
+        await expect(parser.parseEvent(fixture.event)).resolves.not.toThrow();
+      });
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Valid baseline — verifies the mock Prisma receives well-formed arguments
+  // when a correctly structured created event is supplied.
+  // ---------------------------------------------------------------------------
+  it('valid created event calls prisma.stream.upsert with correct fields', async () => {
+    const now = new Date('2026-01-01T00:00:00Z');
+    const event = {
+      type: 'created' as const,
+      streamId: 300,
+      creator: 'GCREATOR_VALID',
+      recipient: 'GRECIPIENT_VALID',
+      amount: '5000000000',
+      hasMetadata: true,
+      metadata: 'ipfs://QmValid',
+      txHash: '0xvalidhash',
+      timestamp: now,
+    };
+
+    await parser.parseCreatedEvent(event);
+
+    expect(upsertMock).toHaveBeenCalledOnce();
+    const call = upsertMock.mock.calls[0][0];
+    expect(call.where.streamId).toBe(300);
+    expect(call.create.creator).toBe('GCREATOR_VALID');
+    expect(call.create.recipient).toBe('GRECIPIENT_VALID');
+    expect(call.create.amount).toBe(BigInt('5000000000'));
+    expect(call.create.metadata).toBe('ipfs://QmValid');
+    expect(call.create.createdAt).toEqual(now);
+    // Replay idempotency: update block must be a no-op
+    expect(Object.keys(call.update)).toHaveLength(0);
+  });
+
+  it('valid claimed event calls prisma.stream.update with status CLAIMED', async () => {
+    const claimedAt = new Date('2026-02-01T00:00:00Z');
+    const event = {
+      type: 'claimed' as const,
+      streamId: 301,
+      recipient: 'GRECIPIENT_VALID',
+      amount: '5000000000',
+      txHash: '0xclaimedvalid',
+      timestamp: claimedAt,
+    };
+
+    await parser.parseClaimedEvent(event);
+
+    expect(updateMock).toHaveBeenCalledOnce();
+    const call = updateMock.mock.calls[0][0];
+    expect(call.where.streamId).toBe(301);
+    expect(call.data.status).toBe(StreamStatus.CLAIMED);
+    expect(call.data.claimedAt).toEqual(claimedAt);
+  });
+
+  it('valid cancelled event calls prisma.stream.update with status CANCELLED', async () => {
+    const cancelledAt = new Date('2026-03-01T00:00:00Z');
+    const event = {
+      type: 'cancelled' as const,
+      streamId: 302,
+      creator: 'GCREATOR_VALID',
+      refundAmount: '5000000000',
+      txHash: '0xcancelledvalid',
+      timestamp: cancelledAt,
+    };
+
+    await parser.parseCancelledEvent(event);
+
+    expect(updateMock).toHaveBeenCalledOnce();
+    const call = updateMock.mock.calls[0][0];
+    expect(call.where.streamId).toBe(302);
+    expect(call.data.status).toBe(StreamStatus.CANCELLED);
+    expect(call.data.cancelledAt).toEqual(cancelledAt);
+  });
+
+  it('valid metadata_updated event calls prisma.stream.update with new metadata', async () => {
+    const event = {
+      type: 'metadata_updated' as const,
+      streamId: 303,
+      updater: 'GCREATOR_VALID',
+      hasMetadata: true,
+      metadata: 'ipfs://QmNewMetadata',
+      txHash: '0xmetavalid',
+      timestamp: new Date(),
+    };
+
+    await parser.parseMetadataUpdatedEvent(event);
+
+    expect(updateMock).toHaveBeenCalledOnce();
+    const call = updateMock.mock.calls[0][0];
+    expect(call.where.streamId).toBe(303);
+    expect(call.data.metadata).toBe('ipfs://QmNewMetadata');
+  });
+
+  it('metadata_updated with hasMetadata=false clears metadata to null', async () => {
+    const event = {
+      type: 'metadata_updated' as const,
+      streamId: 304,
+      updater: 'GCREATOR_VALID',
+      hasMetadata: false,
+      // metadata field intentionally absent
+      txHash: '0xmetaclear',
+      timestamp: new Date(),
+    };
+
+    await parser.parseMetadataUpdatedEvent(event);
+
+    expect(updateMock).toHaveBeenCalledOnce();
+    const call = updateMock.mock.calls[0][0];
+    expect(call.data.metadata).toBeNull();
+  });
+});
 
 const prisma = new PrismaClient();
 const parser = new StreamEventParser(prisma);

--- a/backend/src/__tests__/streamMetadataService.test.ts
+++ b/backend/src/__tests__/streamMetadataService.test.ts
@@ -1,0 +1,369 @@
+/**
+ * Tests for StreamMetadataService
+ *
+ * Verifies that stream metadata is kept in sync with on-chain state, that
+ * financial invariants (amount, creator, recipient, schedule) are preserved
+ * across updates, and that invalid or unauthorized updates are rejected.
+ *
+ * All tests use an in-memory mock of Prisma — no real database required.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { StreamMetadataService } from '../services/streamMetadataService';
+
+// ---------------------------------------------------------------------------
+// In-memory stream store + Prisma mock
+// ---------------------------------------------------------------------------
+
+type StreamRow = {
+  id: string;
+  streamId: number;
+  creator: string;
+  recipient: string;
+  amount: bigint;
+  metadata: string | null;
+  status: string;
+  txHash: string;
+  createdAt: Date;
+  claimedAt: Date | null;
+  cancelledAt: Date | null;
+};
+
+let streamStore: Map<number, StreamRow>;
+
+function makeStream(overrides: Partial<StreamRow> = {}): StreamRow {
+  return {
+    id: 'mock-id',
+    streamId: 1,
+    creator: 'GCREATOR_ADDRESS',
+    recipient: 'GRECIPIENT_ADDRESS',
+    amount: BigInt('10000000000'),
+    metadata: null,
+    status: 'CREATED',
+    txHash: '0xabc',
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    claimedAt: null,
+    cancelledAt: null,
+    ...overrides,
+  };
+}
+
+let findUniqueMock: ReturnType<typeof vi.fn>;
+let updateMock: ReturnType<typeof vi.fn>;
+let findManyMock: ReturnType<typeof vi.fn>;
+
+function buildMockPrisma() {
+  findUniqueMock = vi.fn(async ({ where, select }: any) => {
+    const row = streamStore.get(where.streamId);
+    if (!row) return null;
+    if (select) {
+      // Return only selected fields
+      const result: any = {};
+      for (const key of Object.keys(select)) {
+        result[key] = (row as any)[key];
+      }
+      return result;
+    }
+    return row;
+  });
+
+  updateMock = vi.fn(async ({ where, data }: any) => {
+    const row = streamStore.get(where.streamId);
+    if (!row) throw new Error(`Stream ${where.streamId} not found`);
+    const updated = { ...row, ...data };
+    streamStore.set(where.streamId, updated);
+    return updated;
+  });
+
+  findManyMock = vi.fn(async ({ where }: any) => {
+    const results: StreamRow[] = [];
+    for (const row of streamStore.values()) {
+      let match = true;
+      if (where.creator && row.creator !== where.creator) match = false;
+      if (where.metadata?.not === null && row.metadata === null) match = false;
+      if (where.metadata === null && row.metadata !== null) match = false;
+      if (match) results.push(row);
+    }
+    return results.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+  });
+
+  return {
+    stream: {
+      findUnique: findUniqueMock,
+      update: updateMock,
+      findMany: findManyMock,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe('StreamMetadataService', () => {
+  let service: StreamMetadataService;
+
+  beforeEach(() => {
+    streamStore = new Map();
+    const mockPrisma = buildMockPrisma();
+    service = new StreamMetadataService(mockPrisma as any);
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // 1. Metadata created (set) on stream-created event
+  //    → upsert a stream with initial metadata, then read it back
+  // ──────────────────────────────────────────────────────────────────────────
+  describe('metadata created on stream-created event', () => {
+    it('stores metadata when a stream is seeded with initial metadata', async () => {
+      streamStore.set(1, makeStream({ streamId: 1, metadata: 'ipfs://QmInitial' }));
+
+      const meta = await service.getMetadata(1);
+      expect(meta).toBe('ipfs://QmInitial');
+    });
+
+    it('stores null when stream is created without metadata', async () => {
+      streamStore.set(2, makeStream({ streamId: 2, metadata: null }));
+
+      const meta = await service.getMetadata(2);
+      expect(meta).toBeNull();
+    });
+
+    it('getMetadata throws when stream does not exist', async () => {
+      await expect(service.getMetadata(999)).rejects.toThrow('999 not found');
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // 2. Metadata updated on rate-change event
+  //    (represented here as a metadata string update by the creator)
+  // ──────────────────────────────────────────────────────────────────────────
+  describe('metadata updated on rate-change event', () => {
+    beforeEach(() => {
+      streamStore.set(10, makeStream({ streamId: 10, metadata: 'ipfs://QmOld' }));
+    });
+
+    it('updates metadata to a new IPFS URI', async () => {
+      const result = await service.updateMetadata(10, 'GCREATOR_ADDRESS', 'ipfs://QmNew');
+      expect(result.metadata).toBe('ipfs://QmNew');
+    });
+
+    it('records the updated value in the store', async () => {
+      await service.updateMetadata(10, 'GCREATOR_ADDRESS', 'ipfs://QmUpdated');
+      const meta = await service.getMetadata(10);
+      expect(meta).toBe('ipfs://QmUpdated');
+    });
+
+    it('clears metadata when new value is null', async () => {
+      await service.updateMetadata(10, 'GCREATOR_ADDRESS', null);
+      const meta = await service.getMetadata(10);
+      expect(meta).toBeNull();
+    });
+
+    it('preserves financial terms after update — amount unchanged', async () => {
+      const before = streamStore.get(10)!;
+      await service.updateMetadata(10, 'GCREATOR_ADDRESS', 'ipfs://QmNew');
+      const after = streamStore.get(10)!;
+      expect(after.amount).toBe(before.amount);
+    });
+
+    it('preserves financial terms after update — creator unchanged', async () => {
+      const before = streamStore.get(10)!;
+      await service.updateMetadata(10, 'GCREATOR_ADDRESS', 'ipfs://QmNew');
+      const after = streamStore.get(10)!;
+      expect(after.creator).toBe(before.creator);
+    });
+
+    it('preserves financial terms after update — recipient unchanged', async () => {
+      const before = streamStore.get(10)!;
+      await service.updateMetadata(10, 'GCREATOR_ADDRESS', 'ipfs://QmNew');
+      const after = streamStore.get(10)!;
+      expect(after.recipient).toBe(before.recipient);
+    });
+
+    it('preserves financial terms after update — createdAt unchanged', async () => {
+      const before = streamStore.get(10)!;
+      await service.updateMetadata(10, 'GCREATOR_ADDRESS', 'ipfs://QmNew');
+      const after = streamStore.get(10)!;
+      expect(after.createdAt).toEqual(before.createdAt);
+    });
+
+    it('calls prisma.stream.update exactly once', async () => {
+      await service.updateMetadata(10, 'GCREATOR_ADDRESS', 'ipfs://QmNew');
+      expect(updateMock).toHaveBeenCalledOnce();
+    });
+
+    it('passes the correct streamId to prisma.stream.update', async () => {
+      await service.updateMetadata(10, 'GCREATOR_ADDRESS', 'ipfs://QmNew');
+      const call = updateMock.mock.calls[0][0];
+      expect(call.where.streamId).toBe(10);
+      expect(call.data.metadata).toBe('ipfs://QmNew');
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // 3. Stale-metadata-overwrite guard
+  //    → an update event referencing an unknown stream must be rejected
+  // ──────────────────────────────────────────────────────────────────────────
+  describe('stale-metadata-overwrite guard', () => {
+    it('rejects updateMetadata for a stream that does not exist', async () => {
+      // Store is empty — stream 42 was never created
+      await expect(
+        service.updateMetadata(42, 'GCREATOR_ADDRESS', 'ipfs://QmStale'),
+      ).rejects.toThrow('42 not found');
+    });
+
+    it('does not call prisma.stream.update when the stream is missing', async () => {
+      try {
+        await service.updateMetadata(42, 'GCREATOR_ADDRESS', 'ipfs://QmStale');
+      } catch {
+        // expected
+      }
+      expect(updateMock).not.toHaveBeenCalled();
+    });
+
+    it('rejects updateMetadata by a non-creator caller', async () => {
+      streamStore.set(20, makeStream({ streamId: 20 }));
+
+      await expect(
+        service.updateMetadata(20, 'GINTRUDER_ADDRESS', 'ipfs://QmBad'),
+      ).rejects.toThrow('creator');
+    });
+
+    it('does not modify the stream when an unauthorized update is attempted', async () => {
+      streamStore.set(21, makeStream({ streamId: 21, metadata: 'ipfs://QmOriginal' }));
+
+      try {
+        await service.updateMetadata(21, 'GINTRUDER_ADDRESS', 'ipfs://QmBad');
+      } catch {
+        // expected
+      }
+
+      const row = streamStore.get(21)!;
+      expect(row.metadata).toBe('ipfs://QmOriginal');
+    });
+
+    it('rejects empty-string metadata (stale event with blank payload)', async () => {
+      streamStore.set(22, makeStream({ streamId: 22 }));
+
+      await expect(
+        service.updateMetadata(22, 'GCREATOR_ADDRESS', ''),
+      ).rejects.toThrow('empty');
+    });
+
+    it('rejects metadata exceeding 512 characters', async () => {
+      streamStore.set(23, makeStream({ streamId: 23 }));
+      const oversized = 'x'.repeat(513);
+
+      await expect(
+        service.updateMetadata(23, 'GCREATOR_ADDRESS', oversized),
+      ).rejects.toThrow('512');
+    });
+
+    it('accepts metadata of exactly 512 characters', async () => {
+      streamStore.set(24, makeStream({ streamId: 24 }));
+      const maxLen = 'x'.repeat(512);
+
+      const result = await service.updateMetadata(24, 'GCREATOR_ADDRESS', maxLen);
+      expect(result.metadata).toBe(maxLen);
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // 4. Batch validation helper
+  // ──────────────────────────────────────────────────────────────────────────
+  describe('validateBatchUpdates', () => {
+    beforeEach(() => {
+      streamStore.set(30, makeStream({ streamId: 30 }));
+      streamStore.set(31, makeStream({ streamId: 31 }));
+    });
+
+    it('returns valid=true for well-formed updates by the creator', async () => {
+      const results = await service.validateBatchUpdates([
+        { streamId: 30, creator: 'GCREATOR_ADDRESS', newMetadata: 'ipfs://Qm30' },
+        { streamId: 31, creator: 'GCREATOR_ADDRESS', newMetadata: 'ipfs://Qm31' },
+      ]);
+
+      expect(results).toHaveLength(2);
+      expect(results[0]).toEqual({ streamId: 30, valid: true });
+      expect(results[1]).toEqual({ streamId: 31, valid: true });
+    });
+
+    it('returns valid=false with error when stream is missing', async () => {
+      const results = await service.validateBatchUpdates([
+        { streamId: 999, creator: 'GCREATOR_ADDRESS', newMetadata: 'ipfs://Qm999' },
+      ]);
+
+      expect(results[0].valid).toBe(false);
+      expect(results[0].error).toMatch(/not found/i);
+    });
+
+    it('returns valid=false when caller is not the creator', async () => {
+      const results = await service.validateBatchUpdates([
+        { streamId: 30, creator: 'GINTRUDER_ADDRESS', newMetadata: 'ipfs://QmBad' },
+      ]);
+
+      expect(results[0].valid).toBe(false);
+      expect(results[0].error).toMatch(/unauthorized/i);
+    });
+
+    it('returns valid=false for empty-string metadata', async () => {
+      const results = await service.validateBatchUpdates([
+        { streamId: 30, creator: 'GCREATOR_ADDRESS', newMetadata: '' },
+      ]);
+
+      expect(results[0].valid).toBe(false);
+      expect(results[0].error).toBeDefined();
+    });
+
+    it('handles mixed valid and invalid entries independently', async () => {
+      const results = await service.validateBatchUpdates([
+        { streamId: 30, creator: 'GCREATOR_ADDRESS', newMetadata: 'ipfs://valid' },
+        { streamId: 31, creator: 'GINTRUDER_ADDRESS', newMetadata: 'ipfs://bad' },
+        { streamId: 999, creator: 'GCREATOR_ADDRESS', newMetadata: 'ipfs://missing' },
+      ]);
+
+      expect(results[0].valid).toBe(true);
+      expect(results[1].valid).toBe(false);
+      expect(results[2].valid).toBe(false);
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // 5. getStreamsByCreator
+  // ──────────────────────────────────────────────────────────────────────────
+  describe('getStreamsByCreator', () => {
+    beforeEach(() => {
+      streamStore.set(40, makeStream({ streamId: 40, creator: 'GCREATOR_A', metadata: 'ipfs://Qm40' }));
+      streamStore.set(41, makeStream({ streamId: 41, creator: 'GCREATOR_A', metadata: null }));
+      streamStore.set(42, makeStream({ streamId: 42, creator: 'GCREATOR_B', metadata: 'ipfs://Qm42' }));
+    });
+
+    it('returns all streams for a creator when hasMetadata is not filtered', async () => {
+      const results = await service.getStreamsByCreator('GCREATOR_A');
+      expect(results).toHaveLength(2);
+    });
+
+    it('returns only streams with metadata when hasMetadata=true', async () => {
+      const results = await service.getStreamsByCreator('GCREATOR_A', true);
+      expect(results).toHaveLength(1);
+      expect(results[0].streamId).toBe(40);
+    });
+
+    it('returns only streams without metadata when hasMetadata=false', async () => {
+      const results = await service.getStreamsByCreator('GCREATOR_A', false);
+      expect(results).toHaveLength(1);
+      expect(results[0].streamId).toBe(41);
+    });
+
+    it('returns empty array for an unknown creator', async () => {
+      const results = await service.getStreamsByCreator('GUNKNOWN');
+      expect(results).toHaveLength(0);
+    });
+
+    it('does not leak streams belonging to a different creator', async () => {
+      const results = await service.getStreamsByCreator('GCREATOR_A');
+      const streamIds = results.map((r: any) => r.streamId);
+      expect(streamIds).not.toContain(42);
+    });
+  });
+});


### PR DESCRIPTION
  Summary
  
  Two services — streamEventParser.ts and streamMetadataService.ts — had no test coverage. This PR adds a unit test suite for each, covering the gaps described
  in the issue.
  
  Changes
  
  src/__tests__/streamEventParser.test.ts — extended with a new StreamEventParser — malformed-payload guard describe block:
  
  - Table-driven fixtures covering 12 malformed event shapes: missing type, unknown event type, null streamId, missing timestamp, wrong field types,
  null/primitive event values, and empty object
  - Valid baseline tests asserting the Prisma mock receives correctly shaped arguments for created, claimed, cancelled, and metadata_updated events
  - Verifies the replay idempotency contract: the update block on upsert must be empty
  - Uses vi.fn() mocks — no database connection required
  
  src/__tests__/streamMetadataService.test.ts — new file, 5 describe blocks:
  
  - Metadata created on stream-created event: getMetadata returns the initial value; null for streams without metadata; throws for unknown streams
  - Metadata updated on rate-change event: confirms new URI is persisted; financial terms (amount, creator, recipient, createdAt) are unchanged after every
  update; Prisma update is called once with the correct streamId
  - Stale-metadata-overwrite guard: updateMetadata throws and does not call Prisma when the stream does not exist; throws on unauthorized caller; does not
  mutate the stored row on auth failure; rejects empty-string and >512-char metadata payloads
  - validateBatchUpdates: valid/invalid entries are assessed independently; missing stream, wrong creator, and empty metadata each produce a descriptive error
  - getStreamsByCreator: hasMetadata filter works for both true/false/undefined; no data from a different creator leaks through
  
  Testing
  
  All tests are pure unit tests using an in-memory mock of Prisma — no database or network required. Run with:
  
  cd backend
  npx vitest run src/__tests__/streamEventParser.test.ts src/__tests__/streamMetadataService.test.ts
  
  What was not changed
  
  Source files (streamEventParser.ts, streamMetadataService.ts) are unchanged. The issue asks for test coverage only.


closes #1547 