### PR TITLE
Backend resilience batch: config parity check, leader election, saga coordinator, snapshot replay

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Type check
         run: npm run type-check
 
+      - name: Cross-service config parity check
+        run: npx tsx ../scripts/check-config-parity.ts
+
       - name: Verify generated event types are in sync with event-schemas/
         run: |
           npm run generate:event-types

--- a/backend/prisma/migrations/20260627000000_add_saga_coordinator/migration.sql
+++ b/backend/prisma/migrations/20260627000000_add_saga_coordinator/migration.sql
@@ -1,0 +1,47 @@
+-- CreateEnum
+CREATE TYPE "SagaStatus" AS ENUM ('RUNNING', 'COMPLETED', 'COMPENSATING', 'COMPENSATED', 'FAILED');
+
+-- CreateEnum
+CREATE TYPE "SagaCompensationStatus" AS ENUM ('NOT_STARTED', 'IN_PROGRESS', 'COMPLETED');
+
+-- CreateTable
+CREATE TABLE "SagaExecution" (
+    "id" TEXT NOT NULL,
+    "sagaType" TEXT NOT NULL,
+    "status" "SagaStatus" NOT NULL DEFAULT 'RUNNING',
+    "currentStepIndex" INTEGER NOT NULL DEFAULT 0,
+    "stepCount" INTEGER NOT NULL,
+    "context" JSONB NOT NULL,
+    "compensationStatus" "SagaCompensationStatus" NOT NULL DEFAULT 'NOT_STARTED',
+    "compensatedStepIndex" INTEGER,
+    "error" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "completedAt" TIMESTAMP(3),
+
+    CONSTRAINT "SagaExecution_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "TokenGovernanceRegistration" (
+    "id" TEXT NOT NULL,
+    "tokenId" TEXT NOT NULL,
+    "registeredAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "TokenGovernanceRegistration_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "SagaExecution_status_idx" ON "SagaExecution"("status");
+
+-- CreateIndex
+CREATE INDEX "SagaExecution_sagaType_idx" ON "SagaExecution"("sagaType");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "TokenGovernanceRegistration_tokenId_key" ON "TokenGovernanceRegistration"("tokenId");
+
+-- CreateIndex
+CREATE INDEX "TokenGovernanceRegistration_tokenId_idx" ON "TokenGovernanceRegistration"("tokenId");
+
+-- AddForeignKey
+ALTER TABLE "TokenGovernanceRegistration" ADD CONSTRAINT "TokenGovernanceRegistration_tokenId_fkey" FOREIGN KEY ("tokenId") REFERENCES "Token"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/prisma/migrations/20260628000000_add_projection_snapshot/migration.sql
+++ b/backend/prisma/migrations/20260628000000_add_projection_snapshot/migration.sql
@@ -1,0 +1,21 @@
+-- CreateEnum
+CREATE TYPE "ProjectionType" AS ENUM ('CAMPAIGN', 'GOVERNANCE', 'STREAM', 'VAULT');
+
+-- CreateTable
+CREATE TABLE "ProjectionSnapshot" (
+    "id" TEXT NOT NULL,
+    "projectionType" "ProjectionType" NOT NULL,
+    "ledger" INTEGER NOT NULL,
+    "cursor" TEXT NOT NULL,
+    "formatVersion" INTEGER NOT NULL DEFAULT 1,
+    "data" JSONB NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ProjectionSnapshot_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ProjectionSnapshot_projectionType_ledger_key" ON "ProjectionSnapshot"("projectionType", "ledger");
+
+-- CreateIndex
+CREATE INDEX "ProjectionSnapshot_projectionType_ledger_idx" ON "ProjectionSnapshot"("projectionType", "ledger");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -503,3 +503,33 @@ model TokenGovernanceRegistration {
 
   @@index([tokenId])
 }
+
+/// Point-in-time capture of a single projection type's full state at a given
+/// ledger height (#1620). Lets the replay engine resume from the nearest
+/// usable snapshot instead of always replaying from ledger zero. See
+/// docs/PROJECTION_SNAPSHOTS.md for the payload format and versioning
+/// strategy, including why STREAM and VAULT currently snapshot the same
+/// underlying table.
+model ProjectionSnapshot {
+  id             String         @id @default(uuid())
+  projectionType ProjectionType
+  /// Ledger height this snapshot represents — the projection reflects every event up to and including this ledger.
+  ledger         Int
+  /// Full event-store paging cursor at capture time, for precise replay resumption.
+  cursor         String
+  /// Payload schema version — see docs/PROJECTION_SNAPSHOTS.md for the compatibility policy across versions.
+  formatVersion  Int            @default(1)
+  /// The captured projection rows (shape depends on projectionType — see docs/PROJECTION_SNAPSHOTS.md).
+  data           Json
+  createdAt      DateTime       @default(now())
+
+  @@unique([projectionType, ledger])
+  @@index([projectionType, ledger])
+}
+
+enum ProjectionType {
+  CAMPAIGN
+  GOVERNANCE
+  STREAM
+  VAULT
+}

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -33,6 +33,7 @@ model Token {
   burnRecords    BurnRecord[]
   analytics      Analytics[]
   dividendPools  DividendPool[]
+  governanceRegistration TokenGovernanceRegistration?
 
   @@index([address])
   @@index([creator])
@@ -447,4 +448,58 @@ model IPFSPin {
   @@index([pinned])
   @@index([failureCount])
   @@index([tokenAddress])
+}
+
+/// Durable state for the SagaCoordinator (#1621). Persists the step index and
+/// per-step context of a multi-step, cross-contract operation so an in-flight
+/// saga survives a process restart and can be resumed forward or compensated
+/// (rolled back in reverse step order) correctly rather than being lost.
+model SagaExecution {
+  id                   String                @id @default(uuid())
+  /// Identifies which saga definition this execution is running (e.g. "batch_deploy_with_governance_registration").
+  sagaType             String
+  status               SagaStatus            @default(RUNNING)
+  /// Index of the next step to execute (forward) or the step compensation is currently undoing.
+  currentStepIndex     Int                   @default(0)
+  stepCount            Int
+  /// Arbitrary saga-specific input/intermediate state (step results accumulate here as the saga progresses).
+  context              Json
+  compensationStatus   SagaCompensationStatus @default(NOT_STARTED)
+  /// Highest step index compensation has completed undoing so far — makes compensation resumable/idempotent.
+  compensatedStepIndex Int?
+  error                String?
+  createdAt            DateTime              @default(now())
+  updatedAt            DateTime              @updatedAt
+  completedAt          DateTime?
+
+  @@index([status])
+  @@index([sagaType])
+}
+
+enum SagaStatus {
+  RUNNING
+  COMPLETED
+  COMPENSATING
+  COMPENSATED
+  FAILED
+}
+
+enum SagaCompensationStatus {
+  NOT_STARTED
+  IN_PROGRESS
+  COMPLETED
+}
+
+/// Marks a deployed token as registered for governance participation (voting
+/// eligibility). Written by the batch-deploy-plus-governance-registration saga
+/// as its second step; deleted by that step's compensation if a later step
+/// in the same saga fails and the whole operation must be undone.
+model TokenGovernanceRegistration {
+  id           String   @id @default(uuid())
+  tokenId      String   @unique
+  registeredAt DateTime @default(now())
+
+  token Token @relation(fields: [tokenId], references: [id])
+
+  @@index([tokenId])
 }

--- a/backend/src/__tests__/checkConfigParity.test.ts
+++ b/backend/src/__tests__/checkConfigParity.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { join } from "path";
+import {
+  parseEnvExample,
+  loadServiceEnv,
+  checkParity,
+  type ServiceEnvs,
+} from "../../../scripts/check-config-parity";
+
+const REPO_ROOT = join(__dirname, "..", "..", "..");
+
+function loadRealEnvs(): ServiceEnvs {
+  return {
+    backend: loadServiceEnv(join(REPO_ROOT, "backend", ".env.example")),
+    gateway: loadServiceEnv(join(REPO_ROOT, "gateway", ".env.example")),
+    frontend: loadServiceEnv(join(REPO_ROOT, "frontend", ".env.example")),
+  };
+}
+
+describe("parseEnvExample", () => {
+  it("parses KEY=VALUE pairs and ignores comments/blank lines", () => {
+    const parsed = parseEnvExample(
+      ["# a comment", "", "FOO=bar", "  BAZ=qux  ", "# EMPTY=ignored"].join("\n")
+    );
+    expect(parsed).toEqual({ FOO: "bar", BAZ: "qux" });
+  });
+
+  it("preserves '=' characters inside values", () => {
+    const parsed = parseEnvExample("DATABASE_URL=postgresql://user:pass@host:5432/db?schema=public");
+    expect(parsed.DATABASE_URL).toBe("postgresql://user:pass@host:5432/db?schema=public");
+  });
+});
+
+describe("checkParity against real .env.example files", () => {
+  it("passes with zero mismatches on current config", () => {
+    const mismatches = checkParity(loadRealEnvs());
+    expect(mismatches).toEqual([]);
+  });
+});
+
+describe("checkParity flags deliberately introduced mismatches", () => {
+  it("flags a Redis URL divergence between backend and gateway", () => {
+    const envs = loadRealEnvs();
+    envs.gateway = { ...envs.gateway, REDIS_URL: "redis://some-other-host:6380" };
+
+    const mismatches = checkParity(envs);
+    expect(mismatches.some((m) => m.rule === "redis_url")).toBe(true);
+  });
+
+  it("flags a gateway BACKEND_URL that no longer matches backend.PORT", () => {
+    const envs = loadRealEnvs();
+    envs.gateway = { ...envs.gateway, BACKEND_URL: "http://localhost:9999" };
+
+    const mismatches = checkParity(envs);
+    expect(mismatches.some((m) => m.rule === "gateway_backend_url")).toBe(true);
+  });
+
+  it("flags a frontend API URL that bypasses the gateway port", () => {
+    const envs = loadRealEnvs();
+    envs.frontend = { ...envs.frontend, VITE_API_BASE_URL: "http://localhost:3000/api" };
+
+    const mismatches = checkParity(envs);
+    expect(mismatches.some((m) => m.rule === "frontend_api_base_url")).toBe(true);
+  });
+
+  it("flags a Stellar network mismatch between backend and frontend", () => {
+    const envs = loadRealEnvs();
+    envs.frontend = { ...envs.frontend, VITE_NETWORK: "mainnet" };
+
+    const mismatches = checkParity(envs);
+    expect(mismatches.some((m) => m.rule === "stellar_network")).toBe(true);
+  });
+
+  it("flags a missing frontend origin in the gateway's CORS allowlist", () => {
+    const envs = loadRealEnvs();
+    envs.gateway = { ...envs.gateway, ALLOWED_ORIGINS: "http://example.com" };
+
+    const mismatches = checkParity(envs);
+    expect(mismatches.some((m) => m.rule === "frontend_origin")).toBe(true);
+  });
+});

--- a/backend/src/__tests__/stellarEventListener.test.ts
+++ b/backend/src/__tests__/stellarEventListener.test.ts
@@ -78,7 +78,19 @@ describe("StellarEventListener Reconnect, Cursor Resume, and Backoff", () => {
     const store = (listener as any).cursorStore;
     vi.spyOn(store, "save").mockResolvedValue(undefined);
     vi.spyOn(store, "load").mockResolvedValue("origin-cursor");
-    
+
+    // Stub out leader election so start() doesn't need a real Redis — grant
+    // leadership immediately and keep every fencing-token check valid.
+    (listener as any).leaderElection = {
+      start: async () => {
+        await (listener as any).onBecameLeader(1);
+      },
+      stop: async () => {},
+      isLeader: () => true,
+      getFencingToken: () => 1,
+      validateFencingToken: async () => true,
+    };
+
     process.env.FACTORY_CONTRACT_ID = "CAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
     process.env.STELLAR_NETWORK = "TESTNET";
   });

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -40,6 +40,7 @@ import { streamReconciliationService } from "./services/streamReconciliation";
 import "./services/streamDivergenceAlerting";
 import sagaCoordinator from "./services/sagaCoordinator";
 import "./services/sagas/batchDeployGovernanceSaga";
+import { runProjectionSnapshotJob } from "./services/projectionSnapshotJob";
 
 dotenv.config();
 
@@ -241,6 +242,20 @@ const server = app.listen(PORT, async () => {
     jobQueue.scheduleRecurring("stream_reconciliation", {}, reconciliationInterval);
     console.log(
       `📋 Stream reconciliation scheduled every ${reconciliationInterval}ms`
+    );
+  }
+
+  // Register and schedule periodic cross-projection snapshot capture if enabled
+  jobQueue.register("projection_snapshot", async () => {
+    await runProjectionSnapshotJob(prisma);
+  });
+  if (process.env.ENABLE_PROJECTION_SNAPSHOTS === "true") {
+    const snapshotInterval = parseInt(
+      process.env.PROJECTION_SNAPSHOT_INTERVAL_MS || "1800000" // 30 minutes default
+    );
+    jobQueue.scheduleRecurring("projection_snapshot", {}, snapshotInterval);
+    console.log(
+      `📋 Projection snapshot capture scheduled every ${snapshotInterval}ms`
     );
   }
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -38,6 +38,8 @@ import websocketService from "./services/websocket";
 import jobQueue from "./services/jobQueue";
 import { streamReconciliationService } from "./services/streamReconciliation";
 import "./services/streamDivergenceAlerting";
+import sagaCoordinator from "./services/sagaCoordinator";
+import "./services/sagas/batchDeployGovernanceSaga";
 
 dotenv.config();
 
@@ -247,6 +249,9 @@ const server = app.listen(PORT, async () => {
 
   // Attach GraphQL subscriptions (graphql-ws) on the /graphql WS path
   attachGraphqlSubscriptions(server);
+
+  // Resume or compensate any sagas left in-flight by a prior process restart
+  await sagaCoordinator.recoverInterruptedSagas();
 
   // Start event listener only after server (and DB) are ready
   if (process.env.ENABLE_EVENT_LISTENER === "true") {

--- a/backend/src/lib/leaderElection.ts
+++ b/backend/src/lib/leaderElection.ts
@@ -1,0 +1,270 @@
+/**
+ * Redis-based distributed leader election with fencing tokens.
+ *
+ * Gives a fleet of identical worker instances (e.g. multiple
+ * StellarEventListener processes) a single elected leader at a time, with
+ * automatic failover if the leader crashes or its host dies.
+ *
+ * Mechanics:
+ *   - Leadership is a renewable lease: `SET <lockKey> <instanceId> PX <ttlMs> NX`.
+ *     The holder renews the lease on a fixed interval (`renewIntervalMs`,
+ *     which must be well below `ttlMs`); if it stops renewing (crash, GC
+ *     pause, network partition), the lease expires and any standby can win it.
+ *   - A monotonically increasing fencing token is stored in a separate,
+ *     non-expiring key. It is only incremented when the lock transitions
+ *     from unheld/expired to held (a genuinely new election) — never on a
+ *     same-holder renewal. Every instance that has ever held leadership knows
+ *     the fencing token it was issued; callers must pass that token to
+ *     `validateFencingToken` before any side effect that must not be
+ *     duplicated (e.g. advancing a durable cursor). If a newer election has
+ *     since happened, the stored counter has moved past the caller's token
+ *     and the check fails — this is what makes a demoted former leader
+ *     provably unable to commit a stale write, even if it hasn't yet noticed
+ *     it lost the lease (clock skew, slow GC, delayed network partition
+ *     detection, etc.).
+ *
+ * Bounded failover window: in the worst case a dead leader's lease is not
+ * detected as expired until just before its next renewal was due, so the
+ * window between leader death and a standby taking over is bounded by
+ * `ttlMs + renewIntervalMs` (lease must fully expire, then the standby's own
+ * next acquire attempt — up to one renew interval later — must observe it).
+ * With the defaults below (TTL 10s, renew every 3s) that bound is 13s.
+ *
+ * Acquire/renew is a single Lua script so the "is it free / do I already
+ * hold it / is it held by someone else" check-and-set is atomic — the same
+ * approach used by `../lib/lock.ts` for campaign step locks.
+ */
+
+import Redis from "ioredis";
+import { Counter, register } from "prom-client";
+
+/** Default lease TTL in milliseconds. */
+export const LEADER_LOCK_TTL_MS = 10_000;
+
+/** Default lease renewal interval in milliseconds. Must be well below the TTL. */
+export const LEADER_RENEW_INTERVAL_MS = 3_000;
+
+const KEY_PREFIX = "leader_election";
+
+export type ElectionEventName = "became-leader" | "lost-leadership" | "fencing-token-rejected";
+
+const leaderElectionEventsTotal = new Counter({
+  name: "leader_election_events_total",
+  help: "Count of leader election events by type and role.",
+  labelNames: ["event", "role"],
+  registers: [register],
+});
+
+function logElectionEvent(event: ElectionEventName, role: string, instanceId: string, details: Record<string, unknown> = {}): void {
+  leaderElectionEventsTotal.inc({ event, role });
+  console.log(
+    JSON.stringify({
+      component: "LeaderElection",
+      event,
+      role,
+      instanceId,
+      timestamp: new Date().toISOString(),
+      ...details,
+    }),
+  );
+}
+
+export interface LeaderElectionEvents {
+  onBecameLeader?(fencingToken: number): void;
+  onLostLeadership?(reason: string): void;
+}
+
+export interface LeaderElectionOptions {
+  redis: Redis;
+  /** Logical role/lock name — all instances contending for the same leadership must share this. */
+  role: string;
+  /** Unique identifier for this process instance (e.g. `${hostname}:${pid}:${randomUUID()}`). */
+  instanceId: string;
+  ttlMs?: number;
+  renewIntervalMs?: number;
+  events?: LeaderElectionEvents;
+}
+
+// KEYS[1] = lock key, KEYS[2] = fencing token counter key
+// ARGV[1] = instanceId, ARGV[2] = ttlMs
+// Returns {status, token}: status 1 = newly acquired, 2 = renewed, 0 = held by another instance.
+const ACQUIRE_OR_RENEW_SCRIPT = `
+local current = redis.call("GET", KEYS[1])
+if current == false then
+  redis.call("SET", KEYS[1], ARGV[1], "PX", ARGV[2])
+  local token = redis.call("INCR", KEYS[2])
+  return {1, token}
+elseif current == ARGV[1] then
+  redis.call("PEXPIRE", KEYS[1], ARGV[2])
+  local token = tonumber(redis.call("GET", KEYS[2]))
+  return {2, token}
+else
+  return {0, 0}
+end
+`;
+
+// KEYS[1] = fencing token counter key
+// ARGV[1] = attempted token
+// Returns 1 if ARGV[1] equals the current counter value (still valid), else 0.
+const VALIDATE_FENCING_TOKEN_SCRIPT = `
+local current = tonumber(redis.call("GET", KEYS[1]) or "0")
+if tonumber(ARGV[1]) == current then
+  return 1
+else
+  return 0
+end
+`;
+
+// KEYS[1] = lock key
+// ARGV[1] = instanceId
+// Releases the lock only if still held by this instance (compare-and-delete).
+const RELEASE_SCRIPT = `
+if redis.call("GET", KEYS[1]) == ARGV[1] then
+  return redis.call("DEL", KEYS[1])
+else
+  return 0
+end
+`;
+
+export class LeaderElection {
+  private readonly redis: Redis;
+  private readonly role: string;
+  private readonly instanceId: string;
+  private readonly ttlMs: number;
+  private readonly renewIntervalMs: number;
+  private readonly events: LeaderElectionEvents;
+
+  private fencingToken: number | null = null;
+  private leader = false;
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private stopped = true;
+
+  constructor(options: LeaderElectionOptions) {
+    this.redis = options.redis;
+    this.role = options.role;
+    this.instanceId = options.instanceId;
+    this.ttlMs = options.ttlMs ?? LEADER_LOCK_TTL_MS;
+    this.renewIntervalMs = options.renewIntervalMs ?? LEADER_RENEW_INTERVAL_MS;
+    this.events = options.events ?? {};
+  }
+
+  private lockKey(): string {
+    return `${KEY_PREFIX}:${this.role}:lock`;
+  }
+
+  private fencingKey(): string {
+    return `${KEY_PREFIX}:${this.role}:fencing_token`;
+  }
+
+  /** Whether this instance currently believes it holds leadership. */
+  isLeader(): boolean {
+    return this.leader;
+  }
+
+  /** The fencing token issued for this instance's current (or most recent) leadership term, if any. */
+  getFencingToken(): number | null {
+    return this.fencingToken;
+  }
+
+  /**
+   * Attempts to acquire the lease if free, or renew it if already held by
+   * this instance. Safe to call repeatedly — this is the operation the
+   * internal heartbeat runs on `renewIntervalMs`.
+   */
+  async tryAcquireOrRenew(): Promise<void> {
+    let result: [number, number];
+    try {
+      result = (await this.redis.eval(
+        ACQUIRE_OR_RENEW_SCRIPT,
+        2,
+        this.lockKey(),
+        this.fencingKey(),
+        this.instanceId,
+        this.ttlMs,
+      )) as [number, number];
+    } catch (err) {
+      // Redis unavailable — fail closed: we cannot safely claim leadership
+      // without the coordination store, so treat this as a lost lease.
+      if (this.leader) {
+        this.leader = false;
+        this.events.onLostLeadership?.("redis_unavailable");
+        logElectionEvent("lost-leadership", this.role, this.instanceId, {
+          reason: "redis_unavailable",
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+      return;
+    }
+
+    const [status, token] = result;
+
+    if (status === 1) {
+      this.fencingToken = token;
+      this.leader = true;
+      this.events.onBecameLeader?.(token);
+      logElectionEvent("became-leader", this.role, this.instanceId, { fencingToken: token });
+    } else if (status === 2) {
+      this.fencingToken = token;
+      this.leader = true;
+    } else {
+      if (this.leader) {
+        this.leader = false;
+        this.events.onLostLeadership?.("lease_lost_to_another_instance");
+        logElectionEvent("lost-leadership", this.role, this.instanceId, {
+          reason: "lease_lost_to_another_instance",
+        });
+      }
+    }
+  }
+
+  /**
+   * Validates that `token` is still the current fencing token for this role
+   * — i.e. no newer leadership term has begun since it was issued. Callers
+   * MUST call this immediately before any write that must not be duplicated
+   * by a demoted former leader, and must abort the write if it returns false.
+   */
+  async validateFencingToken(token: number): Promise<boolean> {
+    const valid = (await this.redis.eval(
+      VALIDATE_FENCING_TOKEN_SCRIPT,
+      1,
+      this.fencingKey(),
+      token,
+    )) as number;
+
+    if (valid !== 1) {
+      logElectionEvent("fencing-token-rejected", this.role, this.instanceId, {
+        attemptedToken: token,
+      });
+      return false;
+    }
+    return true;
+  }
+
+  /** Starts the heartbeat: attempts acquisition immediately, then on `renewIntervalMs`. */
+  async start(): Promise<void> {
+    if (!this.stopped) return;
+    this.stopped = false;
+    await this.tryAcquireOrRenew();
+    this.timer = setInterval(() => {
+      void this.tryAcquireOrRenew();
+    }, this.renewIntervalMs);
+    this.timer.unref?.();
+  }
+
+  /** Stops the heartbeat and releases the lease if currently held. */
+  async stop(): Promise<void> {
+    this.stopped = true;
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    if (this.leader) {
+      try {
+        await this.redis.eval(RELEASE_SCRIPT, 1, this.lockKey(), this.instanceId);
+      } catch {
+        // Best-effort release — the lease will still expire via TTL.
+      }
+      this.leader = false;
+    }
+  }
+}

--- a/backend/src/services/eventReplayService.ts
+++ b/backend/src/services/eventReplayService.ts
@@ -12,6 +12,7 @@ import {
 } from './vaultEventParser';
 import { EventCursorStore } from './eventCursorStore';
 import { isRetryableError, sleep } from '../stellar-service-integration/rate-limiter';
+import { findNearestUsableSnapshotLedger, restoreAllProjectionSnapshots } from './projectionSnapshot';
 
 const _env = validateEnv();
 const HORIZON_URL = _env.STELLAR_HORIZON_URL;
@@ -198,6 +199,32 @@ export class EventReplayService {
       const errorMsg = err instanceof Error ? err.message : String(err);
       throw new Error(`Event replay failed: ${errorMsg}`);
     }
+  }
+
+  /**
+   * Replays up to `targetLedger`, resuming from the nearest usable
+   * cross-projection snapshot (see `projectionSnapshot.ts`) instead of
+   * always replaying from ledger zero. Falls back to a full replay from
+   * origin if no complete snapshot set exists at or before `targetLedger`.
+   */
+  async replayFromLedger(
+    targetLedger: number,
+    options: Omit<ReplayOptions, 'startLedger' | 'endLedger'> = {},
+  ): Promise<ReplayResult> {
+    const snapshotLedger = await findNearestUsableSnapshotLedger(this.prisma, targetLedger);
+
+    if (snapshotLedger !== null) {
+      console.log(
+        `[EventReplay] Resuming from snapshot at ledger ${snapshotLedger} (target: ${targetLedger})`,
+      );
+      await restoreAllProjectionSnapshots(this.prisma, snapshotLedger);
+      return this.replay({ ...options, startLedger: snapshotLedger + 1, endLedger: targetLedger });
+    }
+
+    console.log(
+      `[EventReplay] No usable snapshot at or before ledger ${targetLedger} — replaying from origin`,
+    );
+    return this.replay({ ...options, endLedger: targetLedger });
   }
 
   /**

--- a/backend/src/services/projectionConsistencyCheck.ts
+++ b/backend/src/services/projectionConsistencyCheck.ts
@@ -1,0 +1,60 @@
+/**
+ * Snapshot-vs-zero replay consistency check (#1620).
+ *
+ * Verifies the core correctness property snapshot-based replay depends on:
+ * replaying from the nearest usable snapshot up to a target ledger must
+ * produce projection state byte-identical to a full replay from ledger zero
+ * to that same ledger. If a snapshot were captured incorrectly (wrong
+ * ledger, stale data, lossy BigInt/Date serialization) this is what would
+ * catch it.
+ *
+ * Intended for ops tooling / CI verification — run against a disposable
+ * database, since `clearAndRebuild` is destructive.
+ */
+
+import { PrismaClient, ProjectionType } from '@prisma/client';
+import { EventReplayService } from './eventReplayService';
+import { captureAllProjectionData, PROJECTION_TYPES } from './projectionSnapshot';
+
+export interface ProjectionConsistencyResult {
+  consistent: boolean;
+  targetLedger: number;
+  mismatchedProjectionTypes: ProjectionType[];
+}
+
+/**
+ * Runs both replay strategies against the given `prisma`/`replayService` and
+ * compares the resulting projection state for every projection type.
+ *
+ * WARNING: destructive — this clears and rebuilds all projection tables
+ * (via `EventReplayService.clearAndRebuild`) as its second pass. Only run
+ * against a disposable database.
+ */
+export async function verifyProjectionSnapshotConsistency(
+  replayService: EventReplayService,
+  prisma: PrismaClient,
+  targetLedger: number,
+): Promise<ProjectionConsistencyResult> {
+  // Pass 1: replay resuming from the nearest usable snapshot.
+  await replayService.replayFromLedger(targetLedger);
+  const fromSnapshotState = await captureAllProjectionData(prisma);
+
+  // Pass 2: full rebuild from ledger zero, for comparison.
+  await replayService.clearAndRebuild({ endLedger: targetLedger });
+  const fromZeroState = await captureAllProjectionData(prisma);
+
+  const mismatchedProjectionTypes: ProjectionType[] = [];
+  for (const projectionType of PROJECTION_TYPES) {
+    const a = JSON.stringify(fromSnapshotState[projectionType]);
+    const b = JSON.stringify(fromZeroState[projectionType]);
+    if (a !== b) {
+      mismatchedProjectionTypes.push(projectionType);
+    }
+  }
+
+  return {
+    consistent: mismatchedProjectionTypes.length === 0,
+    targetLedger,
+    mismatchedProjectionTypes,
+  };
+}

--- a/backend/src/services/projectionSnapshot.ts
+++ b/backend/src/services/projectionSnapshot.ts
@@ -1,0 +1,276 @@
+/**
+ * Cross-projection snapshot capture and restore (#1620).
+ *
+ * See docs/PROJECTION_SNAPSHOTS.md for the payload format and versioning
+ * strategy. Summary: a snapshot captures every row of a projection type's
+ * table(s) as of a given ledger height, with BigInt/Date fields converted to
+ * JSON-safe strings and rows sorted by `id` so two independently-taken
+ * snapshots of identical underlying state serialize byte-identically.
+ *
+ * STREAM and VAULT both snapshot the same `Stream` table — in this codebase
+ * both `stream_*` and `vault_*` on-chain event topics are parsed into the
+ * same projection (see `stellarEventListener.ts` / `eventReplayService.ts`),
+ * so there is genuinely only one table to capture for either type.
+ */
+
+import { PrismaClient, ProjectionType, ProjectionSnapshot as ProjectionSnapshotRow } from "@prisma/client";
+
+export const PROJECTION_SNAPSHOT_FORMAT_VERSION = 1;
+
+export const PROJECTION_TYPES: ProjectionType[] = [
+  ProjectionType.CAMPAIGN,
+  ProjectionType.GOVERNANCE,
+  ProjectionType.STREAM,
+  ProjectionType.VAULT,
+];
+
+/** Deep-converts BigInt -> string and Date -> ISO string, and sorts object keys, for stable JSON serialization. */
+function toJsonSafe(value: unknown): unknown {
+  if (value === null || value === undefined) return value;
+  if (typeof value === "bigint") return value.toString();
+  if (value instanceof Date) return value.toISOString();
+  if (Array.isArray(value)) return value.map(toJsonSafe);
+  if (typeof value === "object") {
+    const input = value as Record<string, unknown>;
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(input).sort()) {
+      out[key] = toJsonSafe(input[key]);
+    }
+    return out;
+  }
+  return value;
+}
+
+function sortById<T extends { id: string }>(rows: T[]): T[] {
+  return [...rows].sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+}
+
+async function captureCampaignData(prisma: PrismaClient): Promise<unknown> {
+  const [campaigns, executions, auditTrail] = await Promise.all([
+    prisma.campaign.findMany(),
+    prisma.campaignExecution.findMany(),
+    prisma.campaignAuditTrail.findMany(),
+  ]);
+  return toJsonSafe({
+    campaigns: sortById(campaigns),
+    executions: sortById(executions),
+    auditTrail: sortById(auditTrail),
+  });
+}
+
+async function captureGovernanceData(prisma: PrismaClient): Promise<unknown> {
+  const [proposals, votes, executions] = await Promise.all([
+    prisma.proposal.findMany(),
+    prisma.vote.findMany(),
+    prisma.proposalExecution.findMany(),
+  ]);
+  return toJsonSafe({
+    proposals: sortById(proposals),
+    votes: sortById(votes),
+    executions: sortById(executions),
+  });
+}
+
+async function captureStreamData(prisma: PrismaClient): Promise<unknown> {
+  const streams = await prisma.stream.findMany();
+  return toJsonSafe({ streams: sortById(streams) });
+}
+
+async function captureForType(prisma: PrismaClient, projectionType: ProjectionType): Promise<unknown> {
+  switch (projectionType) {
+    case ProjectionType.CAMPAIGN:
+      return captureCampaignData(prisma);
+    case ProjectionType.GOVERNANCE:
+      return captureGovernanceData(prisma);
+    case ProjectionType.STREAM:
+    case ProjectionType.VAULT:
+      return captureStreamData(prisma);
+    default:
+      throw new Error(`Unknown projection type: ${String(projectionType)}`);
+  }
+}
+
+/**
+ * Captures every projection type at the same ledger/cursor in one pass, so
+ * the resulting snapshot set is globally consistent (a replay resuming from
+ * this ledger sees exactly the state every projection had at that point).
+ */
+export async function captureAllProjectionSnapshots(
+  prisma: PrismaClient,
+  ledger: number,
+  cursor: string,
+): Promise<void> {
+  for (const projectionType of PROJECTION_TYPES) {
+    const data = await captureForType(prisma, projectionType);
+    await prisma.projectionSnapshot.upsert({
+      where: { projectionType_ledger: { projectionType, ledger } },
+      create: {
+        projectionType,
+        ledger,
+        cursor,
+        formatVersion: PROJECTION_SNAPSHOT_FORMAT_VERSION,
+        data: data as any,
+      },
+      update: {
+        cursor,
+        formatVersion: PROJECTION_SNAPSHOT_FORMAT_VERSION,
+        data: data as any,
+      },
+    });
+  }
+}
+
+/** Captures every projection type's current state, keyed by type — used by the consistency check to diff two replay strategies. */
+export async function captureAllProjectionData(
+  prisma: PrismaClient,
+): Promise<Record<ProjectionType, unknown>> {
+  const result = {} as Record<ProjectionType, unknown>;
+  for (const projectionType of PROJECTION_TYPES) {
+    result[projectionType] = await captureForType(prisma, projectionType);
+  }
+  return result;
+}
+
+/**
+ * Returns the highest ledger at or below `targetLedger` for which every
+ * projection type has a snapshot (i.e. a complete, globally-consistent
+ * snapshot set), or null if no such ledger exists.
+ */
+export async function findNearestUsableSnapshotLedger(
+  prisma: PrismaClient,
+  targetLedger: number,
+): Promise<number | null> {
+  const rows = await prisma.projectionSnapshot.findMany({
+    where: { ledger: { lte: targetLedger } },
+    select: { ledger: true, projectionType: true },
+  });
+
+  const typesByLedger = new Map<number, Set<ProjectionType>>();
+  for (const row of rows) {
+    if (!typesByLedger.has(row.ledger)) typesByLedger.set(row.ledger, new Set());
+    typesByLedger.get(row.ledger)!.add(row.projectionType);
+  }
+
+  let best: number | null = null;
+  for (const [ledger, types] of typesByLedger) {
+    if (types.size === PROJECTION_TYPES.length && (best === null || ledger > best)) {
+      best = ledger;
+    }
+  }
+  return best;
+}
+
+interface RestoreFieldSpec {
+  bigIntFields?: string[];
+  dateFields?: string[];
+}
+
+/**
+ * Re-inserts snapshot rows via `delegate.create()`, reversing `toJsonSafe`'s
+ * BigInt->string and Date->ISO-string conversions on the way back in.
+ * Restoring exact original `Date` values (including `createdAt`/`updatedAt`)
+ * matters here: the consistency check compares serialized projection state
+ * byte-for-byte, so a restore that let Prisma's `@updatedAt` auto-populate a
+ * fresh timestamp instead of the snapshotted one would fail that comparison
+ * even when the restore was otherwise correct.
+ */
+async function restoreRows(
+  delegate: any,
+  rows: any[] | undefined,
+  { bigIntFields = [], dateFields = [] }: RestoreFieldSpec,
+): Promise<void> {
+  if (!rows || rows.length === 0) return;
+  for (const row of rows) {
+    const data: Record<string, unknown> = { ...row };
+    for (const field of bigIntFields) {
+      if (data[field] !== null && data[field] !== undefined) {
+        data[field] = BigInt(data[field] as string);
+      }
+    }
+    for (const field of dateFields) {
+      if (data[field] !== null && data[field] !== undefined) {
+        data[field] = new Date(data[field] as string);
+      }
+    }
+    await delegate.create({ data });
+  }
+}
+
+async function restoreOne(prisma: PrismaClient, snapshot: ProjectionSnapshotRow): Promise<void> {
+  const data = snapshot.data as any;
+
+  switch (snapshot.projectionType) {
+    case ProjectionType.CAMPAIGN: {
+      await prisma.$transaction([
+        prisma.campaignAuditTrail.deleteMany(),
+        prisma.campaignExecution.deleteMany(),
+        prisma.campaign.deleteMany(),
+      ]);
+      await restoreRows(prisma.campaign, data.campaigns, {
+        bigIntFields: ["targetAmount", "currentAmount"],
+        dateFields: ["startTime", "endTime", "createdAt", "updatedAt", "completedAt", "cancelledAt", "pausedAt"],
+      });
+      await restoreRows(prisma.campaignExecution, data.executions, {
+        bigIntFields: ["amount"],
+        dateFields: ["executedAt"],
+      });
+      await restoreRows(prisma.campaignAuditTrail, data.auditTrail, {
+        dateFields: ["transitionAt"],
+      });
+      return;
+    }
+    case ProjectionType.GOVERNANCE: {
+      await prisma.$transaction([
+        prisma.vote.deleteMany(),
+        prisma.proposalExecution.deleteMany(),
+        prisma.proposal.deleteMany(),
+      ]);
+      await restoreRows(prisma.proposal, data.proposals, {
+        bigIntFields: ["quorum", "threshold"],
+        dateFields: ["startTime", "endTime", "createdAt", "updatedAt", "executedAt", "cancelledAt"],
+      });
+      await restoreRows(prisma.vote, data.votes, {
+        bigIntFields: ["weight"],
+        dateFields: ["timestamp"],
+      });
+      await restoreRows(prisma.proposalExecution, data.executions, {
+        bigIntFields: ["gasUsed"],
+        dateFields: ["executedAt"],
+      });
+      return;
+    }
+    case ProjectionType.STREAM:
+    case ProjectionType.VAULT: {
+      await prisma.stream.deleteMany();
+      await restoreRows(prisma.stream, data.streams, {
+        bigIntFields: ["amount"],
+        dateFields: ["createdAt", "claimedAt", "cancelledAt"],
+      });
+      return;
+    }
+  }
+}
+
+/**
+ * Restores every projection's tables from the complete snapshot set captured
+ * at `ledger`. Destructive: replaces current rows for every table covered by
+ * these projection types. Throws if the snapshot set at `ledger` is
+ * incomplete (missing one or more projection types).
+ *
+ * STREAM and VAULT snapshot the same table (see module docs) — restoring is
+ * only performed once for that table even though both types are present in
+ * the snapshot set.
+ */
+export async function restoreAllProjectionSnapshots(prisma: PrismaClient, ledger: number): Promise<void> {
+  const snapshots = await prisma.projectionSnapshot.findMany({ where: { ledger } });
+  if (snapshots.length !== PROJECTION_TYPES.length) {
+    throw new Error(
+      `Incomplete snapshot set at ledger ${ledger}: found ${snapshots.length}/${PROJECTION_TYPES.length} projection types`,
+    );
+  }
+
+  for (const snapshot of snapshots) {
+    if (snapshot.projectionType === ProjectionType.VAULT) continue; // alias of STREAM — same table, restored once
+    await restoreOne(prisma, snapshot);
+  }
+}

--- a/backend/src/services/projectionSnapshotJob.ts
+++ b/backend/src/services/projectionSnapshotJob.ts
@@ -1,0 +1,31 @@
+/**
+ * Scheduled snapshot-writer job (#1620).
+ *
+ * Captures a fresh cross-projection snapshot at the currently-persisted
+ * event cursor. Wired into `jobQueue` as a recurring job in `index.ts`,
+ * gated by `ENABLE_PROJECTION_SNAPSHOTS` / `PROJECTION_SNAPSHOT_INTERVAL_MS`
+ * the same way `stream_reconciliation` is.
+ */
+
+import { PrismaClient } from '@prisma/client';
+import { EventCursorStore, parseLedgerFromCursor } from './eventCursorStore';
+import { captureAllProjectionSnapshots } from './projectionSnapshot';
+
+export async function runProjectionSnapshotJob(prisma: PrismaClient): Promise<void> {
+  const cursorStore = new EventCursorStore(prisma);
+  const cursor = await cursorStore.load();
+
+  if (!cursor) {
+    console.warn('[ProjectionSnapshotJob] no cursor persisted yet — skipping snapshot capture');
+    return;
+  }
+
+  const ledger = parseLedgerFromCursor(cursor);
+  if (ledger === null) {
+    console.warn(`[ProjectionSnapshotJob] cursor "${cursor}" has no parseable ledger — skipping snapshot capture`);
+    return;
+  }
+
+  await captureAllProjectionSnapshots(prisma, ledger, cursor);
+  console.log(`[ProjectionSnapshotJob] captured snapshot at ledger ${ledger}`);
+}

--- a/backend/src/services/sagaCoordinator.ts
+++ b/backend/src/services/sagaCoordinator.ts
@@ -1,0 +1,218 @@
+/**
+ * Distributed saga coordinator for multi-step, cross-contract operations.
+ *
+ * Some backend-orchestrated operations span multiple independent state
+ * machines (e.g. an on-chain token deploy followed by a governance
+ * registration) with no built-in all-or-nothing guarantee. A failure partway
+ * through can otherwise leave partial state behind with no automated way to
+ * detect or correct it.
+ *
+ * A saga models such an operation as an ordered sequence of steps, each with
+ * a matching compensating (undo) action. Saga state — which step is next,
+ * and the accumulated context produced by completed steps — is persisted to
+ * the `SagaExecution` table after every step transition, so an in-flight
+ * saga survives a process restart: `recoverInterruptedSagas()` resumes a
+ * `RUNNING` saga forward from its last completed step, or continues a
+ * `COMPENSATING` saga's rollback from its last successfully undone step.
+ *
+ * Requirements this implementation is built around:
+ *   - Compensation runs in strict reverse order of completed steps.
+ *   - Compensations MUST be idempotent: the coordinator may re-invoke a
+ *     step's `compensate()` for a step whose undo already completed (the
+ *     narrow crash window between a compensation succeeding and that fact
+ *     being persisted), and that must not double-undo. This is a property
+ *     each step's `compensate()` implementation must provide — e.g. "delete
+ *     if exists" / "delete where id in [...]" rather than a relative
+ *     decrement — the coordinator cannot enforce this for arbitrary step
+ *     logic, only guarantee it will call compensate() at-least-once per
+ *     completed step, in reverse order.
+ *   - Similarly, `execute()` may be re-invoked for the step in progress when
+ *     a crash occurs between a step succeeding and that being persisted, so
+ *     step actions should be safe to retry (standard saga-pattern
+ *     assumption, not enforced by the coordinator).
+ *
+ * Issue: #1621
+ */
+
+import { PrismaClient, SagaStatus, SagaCompensationStatus } from "@prisma/client";
+
+export interface SagaStepDefinition<TContext = Record<string, unknown>> {
+  /** Human-readable step name, used in logs and for debugging persisted state. */
+  name: string;
+  /**
+   * Performs the step's forward action. May return a partial context patch
+   * that is merged into the saga's persisted context for subsequent steps
+   * (and for the eventual compensation pass) to read.
+   */
+  execute(context: TContext): Promise<Partial<TContext> | void>;
+  /**
+   * Undoes this step's forward action. Must be idempotent (safe to call
+   * more than once for the same context) — see module-level docs.
+   */
+  compensate(context: TContext): Promise<void>;
+}
+
+export interface SagaDefinition<TContext = Record<string, unknown>> {
+  /** Unique identifier for this saga definition, persisted as `SagaExecution.sagaType`. */
+  sagaType: string;
+  steps: SagaStepDefinition<TContext>[];
+}
+
+export interface SagaResult<TContext = Record<string, unknown>> {
+  sagaId: string;
+  status: SagaStatus;
+  context: TContext;
+  error?: string;
+}
+
+export class SagaCoordinator {
+  private readonly prisma: PrismaClient;
+  private readonly definitions = new Map<string, SagaDefinition<any>>();
+
+  constructor(prisma: PrismaClient = new PrismaClient()) {
+    this.prisma = prisma;
+  }
+
+  /** Registers a saga definition so it can be run by `run()` and resumed by `recoverInterruptedSagas()`. */
+  registerSaga<TContext>(definition: SagaDefinition<TContext>): void {
+    this.definitions.set(definition.sagaType, definition);
+  }
+
+  private getDefinition(sagaType: string): SagaDefinition<any> {
+    const definition = this.definitions.get(sagaType);
+    if (!definition) {
+      throw new Error(`No saga definition registered for sagaType "${sagaType}"`);
+    }
+    return definition;
+  }
+
+  /** Starts a new saga execution and runs it to completion or compensation. */
+  async run<TContext extends Record<string, unknown>>(
+    sagaType: string,
+    initialContext: TContext,
+  ): Promise<SagaResult<TContext>> {
+    const definition = this.getDefinition(sagaType);
+
+    const saga = await this.prisma.sagaExecution.create({
+      data: {
+        sagaType,
+        stepCount: definition.steps.length,
+        context: initialContext as any,
+        status: SagaStatus.RUNNING,
+        currentStepIndex: 0,
+      },
+    });
+
+    return this.executeFrom(saga.id, definition, initialContext, 0);
+  }
+
+  /** Scans for sagas left `RUNNING` or `COMPENSATING` by a prior process (crash/restart) and resumes them. */
+  async recoverInterruptedSagas(): Promise<void> {
+    const interrupted = await this.prisma.sagaExecution.findMany({
+      where: { status: { in: [SagaStatus.RUNNING, SagaStatus.COMPENSATING] } },
+    });
+
+    for (const saga of interrupted) {
+      const definition = this.definitions.get(saga.sagaType);
+      if (!definition) {
+        console.error(
+          `[SagaCoordinator] cannot recover saga ${saga.id}: no definition registered for sagaType "${saga.sagaType}"`,
+        );
+        continue;
+      }
+
+      console.log(
+        `[SagaCoordinator] recovering saga ${saga.id} (type=${saga.sagaType}, status=${saga.status}, stepIndex=${saga.currentStepIndex})`,
+      );
+
+      try {
+        if (saga.status === SagaStatus.RUNNING) {
+          await this.executeFrom(saga.id, definition, saga.context as any, saga.currentStepIndex);
+        } else {
+          const resumeFrom = saga.compensatedStepIndex ?? saga.currentStepIndex;
+          await this.runCompensation(saga.id, definition, saga.context as any, resumeFrom);
+        }
+      } catch (err) {
+        console.error(`[SagaCoordinator] recovery failed for saga ${saga.id}:`, err);
+      }
+    }
+  }
+
+  /** Executes `definition.steps[fromIndex..]` in order, persisting progress after each step. */
+  private async executeFrom<TContext extends Record<string, unknown>>(
+    sagaId: string,
+    definition: SagaDefinition<TContext>,
+    context: TContext,
+    fromIndex: number,
+  ): Promise<SagaResult<TContext>> {
+    let ctx = context;
+
+    for (let i = fromIndex; i < definition.steps.length; i++) {
+      const step = definition.steps[i];
+      try {
+        const patch = await step.execute(ctx);
+        ctx = { ...ctx, ...(patch ?? {}) };
+
+        await this.prisma.sagaExecution.update({
+          where: { id: sagaId },
+          data: { currentStepIndex: i + 1, context: ctx as any },
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Saga step failed";
+        console.error(`[SagaCoordinator] saga ${sagaId} step "${step.name}" (index ${i}) failed: ${message}`);
+
+        await this.prisma.sagaExecution.update({
+          where: { id: sagaId },
+          data: {
+            status: SagaStatus.COMPENSATING,
+            error: message,
+            context: ctx as any,
+            currentStepIndex: i,
+          },
+        });
+
+        await this.runCompensation(sagaId, definition, ctx, i);
+
+        return { sagaId, status: SagaStatus.COMPENSATED, context: ctx, error: message };
+      }
+    }
+
+    await this.prisma.sagaExecution.update({
+      where: { id: sagaId },
+      data: { status: SagaStatus.COMPLETED, completedAt: new Date(), context: ctx as any },
+    });
+
+    return { sagaId, status: SagaStatus.COMPLETED, context: ctx };
+  }
+
+  /**
+   * Compensates completed steps `[failedIndex - 1 .. 0]` in reverse order.
+   * `failedIndex` is the index of the step that failed (or, on recovery, the
+   * step compensation was already in progress at) — that step's own
+   * `compensate()` is not called, only steps that had actually completed.
+   */
+  private async runCompensation<TContext extends Record<string, unknown>>(
+    sagaId: string,
+    definition: SagaDefinition<TContext>,
+    context: TContext,
+    failedIndex: number,
+  ): Promise<void> {
+    for (let i = failedIndex - 1; i >= 0; i--) {
+      const step = definition.steps[i];
+      await step.compensate(context);
+
+      await this.prisma.sagaExecution.update({
+        where: { id: sagaId },
+        data: { compensationStatus: SagaCompensationStatus.IN_PROGRESS, compensatedStepIndex: i },
+      });
+    }
+
+    await this.prisma.sagaExecution.update({
+      where: { id: sagaId },
+      data: { status: SagaStatus.COMPENSATED, compensationStatus: SagaCompensationStatus.COMPLETED },
+    });
+  }
+}
+
+export const sagaCoordinator = new SagaCoordinator();
+export default sagaCoordinator;

--- a/backend/src/services/sagas/batchDeployGovernanceSaga.ts
+++ b/backend/src/services/sagas/batchDeployGovernanceSaga.ts
@@ -1,0 +1,134 @@
+/**
+ * Batch-deploy-plus-governance-registration saga.
+ *
+ * The first real saga run through `SagaCoordinator` (#1621). Models the
+ * two-step, cross-contract operation that previously had no all-or-nothing
+ * guarantee: deploying a batch of tokens on-chain, then registering each
+ * deployed token for governance participation. A failure in the second step
+ * must not leave a token deployed but permanently unregistered — it must be
+ * compensated (in reverse order) so the whole operation is undone.
+ *
+ * Importing this module registers the saga definition against the shared
+ * `sagaCoordinator` singleton as a side effect (see `backend/src/index.ts`).
+ *
+ * Issue: #1621
+ */
+
+import { PrismaClient } from "@prisma/client";
+import { SagaDefinition, SagaResult } from "../sagaCoordinator";
+import sagaCoordinator from "../sagaCoordinator";
+import { callStellarDeploy, TokenDeployInput } from "../batchTokenDeployService";
+import { eventBus } from "../eventBus";
+
+export const BATCH_DEPLOY_GOVERNANCE_SAGA_TYPE = "batch_deploy_with_governance_registration";
+
+export interface BatchDeployGovernanceContext {
+  inputs: TokenDeployInput[];
+  deployedTokenIds?: string[];
+  deployedAddresses?: string[];
+}
+
+/**
+ * Builds the saga definition. Exported (rather than only registered as a
+ * side effect) so callers/tests can construct one against an injected
+ * Prisma client instead of the module-level default.
+ */
+export function createBatchDeployGovernanceSaga(
+  prismaClient: PrismaClient,
+): SagaDefinition<BatchDeployGovernanceContext> {
+  return {
+    sagaType: BATCH_DEPLOY_GOVERNANCE_SAGA_TYPE,
+    steps: [
+      {
+        name: "deploy_tokens",
+        async execute(context) {
+          // On-chain calls first (mirrors batchTokenDeployService's fail-fast
+          // ordering) — no DB writes happen until every call succeeds.
+          const stellarResults = [];
+          for (const input of context.inputs) {
+            stellarResults.push(await callStellarDeploy(input));
+          }
+
+          const createdTokens = await prismaClient.$transaction(
+            context.inputs.map((input, i) => {
+              const supply = BigInt(input.initialSupply);
+              return prismaClient.token.create({
+                data: {
+                  address: stellarResults[i].address,
+                  creator: input.creator,
+                  name: input.name,
+                  symbol: input.symbol,
+                  decimals: input.decimals,
+                  totalSupply: supply,
+                  initialSupply: supply,
+                  totalBurned: BigInt(0),
+                  burnCount: 0,
+                  metadataUri: input.metadataUri ?? null,
+                },
+              });
+            }),
+          );
+
+          for (const token of createdTokens) {
+            // Fire-and-forget: event failures must not roll back a successful step.
+            eventBus
+              .publish("token.deployed", {
+                tokenId: token.id,
+                address: token.address,
+                creator: token.creator,
+                name: token.name,
+                symbol: token.symbol,
+                decimals: token.decimals,
+                initialSupply: token.initialSupply.toString(),
+                metadataUri: token.metadataUri,
+              })
+              .catch((err) => console.error("[batchDeployGovernanceSaga] event emission failed:", err));
+          }
+
+          return {
+            deployedTokenIds: createdTokens.map((t) => t.id),
+            deployedAddresses: createdTokens.map((t) => t.address),
+          } satisfies Partial<BatchDeployGovernanceContext>;
+        },
+        async compensate(context) {
+          const tokenIds = context.deployedTokenIds ?? [];
+          if (tokenIds.length === 0) return;
+          // Idempotent: deleting an already-deleted (or never-created) id set is a no-op.
+          await prismaClient.token.deleteMany({ where: { id: { in: tokenIds } } });
+        },
+      },
+      {
+        name: "register_governance",
+        async execute(context) {
+          const tokenIds = context.deployedTokenIds ?? [];
+          await prismaClient.$transaction(
+            tokenIds.map((tokenId) =>
+              prismaClient.tokenGovernanceRegistration.upsert({
+                where: { tokenId },
+                create: { tokenId },
+                update: {},
+              }),
+            ),
+          );
+        },
+        async compensate(context) {
+          const tokenIds = context.deployedTokenIds ?? [];
+          if (tokenIds.length === 0) return;
+          // Idempotent: deleteMany over an already-undone set is a no-op.
+          await prismaClient.tokenGovernanceRegistration.deleteMany({
+            where: { tokenId: { in: tokenIds } },
+          });
+        },
+      },
+    ],
+  };
+}
+
+sagaCoordinator.registerSaga(createBatchDeployGovernanceSaga(new PrismaClient()));
+
+/** Runs the batch-deploy-plus-governance-registration saga for the given token inputs. */
+export async function deployTokensWithGovernanceRegistration(
+  inputs: TokenDeployInput[],
+): Promise<SagaResult<BatchDeployGovernanceContext>> {
+  return sagaCoordinator.run(BATCH_DEPLOY_GOVERNANCE_SAGA_TYPE, { inputs });
+}

--- a/backend/src/services/stellarEventListener.ts
+++ b/backend/src/services/stellarEventListener.ts
@@ -1,6 +1,10 @@
 import axios from "axios";
-import { Gauge } from "prom-client";
+import { randomUUID } from "crypto";
+import { hostname } from "os";
+import { Gauge, register } from "prom-client";
 import { validateEnv } from "../config/env";
+import { LeaderElection, LEADER_LOCK_TTL_MS, LEADER_RENEW_INTERVAL_MS } from "../lib/leaderElection";
+import { getRedis } from "../lib/redis";
 import { WebhookEventType } from "../types/webhook";
 import webhookDeliveryService from "./webhookDeliveryService";
 import { PrismaClient } from "@prisma/client";
@@ -105,6 +109,15 @@ export class StellarEventListener {
   private alertDebounceMs = 5000;
   private transport: HorizonTransport;
 
+  /**
+   * Distributed leader election — only the elected leader may run the
+   * ingestion loop and advance the event cursor. Standby instances keep
+   * this heartbeat running (hot) but never call `pollEvents()` while idle.
+   */
+  private leaderElection: LeaderElection;
+  private electionStarted = false;
+  private fencingToken: number | null = null;
+
   constructor(transport?: HorizonTransport) {
     this.prisma = new PrismaClient();
     this.governanceParser = new GovernanceEventParser(this.prisma);
@@ -112,6 +125,22 @@ export class StellarEventListener {
     this.cursorStore = new EventCursorStore(this.prisma);
     this.streamEventParser = new StreamEventParser(this.prisma);
     this.transport = transport || new DefaultHorizonTransport();
+    this.leaderElection = new LeaderElection({
+      redis: getRedis(),
+      role: "stellar_event_listener",
+      instanceId: `${hostname()}:${process.pid}:${randomUUID()}`,
+      ttlMs: LEADER_LOCK_TTL_MS,
+      renewIntervalMs: LEADER_RENEW_INTERVAL_MS,
+      events: {
+        onBecameLeader: (token) => this.onBecameLeader(token),
+        onLostLeadership: (reason) => this.onLostLeadership(reason),
+      },
+    });
+  }
+
+  /** Test/tooling hook: allows injecting a LeaderElection instance without going through the constructor's Redis wiring. */
+  setLeaderElection(leaderElection: LeaderElection): void {
+    this.leaderElection = leaderElection;
   }
 
   setTransport(transport: HorizonTransport): void {
@@ -119,11 +148,14 @@ export class StellarEventListener {
   }
 
   /**
-   * Start listening for Stellar events
+   * Start contending for leadership. The ingestion loop only begins once
+   * this instance is actually elected leader (see `onBecameLeader`) — an
+   * instance that never wins the election stays hot (heartbeating) but
+   * idle, exactly like every other standby.
    */
   async start(): Promise<void> {
-    if (this.isRunning) {
-      console.warn("Event listener is already running");
+    if (this.electionStarted) {
+      console.warn("Event listener election already started");
       return;
     }
 
@@ -142,25 +174,57 @@ export class StellarEventListener {
       );
     }
 
+    this.electionStarted = true;
+    console.log("[StellarEventListener] starting leader election heartbeat...");
+    await this.leaderElection.start();
+  }
+
+  /**
+   * Called by the LeaderElection heartbeat when this instance wins (or
+   * regains) leadership. Loads the durable cursor and starts ingestion.
+   */
+  private async onBecameLeader(fencingToken: number): Promise<void> {
+    this.fencingToken = fencingToken;
+
+    if (this.isRunning) {
+      // Already ingesting (e.g. a renewal that the script reported as a
+      // fresh acquisition due to a prior lease expiry/regrant) — nothing to restart.
+      return;
+    }
+
     // Load durable cursor before starting — resumes from last processed event
     this.lastCursor = await this.cursorStore.load();
-    console.log(`Resuming from cursor: ${this.lastCursor ?? "origin"}`);
+    console.log(`[StellarEventListener] became leader (fencingToken=${fencingToken}), resuming from cursor: ${this.lastCursor ?? "origin"}`);
 
     // If cursor is too far behind the live ledger, drop it and do a full catchup
     await this.applyCatchupPolicyIfNeeded();
 
     this.isRunning = true;
-    console.log("Starting Stellar event listener...");
 
     // Start polling loop
     this.pollEvents();
   }
 
   /**
-   * Stop listening for events
+   * Called by the LeaderElection heartbeat when this instance loses (or
+   * never had) leadership. Halts ingestion — the instance remains hot,
+   * still heartbeating and ready to resume if it wins a future election.
    */
-  stop(): void {
+  private onLostLeadership(reason: string): void {
+    if (this.isRunning) {
+      console.warn(`[StellarEventListener] lost leadership (${reason}) — halting ingestion`);
+    }
     this.isRunning = false;
+    this.fencingToken = null;
+  }
+
+  /**
+   * Stop listening for events and release leadership (if held).
+   */
+  async stop(): Promise<void> {
+    this.isRunning = false;
+    this.electionStarted = false;
+    await this.leaderElection.stop();
     console.log("Stopping Stellar event listener...");
   }
 
@@ -239,6 +303,20 @@ export class StellarEventListener {
       console.log(`Processing ${events.length} new events`);
 
       for (const event of events) {
+        // Every cursor write is gated on the fencing token still being
+        // current. If a new leader has since been elected (this instance
+        // was demoted but hasn't noticed — clock skew, slow GC, delayed
+        // partition detection), the token check fails and we must not
+        // advance the cursor with stale/duplicate progress.
+        if (this.fencingToken === null || !(await this.leaderElection.validateFencingToken(this.fencingToken))) {
+          console.error(
+            "[StellarEventListener] fencing-token rejected — refusing stale cursor write, halting ingestion",
+          );
+          this.isRunning = false;
+          this.fencingToken = null;
+          return;
+        }
+
         await this.processEvent(event);
         this.lastCursor = event.paging_token;
         await this.cursorStore.save(this.lastCursor);

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -6,10 +6,12 @@ VITE_FACTORY_CONTRACT_ID=
 VITE_NETWORK=testnet
 
 # Backend API Configuration
-VITE_API_BASE_URL=http://localhost:3000/api
-VITE_TOKEN_INFO_API_URL=http://localhost:3000/api/token-info
-VITE_LEADERBOARD_API_URL=http://localhost:3000/api/leaderboard
-VITE_GOVERNANCE_API_URL=http://localhost:3000/api/governance
+# Must point at the API gateway (see gateway/.env.example GATEWAY_PORT), not
+# directly at the backend — the gateway owns auth, CORS, and rate limiting.
+VITE_API_BASE_URL=http://localhost:4000/api
+VITE_TOKEN_INFO_API_URL=http://localhost:4000/api/token-info
+VITE_LEADERBOARD_API_URL=http://localhost:4000/api/leaderboard
+VITE_GOVERNANCE_API_URL=http://localhost:4000/api/governance
 
 # IPFS Configuration (optional for token metadata)
 VITE_IPFS_API_KEY=

--- a/scripts/check-config-parity.ts
+++ b/scripts/check-config-parity.ts
@@ -1,0 +1,193 @@
+/**
+ * Cross-service config parity check.
+ *
+ * Backend, gateway, and frontend each declare their own `.env.example`, but
+ * nothing verifies they agree on the values that must be consistent across
+ * services (shared Redis instance, CORS origin, proxy target ports, Stellar
+ * network) to avoid silent misconfiguration in a deployed environment.
+ *
+ * Usage:
+ *   npx tsx scripts/check-config-parity.ts
+ *
+ * Issue: #1618
+ */
+
+import { readFileSync } from "fs";
+import { join } from "path";
+
+export type EnvMap = Record<string, string>;
+
+export interface ParityMismatch {
+  rule: string;
+  message: string;
+}
+
+export interface ServiceEnvs {
+  backend: EnvMap;
+  gateway: EnvMap;
+  frontend: EnvMap;
+}
+
+/** Parses a `.env.example`-style file (KEY=VALUE per line, `#` comments, blank lines ignored). */
+export function parseEnvExample(contents: string): EnvMap {
+  const env: EnvMap = {};
+  for (const rawLine of contents.split("\n")) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq === -1) continue;
+    const key = line.slice(0, eq).trim();
+    const value = line.slice(eq + 1).trim();
+    if (key) env[key] = value;
+  }
+  return env;
+}
+
+export function loadServiceEnv(absolutePath: string): EnvMap {
+  return parseEnvExample(readFileSync(absolutePath, "utf-8"));
+}
+
+function hostPort(url: string): string {
+  try {
+    const parsed = new URL(url);
+    return `${parsed.hostname}:${parsed.port || (parsed.protocol === "https:" ? "443" : "80")}`;
+  } catch {
+    return url;
+  }
+}
+
+type Rule = (envs: ServiceEnvs) => ParityMismatch | null;
+
+const RULES: Rule[] = [
+  // Backend and gateway must talk to the same Redis instance — rate limiting,
+  // idempotency keys, and leader-election locks share keyspaces there and
+  // silently diverge if the two services point at different instances.
+  ({ backend, gateway }) => {
+    if (backend.REDIS_URL !== gateway.REDIS_URL) {
+      return {
+        rule: "redis_url",
+        message:
+          `backend.REDIS_URL (${backend.REDIS_URL}) !== gateway.REDIS_URL (${gateway.REDIS_URL}). ` +
+          `Both services must point at the same Redis instance.`,
+      };
+    }
+    return null;
+  },
+
+  // The gateway's CORS allowlist must include the origin the backend expects
+  // the frontend to be served from, or browser requests proxied through the
+  // gateway get rejected.
+  ({ backend, gateway }) => {
+    const allowed = (gateway.ALLOWED_ORIGINS ?? "")
+      .split(",")
+      .map((o) => o.trim())
+      .filter(Boolean);
+    if (backend.FRONTEND_URL && !allowed.includes(backend.FRONTEND_URL)) {
+      return {
+        rule: "frontend_origin",
+        message:
+          `backend.FRONTEND_URL (${backend.FRONTEND_URL}) is not present in ` +
+          `gateway.ALLOWED_ORIGINS (${allowed.join(", ") || "<empty>"}).`,
+      };
+    }
+    return null;
+  },
+
+  // The gateway's upstream BACKEND_URL must actually point at the port the
+  // backend listens on, or the proxy silently talks to nothing.
+  ({ backend, gateway }) => {
+    const backendPort = backend.PORT ?? "3001";
+    const expected = `localhost:${backendPort}`;
+    const actual = hostPort(gateway.BACKEND_URL ?? "");
+    if (actual !== expected) {
+      return {
+        rule: "gateway_backend_url",
+        message:
+          `gateway.BACKEND_URL (${gateway.BACKEND_URL}) resolves to "${actual}", ` +
+          `but backend.PORT is ${backendPort} (expected "${expected}").`,
+      };
+    }
+    return null;
+  },
+
+  // The frontend must call the API through the gateway (which owns auth,
+  // CORS, and rate limiting) rather than a hard-coded, possibly stale port.
+  ({ gateway, frontend }) => {
+    const gatewayPort = gateway.GATEWAY_PORT ?? "4000";
+    const expected = `localhost:${gatewayPort}`;
+    const apiVars = [
+      "VITE_API_BASE_URL",
+      "VITE_TOKEN_INFO_API_URL",
+      "VITE_LEADERBOARD_API_URL",
+      "VITE_GOVERNANCE_API_URL",
+    ];
+    for (const key of apiVars) {
+      const value = frontend[key];
+      if (!value) continue;
+      const actual = hostPort(value);
+      if (actual !== expected) {
+        return {
+          rule: "frontend_api_base_url",
+          message:
+            `frontend.${key} (${value}) resolves to "${actual}", but gateway.GATEWAY_PORT is ` +
+            `${gatewayPort} (expected "${expected}"). The frontend must call the API through the gateway.`,
+        };
+      }
+    }
+    return null;
+  },
+
+  // Frontend and backend must agree on which Stellar network they target —
+  // a mismatch means the UI silently renders against the wrong ledger.
+  ({ backend, frontend }) => {
+    if (
+      backend.STELLAR_NETWORK &&
+      frontend.VITE_NETWORK &&
+      backend.STELLAR_NETWORK !== frontend.VITE_NETWORK
+    ) {
+      return {
+        rule: "stellar_network",
+        message:
+          `backend.STELLAR_NETWORK (${backend.STELLAR_NETWORK}) !== frontend.VITE_NETWORK ` +
+          `(${frontend.VITE_NETWORK}).`,
+      };
+    }
+    return null;
+  },
+];
+
+export function checkParity(envs: ServiceEnvs): ParityMismatch[] {
+  const mismatches: ParityMismatch[] = [];
+  for (const rule of RULES) {
+    const result = rule(envs);
+    if (result) mismatches.push(result);
+  }
+  return mismatches;
+}
+
+function main(): void {
+  const repoRoot = join(__dirname, "..");
+  const envs: ServiceEnvs = {
+    backend: loadServiceEnv(join(repoRoot, "backend", ".env.example")),
+    gateway: loadServiceEnv(join(repoRoot, "gateway", ".env.example")),
+    frontend: loadServiceEnv(join(repoRoot, "frontend", ".env.example")),
+  };
+
+  const mismatches = checkParity(envs);
+
+  if (mismatches.length === 0) {
+    console.log("Cross-service config parity check passed — all shared variables agree.");
+    return;
+  }
+
+  console.error(`Cross-service config parity check failed — ${mismatches.length} mismatch(es):\n`);
+  for (const mismatch of mismatches) {
+    console.error(`  [${mismatch.rule}] ${mismatch.message}`);
+  }
+  console.error("\nFix the .env.example values above so all services agree, then re-run this check.");
+  process.exitCode = 1;
+}
+
+if (require.main === module) {
+  main();
+}


### PR DESCRIPTION
## Summary

Four backend resilience/consistency features, implemented as one batch on a single branch per request:

### Cross-service config parity check (#1618)
- `scripts/check-config-parity.ts`: loads `backend/.env.example`, `gateway/.env.example`, `frontend/.env.example` and checks shared values agree — Redis URL (backend/gateway), CORS origin (backend `FRONTEND_URL` vs gateway `ALLOWED_ORIGINS`), gateway's upstream `BACKEND_URL` vs backend `PORT`, frontend API URLs vs gateway `GATEWAY_PORT`, and `STELLAR_NETWORK` vs `VITE_NETWORK`.
- Running it against current config surfaced a real latent bug: `frontend/.env.example`'s API URLs pointed at port 3000 (a stale/direct-to-backend value) instead of the gateway's port 4000 — the gateway is the actual frontend-facing entry point (auth, CORS, rate limiting, proxy). Fixed `frontend/.env.example` accordingly.
- Wired into `.github/workflows/backend-ci.yml` as a CI step.
- Tests: `backend/src/__tests__/checkConfigParity.test.ts`.

### Leader-election-based HA event listener (#1619)
- `backend/src/lib/leaderElection.ts`: Redis `SET NX PX` lease (renewable heartbeat) + a monotonically increasing fencing token stored in a separate non-expiring key, incremented only on genuinely new elections (not renewals). Atomic acquire/renew and fencing-token validation via Lua scripts, following the existing `lib/lock.ts` CAS pattern. Bounded failover window documented as `ttlMs + renewIntervalMs` (13s with defaults). Structured JSON logs + Prometheus counter for `became-leader` / `lost-leadership` / `fencing-token-rejected`.
- `stellarEventListener.ts`: the ingestion loop now only runs while this instance holds leadership; standbys heartbeat but stay idle. Every cursor write is gated on `validateFencingToken` so a demoted former leader can't advance the cursor after a new election, even if it hasn't yet noticed it lost the lease.
- Also fixed a pre-existing bug in this file: `cursorLagGauge`'s `registers: [register]` referenced an undefined `register` (missing import) — corrected the `prom-client` import.
- Updated `stellarEventListener.test.ts`'s `beforeEach` to stub leader election (grants leadership immediately, no real Redis) so the existing suite keeps passing under the new leadership-gated `start()`.

### Distributed saga coordinator (#1621)
- `backend/src/services/sagaCoordinator.ts`: generic `SagaCoordinator` with a `SagaExecution` Prisma model persisting step index, accumulated context, and compensation progress. Compensates completed steps in strict reverse order; relies on (and documents) step-level idempotency so a compensation re-run after a partial compensation can't double-undo. `recoverInterruptedSagas()` resumes `RUNNING` sagas forward or continues `COMPENSATING` sagas from the last confirmed-undone step.
- `backend/src/services/sagas/batchDeployGovernanceSaga.ts`: the first real saga — batch token deploy + governance registration as two compensable steps (`deploy_tokens`, `register_governance`), backed by a new `TokenGovernanceRegistration` model.
- Recovery job wired into `index.ts` at startup (`sagaCoordinator.recoverInterruptedSagas()`).

### Cross-projection snapshot & point-in-time replay engine (#1620)
- `backend/src/services/projectionSnapshot.ts`: `ProjectionSnapshot` model capturing campaign/governance/stream/vault projection state at a given ledger, versioned via `formatVersion`. BigInt/Date fields serialize to JSON-safe, byte-comparable form; note `stream` and `vault` snapshot the same underlying `Stream` table in this codebase (documented in-code) — restore only writes it once.
- `eventReplayService.ts`: new `replayFromLedger(targetLedger)` resumes from the nearest complete snapshot set instead of always replaying from ledger zero, falling back to full replay when no usable snapshot exists.
- `backend/src/services/projectionConsistencyCheck.ts`: `verifyProjectionSnapshotConsistency` runs both replay strategies and byte-compares the resulting projection state per type (destructive — intended for a disposable DB/ops tooling).
- `backend/src/services/projectionSnapshotJob.ts`: scheduled snapshot capture at the current cursor, wired into `jobQueue` in `index.ts` (gated by `ENABLE_PROJECTION_SNAPSHOTS` / `PROJECTION_SNAPSHOT_INTERVAL_MS`, mirroring the existing `stream_reconciliation` job pattern).

Closes #1618
Closes #1619
Closes #1621
Closes #1620

## Test plan
- [ ] `npx tsx scripts/check-config-parity.ts` passes on current config
- [ ] `npx vitest run` for the backend test suite (including the updated `stellarEventListener.test.ts` and new `checkConfigParity.test.ts`)
- [ ] `npx prisma generate && npx prisma migrate deploy` picks up the new `SagaExecution`, `TokenGovernanceRegistration`, and `ProjectionSnapshot` models/migrations cleanly
- [ ] `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)