### PR TITLE
Gas-bounded batch scheduler, zero-downtime migrations, cross-contract settlement, and invariant fuzzing

### DIFF
--- a/.github/workflows/fuzz-testing.yml
+++ b/.github/workflows/fuzz-testing.yml
@@ -100,6 +100,57 @@ jobs:
         echo "" >> $GITHUB_STEP_SUMMARY
         cargo test --release 2>&1 | tail -20 >> $GITHUB_STEP_SUMMARY
 
+  cross-contract-invariant-fuzz:
+    name: Cross-Contract Invariant Fuzz (token-factory <-> governance) (#1623)
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v7
+
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        target: wasm32-unknown-unknown
+        override: true
+
+    - name: Cache cargo registry
+      uses: actions/cache@v6
+      with:
+        path: ~/.cargo/registry
+        key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+
+    - name: Cache cargo build
+      uses: actions/cache@v6
+      with:
+        path: contracts/target
+        key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+
+    - name: Install cargo-fuzz
+      run: cargo install cargo-fuzz --locked || true
+
+    - name: Build governance.wasm (contractimport! dependency of the fuzz target)
+      working-directory: contracts
+      run: cargo build -p governance --release --target wasm32-unknown-unknown
+
+    - name: Run cross-contract invariant fuzz target
+      id: cross-contract-fuzz
+      working-directory: contracts/token-factory/fuzz
+      run: |
+        cargo fuzz run cross_contract_invariants -- -max_total_time=120 2>&1 | tee cross-contract-fuzz-results.txt
+        echo "## Cross-Contract Invariant Fuzz Results" >> $GITHUB_STEP_SUMMARY
+        tail -30 cross-contract-fuzz-results.txt >> $GITHUB_STEP_SUMMARY
+
+    - name: Upload crash artifacts on failure
+      if: failure() && steps.cross-contract-fuzz.outcome == 'failure'
+      uses: actions/upload-artifact@v7
+      with:
+        name: cross-contract-invariant-fuzz-failure-${{ github.run_number }}
+        path: |
+          contracts/token-factory/fuzz/cross-contract-fuzz-results.txt
+          contracts/token-factory/fuzz/artifacts/cross_contract_invariants/
+        retention-days: 30
+
   campaign-stateful-fuzz-nightly:
     name: Campaign Stateful Fuzz (Nightly High Depth)
     runs-on: ubuntu-latest

--- a/backend/src/services/migrationOrchestrator.ts
+++ b/backend/src/services/migrationOrchestrator.ts
@@ -1,0 +1,576 @@
+import type { PrismaClient, Prisma } from "@prisma/client";
+
+/**
+ * Zero-downtime live schema migration framework. (#1622)
+ *
+ * Coordinates a dual-write / backfill / verify / cutover / cleanup lifecycle
+ * for moving a live table to a new schema shape without blocking writers or
+ * losing writes issued during the transition:
+ *
+ * 1. `startDualWrite` creates the shadow table and installs a Prisma
+ *    middleware that transparently mirrors every write issued through the
+ *    existing Prisma client to the shadow table too — callers do not need to
+ *    change anything.
+ * 2. `runBackfill` copies pre-existing rows into the shadow table in
+ *    batches, without clobbering rows a concurrent dual-write already wrote.
+ * 3. `verifyParity` compares *every* row (not a sample) between the old and
+ *    shadow tables and returns a pass/fail report.
+ * 4. `cutover` — only allowed once `verifyParity` has passed — atomically
+ *    repoints a read view at the shadow table with a single `CREATE OR
+ *    REPLACE VIEW` statement. No data is copied at cutover time.
+ * 5. `recordPostCutoverOutcome` lets callers report post-cutover read/write
+ *    success or failure; if the rolling error rate crosses
+ *    `errorRateThreshold`, the orchestrator automatically rolls the view
+ *    back to the old table.
+ * 6. `cleanup` drops the old table once the migration has been confirmed
+ *    stable (`completed`), and removes the dual-write middleware.
+ */
+
+export type MigrationPhase =
+  | "idle"
+  | "dual_write"
+  | "backfilling"
+  | "verifying"
+  | "verified"
+  | "cutover"
+  | "monitoring"
+  | "completed"
+  | "rolled_back";
+
+export interface MigrationConfig {
+  /** Prisma model name being migrated (as used in `params.model`), e.g. "HolderSnapshot". */
+  modelName: string;
+  /** Live table name in Postgres, e.g. "HolderSnapshot". */
+  tableName: string;
+  /** New-schema-shape shadow table name, e.g. "HolderSnapshot_shadow". */
+  shadowTableName: string;
+  /** Read view callers should query through; cutover atomically repoints this. */
+  viewName: string;
+  /** Primary key column, e.g. "id". */
+  primaryKeyColumn: string;
+  /**
+   * Non-generated columns to compare/copy. Must be identical between the old
+   * table and the shadow table (this framework migrates a table's storage
+   * shape/backing, not its logical column set).
+   */
+  columns: string[];
+  /**
+   * Custom `CREATE TABLE` statement for the shadow table, for migrations
+   * that actually change the schema shape (renamed/retyped/split columns).
+   * Defaults to `CREATE TABLE IF NOT EXISTS <shadow> (LIKE <table> INCLUDING ALL)`,
+   * which is only correct when the shadow table's shape is identical to the
+   * old table (e.g. a storage/indexing-strategy migration).
+   */
+  createShadowTableSql?: string;
+  /** Rows copied per backfill batch. Default 1000. */
+  batchSize?: number;
+  /** Fraction (0-1) of post-cutover failures that triggers auto-rollback. Default 0.05. */
+  errorRateThreshold?: number;
+  /** Rolling window (ms) the error rate is evaluated over. Default 60_000. */
+  errorRateWindowMs?: number;
+  /** Minimum sample count within the window before the error rate is trusted. Default 20. */
+  minSamplesForRollback?: number;
+}
+
+export interface RowMismatch {
+  primaryKey: string;
+  column: string;
+  oldValue: unknown;
+  shadowValue: unknown;
+}
+
+export interface ParityReport {
+  totalOldRows: number;
+  totalShadowRows: number;
+  missingInShadow: number;
+  missingInOld: number;
+  mismatchedRows: number;
+  /** Capped sample of individual mismatches for diagnostics; counts above are exhaustive. */
+  mismatches: RowMismatch[];
+  passed: boolean;
+  checkedAt: Date;
+}
+
+export interface MigrationState {
+  phase: MigrationPhase;
+  dualWriteStartedAt?: Date;
+  backfillCompletedAt?: Date;
+  lastParityReport?: ParityReport;
+  cutoverAt?: Date;
+  rolledBackAt?: Date;
+  rollbackReason?: string;
+  completedAt?: Date;
+}
+
+const IDENTIFIER_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+function assertSafeIdentifier(name: string, kind: string): void {
+  if (!IDENTIFIER_RE.test(name)) {
+    throw new Error(
+      `MigrationOrchestrator: unsafe ${kind} identifier "${name}" — must match ${IDENTIFIER_RE}`,
+    );
+  }
+}
+
+function quoteIdent(name: string): string {
+  return `"${name}"`;
+}
+
+export class MigrationOrchestrator {
+  private readonly prisma: PrismaClient;
+  private readonly config: Required<MigrationConfig>;
+  private state: MigrationState = { phase: "idle" };
+  private middlewareInstalled = false;
+  private outcomes: Array<{ at: number; success: boolean }> = [];
+
+  constructor(prisma: PrismaClient, config: MigrationConfig) {
+    assertSafeIdentifier(config.tableName, "tableName");
+    assertSafeIdentifier(config.shadowTableName, "shadowTableName");
+    assertSafeIdentifier(config.viewName, "viewName");
+    assertSafeIdentifier(config.primaryKeyColumn, "primaryKeyColumn");
+    for (const col of config.columns) {
+      assertSafeIdentifier(col, "column");
+    }
+
+    this.prisma = prisma;
+    this.config = {
+      createShadowTableSql: `CREATE TABLE IF NOT EXISTS ${quoteIdent(config.shadowTableName)} (LIKE ${quoteIdent(config.tableName)} INCLUDING ALL)`,
+      batchSize: 1000,
+      errorRateThreshold: 0.05,
+      errorRateWindowMs: 60_000,
+      minSamplesForRollback: 20,
+      ...config,
+    };
+  }
+
+  getState(): Readonly<MigrationState> {
+    return this.state;
+  }
+
+  private requirePhase(...allowed: MigrationPhase[]): void {
+    if (!allowed.includes(this.state.phase)) {
+      throw new Error(
+        `MigrationOrchestrator: cannot perform this action in phase "${this.state.phase}" (expected one of: ${allowed.join(", ")})`,
+      );
+    }
+  }
+
+  // ── Phase 1: dual-write ────────────────────────────────────────────────
+
+  /**
+   * Creates the shadow table (same structure as the live table) if it
+   * doesn't exist, points the read view at the old table (so existing
+   * readers are unaffected), and installs Prisma middleware that mirrors
+   * every write to `modelName` onto the shadow table too.
+   */
+  async startDualWrite(): Promise<void> {
+    this.requirePhase("idle");
+
+    const table = quoteIdent(this.config.tableName);
+    const view = quoteIdent(this.config.viewName);
+
+    await this.prisma.$executeRawUnsafe(this.config.createShadowTableSql);
+    await this.prisma.$executeRawUnsafe(
+      `CREATE OR REPLACE VIEW ${view} AS SELECT * FROM ${table}`,
+    );
+
+    this.installDualWriteMiddleware();
+
+    this.state = {
+      ...this.state,
+      phase: "dual_write",
+      dualWriteStartedAt: new Date(),
+    };
+  }
+
+  private installDualWriteMiddleware(): void {
+    if (this.middlewareInstalled) return;
+
+    const middleware: Prisma.Middleware = async (params, next) => {
+      const result = await next(params);
+
+      const mirroring: MigrationPhase[] = [
+        "dual_write",
+        "backfilling",
+        "verifying",
+        "verified",
+      ];
+      if (params.model !== this.config.modelName || !mirroring.includes(this.state.phase)) {
+        return result;
+      }
+
+      try {
+        await this.mirrorWrite(params.action, params.args, result);
+      } catch (err) {
+        // Dual-write mirroring must never break the primary write path —
+        // the primary table is always the source of truth until cutover.
+        console.error("MigrationOrchestrator: dual-write mirror failed", err);
+      }
+
+      return result;
+    };
+
+    this.prisma.$use(middleware);
+    this.middlewareInstalled = true;
+  }
+
+  private async mirrorWrite(action: string, args: any, result: any): Promise<void> {
+    switch (action) {
+      case "create":
+      case "update":
+      case "upsert":
+        if (result) await this.upsertShadowRow(result);
+        return;
+      case "delete":
+        if (result) await this.deleteShadowRow(result[this.config.primaryKeyColumn]);
+        return;
+      case "createMany":
+        if (Array.isArray(result) ? result.length : true) {
+          // createMany doesn't return created rows; re-read by the data's
+          // natural keys isn't generically possible, so re-read via the
+          // batch's primary keys when the caller supplied them.
+          const rows: any[] = Array.isArray(args?.data) ? args.data : [];
+          for (const row of rows) {
+            if (row[this.config.primaryKeyColumn] !== undefined) {
+              await this.copyRowFromOldToShadow(row[this.config.primaryKeyColumn]);
+            }
+          }
+        }
+        return;
+      case "updateMany": {
+        const affected = await this.findAffectedPrimaryKeys(args?.where);
+        for (const pk of affected) {
+          await this.copyRowFromOldToShadow(pk);
+        }
+        return;
+      }
+      case "deleteMany": {
+        // Rows are already gone from the old table by the time we get here,
+        // so mirror the same predicate directly against the shadow table.
+        await this.deleteManyShadowByOldPredicate(args?.where);
+        return;
+      }
+      default:
+        return;
+    }
+  }
+
+  private async upsertShadowRow(row: Record<string, unknown>): Promise<void> {
+    const cols = [this.config.primaryKeyColumn, ...this.config.columns.filter(c => c !== this.config.primaryKeyColumn)];
+    const shadow = quoteIdent(this.config.shadowTableName);
+    const pk = quoteIdent(this.config.primaryKeyColumn);
+
+    const values = cols.map(c => row[c] ?? null);
+    const placeholders = cols.map((_, i) => `$${i + 1}`).join(", ");
+    const colList = cols.map(quoteIdent).join(", ");
+    const updateSet = cols
+      .filter(c => c !== this.config.primaryKeyColumn)
+      .map(c => `${quoteIdent(c)} = EXCLUDED.${quoteIdent(c)}`)
+      .join(", ");
+
+    await this.prisma.$executeRawUnsafe(
+      `INSERT INTO ${shadow} (${colList}) VALUES (${placeholders})
+       ON CONFLICT (${pk}) DO UPDATE SET ${updateSet}`,
+      ...values,
+    );
+  }
+
+  private async deleteShadowRow(primaryKey: unknown): Promise<void> {
+    const shadow = quoteIdent(this.config.shadowTableName);
+    const pk = quoteIdent(this.config.primaryKeyColumn);
+    await this.prisma.$executeRawUnsafe(`DELETE FROM ${shadow} WHERE ${pk} = $1`, primaryKey);
+  }
+
+  private async copyRowFromOldToShadow(primaryKey: unknown): Promise<void> {
+    const table = quoteIdent(this.config.tableName);
+    const pk = quoteIdent(this.config.primaryKeyColumn);
+    const rows = await this.prisma.$queryRawUnsafe<Array<Record<string, unknown>>>(
+      `SELECT * FROM ${table} WHERE ${pk} = $1`,
+      primaryKey,
+    );
+    if (rows[0]) {
+      await this.upsertShadowRow(rows[0]);
+    } else {
+      await this.deleteShadowRow(primaryKey);
+    }
+  }
+
+  private async findAffectedPrimaryKeys(where: unknown): Promise<unknown[]> {
+    // Best-effort: re-read the current state of the old table restricted to
+    // the primary keys the update touched, using Prisma's own query builder
+    // (not raw SQL) so arbitrary `where` shapes are supported safely.
+    const model = (this.prisma as any)[this.lowerFirst(this.config.modelName)];
+    if (!model) return [];
+    const rows: Array<Record<string, unknown>> = await model.findMany({
+      where,
+      select: { [this.config.primaryKeyColumn]: true },
+    });
+    return rows.map(r => r[this.config.primaryKeyColumn]);
+  }
+
+  private async deleteManyShadowByOldPredicate(where: unknown): Promise<void> {
+    // deleteMany already removed the rows from the old table, so we can no
+    // longer resolve `where` against it. Instead, delete from the shadow
+    // table anything that is no longer present in the old table.
+    const table = quoteIdent(this.config.tableName);
+    const shadow = quoteIdent(this.config.shadowTableName);
+    const pk = quoteIdent(this.config.primaryKeyColumn);
+    void where;
+    await this.prisma.$executeRawUnsafe(
+      `DELETE FROM ${shadow} s WHERE NOT EXISTS (SELECT 1 FROM ${table} o WHERE o.${pk} = s.${pk})`,
+    );
+  }
+
+  private lowerFirst(s: string): string {
+    return s.charAt(0).toLowerCase() + s.slice(1);
+  }
+
+  // ── Phase 2: backfill ─────────────────────────────────────────────────
+
+  /**
+   * Copies rows from the old table into the shadow table in batches,
+   * ordered by primary key. Uses `ON CONFLICT DO NOTHING` so a row already
+   * written by a concurrent dual-write (which reflects a newer state) is
+   * never clobbered by a stale backfilled snapshot.
+   */
+  async runBackfill(): Promise<{ rowsCopied: number }> {
+    this.requirePhase("dual_write");
+    this.state = { ...this.state, phase: "backfilling" };
+
+    const table = quoteIdent(this.config.tableName);
+    const shadow = quoteIdent(this.config.shadowTableName);
+    const pk = quoteIdent(this.config.primaryKeyColumn);
+    const colList = [this.config.primaryKeyColumn, ...this.config.columns.filter(c => c !== this.config.primaryKeyColumn)]
+      .map(quoteIdent)
+      .join(", ");
+
+    let cursor: unknown = null;
+    let rowsCopied = 0;
+
+    for (;;) {
+      const batch = cursor === null
+        ? await this.prisma.$queryRawUnsafe<Array<Record<string, unknown>>>(
+            `SELECT * FROM ${table} ORDER BY ${pk} ASC LIMIT $1`,
+            this.config.batchSize,
+          )
+        : await this.prisma.$queryRawUnsafe<Array<Record<string, unknown>>>(
+            `SELECT * FROM ${table} WHERE ${pk} > $1 ORDER BY ${pk} ASC LIMIT $2`,
+            cursor,
+            this.config.batchSize,
+          );
+
+      if (batch.length === 0) break;
+
+      await this.prisma.$executeRawUnsafe(
+        `INSERT INTO ${shadow} (${colList})
+         SELECT ${colList} FROM ${table} WHERE ${pk} = ANY($1::text[])
+         ON CONFLICT (${pk}) DO NOTHING`,
+        batch.map(r => String(r[this.config.primaryKeyColumn])),
+      );
+
+      rowsCopied += batch.length;
+      cursor = batch[batch.length - 1][this.config.primaryKeyColumn];
+    }
+
+    this.state = {
+      ...this.state,
+      phase: "dual_write",
+      backfillCompletedAt: new Date(),
+    };
+
+    return { rowsCopied };
+  }
+
+  // ── Phase 3: verify ───────────────────────────────────────────────────
+
+  /**
+   * Compares every row between the old table and the shadow table (no
+   * sampling). Returns a pass/fail report; `cutover` refuses to run unless
+   * the most recent report passed.
+   */
+  async verifyParity(maxSampledMismatches = 100): Promise<ParityReport> {
+    this.requirePhase("dual_write", "backfilling", "verifying");
+    this.state = { ...this.state, phase: "verifying" };
+
+    const table = quoteIdent(this.config.tableName);
+    const shadow = quoteIdent(this.config.shadowTableName);
+    const pk = quoteIdent(this.config.primaryKeyColumn);
+
+    const [{ count: totalOldRows }] = await this.prisma.$queryRawUnsafe<Array<{ count: bigint }>>(
+      `SELECT COUNT(*)::bigint AS count FROM ${table}`,
+    );
+    const [{ count: totalShadowRows }] = await this.prisma.$queryRawUnsafe<Array<{ count: bigint }>>(
+      `SELECT COUNT(*)::bigint AS count FROM ${shadow}`,
+    );
+
+    const [{ count: missingInShadow }] = await this.prisma.$queryRawUnsafe<Array<{ count: bigint }>>(
+      `SELECT COUNT(*)::bigint AS count FROM ${table} o
+       WHERE NOT EXISTS (SELECT 1 FROM ${shadow} s WHERE s.${pk} = o.${pk})`,
+    );
+    const [{ count: missingInOld }] = await this.prisma.$queryRawUnsafe<Array<{ count: bigint }>>(
+      `SELECT COUNT(*)::bigint AS count FROM ${shadow} s
+       WHERE NOT EXISTS (SELECT 1 FROM ${table} o WHERE o.${pk} = s.${pk})`,
+    );
+
+    const compareCols = this.config.columns.filter(c => c !== this.config.primaryKeyColumn);
+    const diffClause = compareCols
+      .map(c => `o.${quoteIdent(c)} IS DISTINCT FROM s.${quoteIdent(c)}`)
+      .join(" OR ");
+
+    let mismatchedRows = 0;
+    const mismatches: RowMismatch[] = [];
+
+    if (compareCols.length > 0) {
+      const [{ count }] = await this.prisma.$queryRawUnsafe<Array<{ count: bigint }>>(
+        `SELECT COUNT(*)::bigint AS count FROM ${table} o
+         JOIN ${shadow} s ON s.${pk} = o.${pk}
+         WHERE ${diffClause}`,
+      );
+      mismatchedRows = Number(count);
+
+      if (mismatchedRows > 0) {
+        const selectCols = compareCols
+          .map(c => `o.${quoteIdent(c)} AS old_${c}, s.${quoteIdent(c)} AS shadow_${c}`)
+          .join(", ");
+        const sampled = await this.prisma.$queryRawUnsafe<Array<Record<string, unknown>>>(
+          `SELECT o.${pk} AS pk, ${selectCols} FROM ${table} o
+           JOIN ${shadow} s ON s.${pk} = o.${pk}
+           WHERE ${diffClause}
+           LIMIT $1`,
+          maxSampledMismatches,
+        );
+        for (const row of sampled) {
+          for (const c of compareCols) {
+            const oldValue = row[`old_${c}`];
+            const shadowValue = row[`shadow_${c}`];
+            if (oldValue !== shadowValue) {
+              mismatches.push({ primaryKey: String(row.pk), column: c, oldValue, shadowValue });
+            }
+          }
+        }
+      }
+    }
+
+    const passed =
+      Number(missingInShadow) === 0 && Number(missingInOld) === 0 && mismatchedRows === 0;
+
+    const report: ParityReport = {
+      totalOldRows: Number(totalOldRows),
+      totalShadowRows: Number(totalShadowRows),
+      missingInShadow: Number(missingInShadow),
+      missingInOld: Number(missingInOld),
+      mismatchedRows,
+      mismatches,
+      passed,
+      checkedAt: new Date(),
+    };
+
+    this.state = {
+      ...this.state,
+      phase: passed ? "verified" : "verifying",
+      lastParityReport: report,
+    };
+
+    return report;
+  }
+
+  // ── Phase 4: cutover ──────────────────────────────────────────────────
+
+  /**
+   * Atomically repoints the read view at the shadow table. This is a single
+   * `CREATE OR REPLACE VIEW` statement — no rows are copied at cutover time
+   * — and is fully reversible via `rollback`. Hard-blocked unless the most
+   * recent `verifyParity` call passed.
+   */
+  async cutover(): Promise<void> {
+    this.requirePhase("verified");
+    if (!this.state.lastParityReport?.passed) {
+      throw new Error(
+        "MigrationOrchestrator: cutover blocked — no passing parity report on file",
+      );
+    }
+
+    const shadow = quoteIdent(this.config.shadowTableName);
+    const view = quoteIdent(this.config.viewName);
+
+    await this.prisma.$executeRawUnsafe(
+      `CREATE OR REPLACE VIEW ${view} AS SELECT * FROM ${shadow}`,
+    );
+
+    this.outcomes = [];
+    this.state = {
+      ...this.state,
+      phase: "monitoring",
+      cutoverAt: new Date(),
+    };
+  }
+
+  // ── Post-cutover monitoring + automated rollback ─────────────────────
+
+  /**
+   * Report the outcome of a post-cutover read/write against the view. Once
+   * enough samples land within `errorRateWindowMs`, an error rate above
+   * `errorRateThreshold` triggers an automatic `rollback`.
+   */
+  async recordPostCutoverOutcome(success: boolean): Promise<void> {
+    if (this.state.phase !== "monitoring") return;
+
+    const now = Date.now();
+    this.outcomes.push({ at: now, success });
+    this.outcomes = this.outcomes.filter(o => now - o.at <= this.config.errorRateWindowMs);
+
+    if (this.outcomes.length < this.config.minSamplesForRollback) return;
+
+    const failures = this.outcomes.filter(o => !o.success).length;
+    const errorRate = failures / this.outcomes.length;
+
+    if (errorRate > this.config.errorRateThreshold) {
+      await this.rollback(
+        `post-cutover error rate ${(errorRate * 100).toFixed(1)}% exceeded threshold ${(this.config.errorRateThreshold * 100).toFixed(1)}% over last ${this.outcomes.length} samples`,
+      );
+    }
+  }
+
+  /** Mark the migration as stable, ending the monitoring window. */
+  async confirmStable(): Promise<void> {
+    this.requirePhase("monitoring");
+    this.state = { ...this.state, phase: "completed", completedAt: new Date() };
+  }
+
+  /**
+   * Atomically repoints the view back at the old table. Safe to call from
+   * `monitoring` (automated or manual rollback) or `cutover`.
+   */
+  async rollback(reason: string): Promise<void> {
+    this.requirePhase("cutover", "monitoring");
+
+    const table = quoteIdent(this.config.tableName);
+    const view = quoteIdent(this.config.viewName);
+
+    await this.prisma.$executeRawUnsafe(
+      `CREATE OR REPLACE VIEW ${view} AS SELECT * FROM ${table}`,
+    );
+
+    this.state = {
+      ...this.state,
+      phase: "rolled_back",
+      rolledBackAt: new Date(),
+      rollbackReason: reason,
+    };
+  }
+
+  // ── Phase 5: cleanup ──────────────────────────────────────────────────
+
+  /**
+   * Drops the old table now that the shadow table is the confirmed source
+   * of truth, and removes dual-write mirroring. Only allowed once
+   * `confirmStable` has run.
+   */
+  async cleanup(): Promise<void> {
+    this.requirePhase("completed");
+
+    const table = quoteIdent(this.config.tableName);
+    await this.prisma.$executeRawUnsafe(`DROP TABLE IF EXISTS ${table}`);
+    this.middlewareInstalled = false;
+  }
+}

--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -2,12 +2,13 @@
 
 mod delegation;
 mod events;
+mod settlement;
 mod storage;
 mod types;
 
 use soroban_sdk::{contract, contractimpl, Address, Env, String};
 use types::{
-    DelegationRecord, Error,
+    DelegationRecord, Disbursement, Error,
     GovernanceProposal, ProposalStatus, ProposalVote,
     VoteError, FinalizationError,
 };
@@ -166,13 +167,67 @@ impl GovernanceContract {
             votes_against: 0,
             payload,
             status: ProposalStatus::Active,
+            disbursement: None,
         };
         storage::set_proposal(&env, proposal_id, &proposal);
         storage::set_proposal_count(&env, proposal_id + 1);
         proposal_id
     }
 
-    /// Execute a passed proposal (atomically with state change)
+    /// Admin-only: configure the deployed token-factory contract this
+    /// governance instance is authorized to disburse treasury payouts
+    /// through via the two-phase settlement protocol (#1624).
+    pub fn set_token_factory(env: Env, admin: Address, token_factory: Address) -> Result<(), Error> {
+        admin.require_auth();
+        let stored_admin = storage::get_admin(&env);
+        if admin != stored_admin {
+            return Err(Error::Unauthorized);
+        }
+        storage::set_token_factory(&env, &token_factory);
+        Ok(())
+    }
+
+    /// Attach a treasury payout to an active proposal, to be disbursed
+    /// through token-factory's prepare/commit settlement protocol when the
+    /// proposal executes. Only the proposal's creator may attach a
+    /// disbursement, only while the proposal is still `Active`, and only
+    /// once per proposal.
+    pub fn attach_disbursement(
+        env: Env,
+        creator: Address,
+        proposal_id: u32,
+        recipient: Address,
+        token_index: u32,
+        amount: i128,
+    ) -> Result<(), FinalizationError> {
+        creator.require_auth();
+        let mut proposal = storage::get_proposal(&env, proposal_id)
+            .ok_or(FinalizationError::ProposalNotFound)?;
+        if proposal.creator != creator {
+            return Err(FinalizationError::ProposalNotFound);
+        }
+        if proposal.status != ProposalStatus::Active {
+            return Err(FinalizationError::AlreadyFinalized);
+        }
+        if proposal.disbursement.is_some() {
+            return Err(FinalizationError::DisbursementAlreadyAttached);
+        }
+        proposal.disbursement = Some(Disbursement {
+            recipient,
+            token_index,
+            amount,
+        });
+        storage::set_proposal(&env, proposal_id, &proposal);
+        Ok(())
+    }
+
+    /// Execute a passed proposal (atomically with state change).
+    ///
+    /// If the proposal carries a `disbursement`, it is settled through
+    /// token-factory's two-phase prepare/commit protocol *before* the
+    /// proposal is marked `Executed` (#1624) — a failed commit auto-aborts
+    /// the reservation and leaves the proposal `Passed` (retryable) rather
+    /// than silently losing the payout.
     pub fn execute_proposal(env: Env, proposal_id: u32) -> Result<(), FinalizationError> {
         let mut proposal = storage::get_proposal(&env, proposal_id)
             .ok_or(FinalizationError::ProposalNotFound)?;
@@ -185,7 +240,13 @@ impl GovernanceContract {
             return Err(FinalizationError::ProposalNotPassed);
         }
 
-        // Atomically mark as executed
+        if let Some(disbursement) = proposal.disbursement.clone() {
+            let token_factory = storage::get_token_factory(&env)
+                .ok_or(FinalizationError::TokenFactoryNotConfigured)?;
+            settlement::execute_disbursement(&env, &token_factory, proposal_id, &disbursement)?;
+        }
+
+        // Only set once settlement (if any) is confirmed committed.
         proposal.status = ProposalStatus::Executed;
         storage::set_proposal(&env, proposal_id, &proposal);
 

--- a/contracts/governance/src/settlement.rs
+++ b/contracts/governance/src/settlement.rs
@@ -1,0 +1,95 @@
+//! Cross-contract atomic settlement client. (#1624)
+//!
+//! Governance treasury payouts must never be lost: if a passed proposal's
+//! disbursement fails partway through, funds must not be stuck and the
+//! proposal must not be marked executed. This module drives token-factory's
+//! two-phase settlement protocol (`prepare_settlement` → `commit_settlement`,
+//! aborting via `abort_settlement` on any commit failure) so
+//! `execute_proposal` only ever sets `ProposalStatus::Executed` after
+//! token-factory has confirmed the disbursement actually landed.
+//!
+//! token-factory and this contract pin different soroban-sdk major versions
+//! (26.x vs 21.x), so there is no shared generated contract client here —
+//! calls go through `Env::invoke_contract` / `Env::try_invoke_contract`
+//! against the deployed token-factory address, which works across SDK
+//! versions since argument/return marshaling happens at the host (ScVal)
+//! level, not the Rust type level.
+
+use soroban_sdk::{Address, Env, IntoVal, Symbol, Val, Vec};
+
+use crate::types::{Disbursement, FinalizationError};
+
+/// Local decode target for a token-factory contract error surfaced through
+/// `try_invoke_contract`. token-factory's own `Error` type isn't available
+/// here (different soroban-sdk major version), so only the raw numeric
+/// error code is recovered — sufficient to know *that* commit failed.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct RemoteError(pub u32);
+
+impl TryFrom<soroban_sdk::Error> for RemoteError {
+    type Error = soroban_sdk::Error;
+    fn try_from(value: soroban_sdk::Error) -> Result<Self, Self::Error> {
+        Ok(RemoteError(value.get_code()))
+    }
+}
+
+fn prepare_sym(env: &Env) -> Symbol {
+    Symbol::new(env, "prepare_settlement")
+}
+fn commit_sym(env: &Env) -> Symbol {
+    Symbol::new(env, "commit_settlement")
+}
+fn abort_sym(env: &Env) -> Symbol {
+    Symbol::new(env, "abort_settlement")
+}
+
+/// Runs `disbursement` through token-factory's prepare → commit protocol,
+/// calling `abort_settlement` on any commit failure. Returns `Ok(())` only
+/// once token-factory has confirmed the commit succeeded (tokens actually
+/// minted to the recipient) — callers must not mark a proposal `Executed`
+/// unless this returns `Ok`.
+///
+/// A failed *prepare* call traps and aborts this whole invocation (nothing
+/// was reserved yet, so the proposal stays `Passed` and executable again
+/// later). A failed *commit* is caught without aborting the transaction so
+/// this function can explicitly release the reservation via
+/// `abort_settlement` before returning `Err`.
+pub fn execute_disbursement(
+    env: &Env,
+    token_factory: &Address,
+    proposal_id: u32,
+    disbursement: &Disbursement,
+) -> Result<(), FinalizationError> {
+    let this_contract = env.current_contract_address();
+
+    let prepare_args: Vec<Val> = soroban_sdk::vec![
+        env,
+        this_contract.clone().into_val(env),
+        (proposal_id as u64).into_val(env),
+        disbursement.recipient.clone().into_val(env),
+        disbursement.token_index.into_val(env),
+        disbursement.amount.into_val(env),
+    ];
+    let reservation_id: u64 = env.invoke_contract(token_factory, &prepare_sym(env), prepare_args);
+
+    let commit_args: Vec<Val> = soroban_sdk::vec![
+        env,
+        this_contract.clone().into_val(env),
+        reservation_id.into_val(env),
+    ];
+    let commit_result =
+        env.try_invoke_contract::<(), RemoteError>(token_factory, &commit_sym(env), commit_args);
+
+    match commit_result {
+        Ok(Ok(())) => Ok(()),
+        _ => {
+            let abort_args: Vec<Val> = soroban_sdk::vec![
+                env,
+                this_contract.into_val(env),
+                reservation_id.into_val(env),
+            ];
+            let _: () = env.invoke_contract(token_factory, &abort_sym(env), abort_args);
+            Err(FinalizationError::DisbursementFailed)
+        }
+    }
+}

--- a/contracts/governance/src/storage.rs
+++ b/contracts/governance/src/storage.rs
@@ -203,6 +203,16 @@ pub fn has_voted(env: &Env, proposal_id: u32, voter: &Address) -> bool {
         .has(&DataKey::Vote(proposal_id, voter.clone()))
 }
 
+// ─── Token-factory address (cross-contract settlement, #1624) ─────────────
+
+pub fn get_token_factory(env: &Env) -> Option<Address> {
+    env.storage().instance().get(&DataKey::TokenFactory)
+}
+
+pub fn set_token_factory(env: &Env, address: &Address) {
+    env.storage().instance().set(&DataKey::TokenFactory, address);
+}
+
 /// Query a token balance for vote-weight purposes.
 /// In production this calls the actual token contract; in tests it returns a
 /// fixed value so the proposal tests remain self-contained.

--- a/contracts/governance/src/types.rs
+++ b/contracts/governance/src/types.rs
@@ -47,6 +47,11 @@ pub enum DataKey {
     Proposal(u32),
     /// Vote cast by a specific voter on a specific proposal
     Vote(u32, Address),
+
+    // ── Cross-contract settlement (#1624) ───────────────────────────────
+    /// Address of the deployed token-factory contract this governance
+    /// instance is authorized to disburse treasury payouts through.
+    TokenFactory,
 }
 
 // ─── Delegation structs ────────────────────────────────────────────────────
@@ -96,6 +101,19 @@ pub struct GovernanceProposal {
     pub votes_against: i128,
     pub payload: soroban_sdk::Bytes,
     pub status: ProposalStatus,
+    /// Treasury payout to disburse through token-factory on execution, if any.
+    pub disbursement: Option<Disbursement>,
+}
+
+/// A treasury payout a passed proposal disburses through token-factory's
+/// two-phase settlement protocol (`prepare_settlement` → `commit_settlement`)
+/// when executed. See `settlement::execute_disbursement`.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Disbursement {
+    pub recipient: Address,
+    pub token_index: u32,
+    pub amount: i128,
 }
 
 /// Status of a governance proposal.
@@ -172,4 +190,11 @@ pub enum FinalizationError {
     AlreadyFinalized = 3,
     AlreadyExecuted = 4,
     ProposalNotPassed = 5,
+    /// No token-factory address has been configured via `set_token_factory`.
+    TokenFactoryNotConfigured = 6,
+    /// The proposal already has a disbursement attached.
+    DisbursementAlreadyAttached = 7,
+    /// Cross-contract settlement failed (prepare succeeded but commit did
+    /// not); the reservation was released via `abort_settlement`.
+    DisbursementFailed = 8,
 }

--- a/contracts/token-factory/docs/CROSS_CONTRACT_INVARIANT_FUZZING.txt
+++ b/contracts/token-factory/docs/CROSS_CONTRACT_INVARIANT_FUZZING.txt
@@ -1,0 +1,71 @@
+# Cross-Contract Invariant Fuzzing (#1623)
+
+## The invariant
+
+Across `token-factory` and `governance` together, total voting power derived
+from token balances must never exceed total token supply:
+
+```
+sum(governance.get_vote_power(u) for u in users) <= token_factory.get_token_info(token_index).total_supply
+```
+
+`invariants.rs` / `invariant_tests.rs` in `token-factory` only ever check
+invariants that hold *within* that single contract (e.g. sum of balances ==
+total supply). Nothing previously fuzzed the invariant that must hold
+*across* both contracts under concurrent mint/burn/vote/delegate sequences.
+
+## Why this needs a real cross-contract harness
+
+`governance` maintains its own independent `Balance` / `VotePower` /
+`TotalSupply` ledger — it does not read token-factory balances directly.
+In a real deployment, an off-chain indexer relays token-factory mint/burn
+events into governance via `set_balance`. The fuzz harness plays that
+indexer's role explicitly: every successful mint/burn is immediately
+followed by a `set_balance` call carrying the holder's new real balance
+(read back via `get_balance_at`) into governance.
+
+That isolates the actual property under test: **given balances are kept in
+sync, can any interleaving of delegate/undelegate/vote/mint/burn ever make
+governance's own vote-power bookkeeping overshoot real token supply?**
+Delegation has non-trivial bookkeeping (chained delegation, snapshotting,
+delta accounting on rebalance) — this is exactly the kind of arithmetic
+where an off-by-one or double-count could let voting power drift above the
+token supply it's supposed to represent.
+
+## Harness design (`fuzz/fuzz_targets/cross_contract_invariants.rs`)
+
+- **token-factory** is deployed natively, in-process. This fuzz crate
+  depends on the `token-factory` crate directly (its `[lib] crate-type`
+  includes `rlib`, so its `TokenFactory` contract struct and generated
+  `TokenFactoryClient` work like any normal Rust library dependency).
+- **governance** pins a different soroban-sdk major version (21.x) than
+  token-factory (26.x). Adding it as a normal Cargo dependency of this fuzz
+  crate would pull two incompatible major versions of soroban-sdk into one
+  binary. Instead, governance is deployed from its **pre-built `.wasm`
+  artifact** via `soroban_sdk::contractimport!`, and driven through the
+  client that macro generates — the same interop boundary real
+  cross-contract calls between independently-versioned Soroban contracts use
+  in production (argument/return marshaling happens at the host ScVal
+  level, not the Rust type level, so the caller's SDK version doesn't need
+  to match the callee's).
+- Each fuzz input is an arbitrary sequence of `Action`s (`Mint`, `Burn`,
+  `Delegate`, `Undelegate`, `Vote`) over a small fixed pool of user
+  addresses. The invariant is asserted once before the sequence runs and
+  again after **every single action**, not just at the end — so a violation
+  is caught (and shrunk by libFuzzer) at the exact operation that caused it.
+
+## Building and running
+
+`governance.wasm` must be built before this fuzz target will link, since
+`contractimport!` reads the wasm file at compile time:
+
+```sh
+# From contracts/ (the workspace root containing token-factory + governance)
+cargo build -p governance --release --target wasm32-unknown-unknown
+
+# Then, from contracts/token-factory/fuzz/
+cargo fuzz run cross_contract_invariants -- -max_total_time=120
+```
+
+This ordering is what `fuzz-testing.yml`'s `cross-contract-invariant-fuzz`
+job runs in CI.

--- a/contracts/token-factory/fuzz/Cargo.toml
+++ b/contracts/token-factory/fuzz/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "token-factory-fuzz"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[package.metadata]
+cargo-fuzz = true
+
+# Deliberately detached from the parent `contracts` workspace: this crate
+# links libfuzzer-sys/arbitrary (which the real contract crates should never
+# depend on) and imports a pre-built governance.wasm artifact rather than
+# depending on the `governance` crate directly (see
+# fuzz_targets/cross_contract_invariants.rs for why).
+[workspace]
+
+[dependencies]
+libfuzzer-sys = "0.4"
+arbitrary = { version = "1", features = ["derive"] }
+soroban-sdk = { version = "26.0.1", features = ["testutils"] }
+token-factory = { path = ".." }
+
+[[bin]]
+name = "cross_contract_invariants"
+path = "fuzz_targets/cross_contract_invariants.rs"
+test = false
+doc = false
+bench = false

--- a/contracts/token-factory/fuzz/fuzz_targets/cross_contract_invariants.rs
+++ b/contracts/token-factory/fuzz/fuzz_targets/cross_contract_invariants.rs
@@ -1,0 +1,165 @@
+//! Cross-contract invariant fuzzing: token supply vs. voting power. (#1623)
+//!
+//! `invariants.rs` / `invariant_tests.rs` in `token-factory` only ever check
+//! invariants that hold *within* that single contract. Nothing previously
+//! fuzzed the invariant that must hold *across* token-factory and
+//! governance together: total voting power derived from token balances must
+//! never exceed total token supply, even under concurrent mint/burn/vote
+//! sequences.
+//!
+//! ## Harness design
+//! - token-factory is deployed **natively** in-process (this fuzz crate
+//!   depends on the `token-factory` crate directly — its `crate-type`
+//!   includes `rlib`, so its `TokenFactory` contract struct and generated
+//!   `TokenFactoryClient` are usable like any Rust library).
+//! - `governance` pins a different soroban-sdk major version (21.x vs
+//!   token-factory's 26.x), so it cannot be a normal Cargo dependency of
+//!   this crate without pulling two incompatible major versions of
+//!   soroban-sdk into one binary. Instead it is deployed from its
+//!   **pre-built `.wasm` artifact** via `soroban_sdk::contractimport!`, and
+//!   called through the client that macro generates — the same interop
+//!   boundary real cross-contract calls between independently-versioned
+//!   Soroban contracts use in production. See `CROSS_CONTRACT_INVARIANT_FUZZING.md`
+//!   in `contracts/token-factory/docs/` for the full design writeup and the
+//!   `governance.wasm` build step this target requires before it will link.
+//!
+//! ## The invariant
+//! After every fuzzed operation: `sum(governance.get_vote_power(u) for u in
+//! users) <= token_factory.get_token_info(token_index).total_supply`.
+//!
+//! Mint/burn on token-factory are relayed into governance's own balance
+//! ledger via `set_balance` (mirroring the indexer/relayer process a real
+//! deployment would run), exactly as governance's own doc comment on
+//! `set_balance` assumes. This isolates the property actually being
+//! fuzzed: given balances are kept in sync, can any interleaving of
+//! delegate/undelegate/vote/mint/burn ever make governance's own vote-power
+//! bookkeeping overshoot real token supply?
+#![no_main]
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
+use token_factory::{TokenFactory, TokenFactoryClient};
+
+mod governance_contract {
+    // Built by `cargo build -p governance --release --target wasm32-unknown-unknown`
+    // from the `contracts` workspace root; see fuzz-testing.yml and
+    // CROSS_CONTRACT_INVARIANT_FUZZING.md for the exact command.
+    soroban_sdk::contractimport!(
+        file = "../../target/wasm32-unknown-unknown/release/governance.wasm"
+    );
+}
+
+const NUM_USERS: usize = 4;
+const MAX_OPS_PER_RUN: usize = 200;
+
+#[derive(Debug, Clone, Arbitrary)]
+enum Action {
+    Mint { holder_idx: u8, amount: u32 },
+    Burn { holder_idx: u8, amount: u32 },
+    Delegate { from_idx: u8, to_idx: u8 },
+    Undelegate { from_idx: u8 },
+    Vote { voter_idx: u8, in_favor: bool },
+}
+
+fn assert_invariant(
+    tf: &TokenFactoryClient,
+    gov: &governance_contract::Client,
+    token_index: u32,
+    users: &[Address],
+) {
+    let total_supply = tf.get_token_info(&token_index).total_supply;
+
+    let mut total_vote_power: i128 = 0;
+    for u in users {
+        total_vote_power += gov.get_vote_power(u);
+    }
+
+    assert!(
+        total_vote_power <= total_supply,
+        "cross-contract invariant violated: total voting power {} exceeds token supply {}",
+        total_vote_power,
+        total_supply,
+    );
+}
+
+fuzz_target!(|actions: Vec<Action>| {
+    if actions.is_empty() {
+        return;
+    }
+
+    let env = Env::default();
+    env.mock_all_auths();
+
+    // ── Deploy token-factory natively ──────────────────────────────────
+    let tf_id = env.register_contract(None, TokenFactory);
+    let tf = TokenFactoryClient::new(&env, &tf_id);
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    tf.initialize(&admin, &treasury, &1_000_000_i128, &500_000_i128);
+
+    let token_index: u32 = 0;
+    tf.create_token(
+        &admin,
+        &String::from_str(&env, "FuzzToken"),
+        &String::from_str(&env, "FZT"),
+        &7u32,
+        &0i128,
+        &None,
+        &1_000_000_i128,
+    );
+
+    // ── Deploy governance from its compiled wasm ───────────────────────
+    let gov_id = env.register_contract_wasm(None, governance_contract::WASM);
+    let gov = governance_contract::Client::new(&env, &gov_id);
+    gov.initialize(&admin, &1_000_000_000_i128);
+
+    let users: Vec<Address> = (0..NUM_USERS).map(|_| Address::generate(&env)).collect();
+
+    assert_invariant(&tf, &gov, token_index, &users);
+
+    for action in actions.into_iter().take(MAX_OPS_PER_RUN) {
+        match action {
+            Action::Mint { holder_idx, amount } => {
+                let holder = &users[holder_idx as usize % users.len()];
+                let amount = (amount % 1_000_000) as i128 + 1;
+                if tf.try_mint(&admin, &token_index, holder, &amount).is_ok() {
+                    let ledger = env.ledger().sequence();
+                    if let Ok(Ok(balance)) = tf.try_get_balance_at(&token_index, holder, &ledger) {
+                        let _ = gov.try_set_balance(&admin, holder, &balance);
+                    }
+                }
+            }
+            Action::Burn { holder_idx, amount } => {
+                let holder = &users[holder_idx as usize % users.len()];
+                let amount = (amount % 1_000_000) as i128 + 1;
+                if tf.try_burn(holder, &token_index, &amount).is_ok() {
+                    let ledger = env.ledger().sequence();
+                    if let Ok(Ok(balance)) = tf.try_get_balance_at(&token_index, holder, &ledger) {
+                        let _ = gov.try_set_balance(&admin, holder, &balance);
+                    }
+                }
+            }
+            Action::Delegate { from_idx, to_idx } => {
+                let from = &users[from_idx as usize % users.len()];
+                let to = &users[to_idx as usize % users.len()];
+                if from != to {
+                    let _ = gov.try_delegate(from, to);
+                }
+            }
+            Action::Undelegate { from_idx } => {
+                let from = &users[from_idx as usize % users.len()];
+                let _ = gov.try_undelegate(from);
+            }
+            Action::Vote { voter_idx, in_favor } => {
+                // Best-effort: only succeeds if an active proposal 0 exists;
+                // included for coverage of vote-weight consumption, which
+                // does not itself change vote power.
+                let voter = &users[voter_idx as usize % users.len()];
+                let _ = gov.try_cast_vote(voter, &0u32, &in_favor);
+            }
+        }
+
+        assert_invariant(&tf, &gov, token_index, &users);
+    }
+});

--- a/contracts/token-factory/src/batch_operations.rs
+++ b/contracts/token-factory/src/batch_operations.rs
@@ -403,7 +403,7 @@ pub fn preflight_batch_settle(
 
 // ── helpers ───────────────────────────────────────────────────────────────────
 
-fn validate_token_params(env: &Env, params: &TokenCreationParams) -> Result<(), Error> {
+pub(crate) fn validate_token_params(env: &Env, params: &TokenCreationParams) -> Result<(), Error> {
     if params.name.len() == 0 || params.name.len() > 32 {
         return Err(Error::InvalidTokenParams);
     }

--- a/contracts/token-factory/src/batch_scheduler.rs
+++ b/contracts/token-factory/src/batch_scheduler.rs
@@ -1,0 +1,549 @@
+/// Gas-bounded batch execution scheduler with fair cross-tenant scheduling. (#1625)
+///
+/// `batch_operations::batch_reveal` / `batch_settle` execute a whole batch
+/// atomically in one call, sized to fit comfortably under a single ledger's
+/// gas envelope (`MAX_BATCH_SIZE` = 50). This module adds a second, additive
+/// entry point for batches that may be *larger* than one ledger should be
+/// asked to absorb, and for ledgers that are shared by multiple tenants:
+///
+/// - Each batch item has an estimated gas (CPU instruction) cost. A batch is
+///   only ever executed up to a configurable **per-ledger gas budget** —
+///   never partially through an item, only ever at an item boundary.
+/// - Work that doesn't fit in the current ledger's budget is persisted as a
+///   **continuation** and must be resumed with `resume_batch_reveal` /
+///   `resume_batch_settle` on a *later* ledger.
+/// - When more than one tenant has pending work in the same ledger, the
+///   ledger's gas budget is split evenly across all pending tenants (a
+///   "fair share"), so one tenant's oversized batch cannot consume the
+///   entire budget while another tenant's queued batch starves.
+///
+/// ## Gas estimate calibration
+/// Per-item costs are calibrated against the measured CPU-instruction
+/// thresholds already established for comparable single-item operations in
+/// `gas_compute_thresholds.rs` (which the project's `gas_benchmark_*` suite
+/// exists to keep honest):
+/// - `THRESHOLD_CREATE_TOKEN` = 6_000_000 CPU instructions — a `batch_reveal`
+///   item performs exactly one `create_token_internal` call, so
+///   `REVEAL_ITEM_GAS_ESTIMATE` is set equal to it.
+/// - `THRESHOLD_PAUSE_TOKEN` / `THRESHOLD_GET_TOKEN_INFO` (2_000_000 /
+///   1_500_000) bracket the cost of a single storage read-modify-write plus
+///   snapshot recording that a `batch_settle` item performs, so
+///   `SETTLE_ITEM_GAS_ESTIMATE` is set above that bracket to also cover the
+///   mint event and snapshot overhead unique to settle.
+///
+/// These are deliberately conservative (over-, not under-, estimates): a
+/// scheduler that occasionally splits a chunk one item smaller than strictly
+/// necessary is safe, one that lets a chunk exceed the real ledger budget is
+/// not.
+use soroban_sdk::{Address, Env, Vec};
+
+use crate::events;
+use crate::storage;
+use crate::types::{
+    BatchScheduleResult, Error, RevealBatchContinuation, SettleBatchContinuation,
+    TokenCreationParams,
+};
+
+/// Default per-ledger gas budget (CPU instructions), used until an admin
+/// calls `set_ledger_gas_budget`. Sized for roughly 6 reveal items or 16
+/// settle items per ledger at the calibrated per-item estimates below.
+pub const DEFAULT_LEDGER_GAS_BUDGET: u64 = 40_000_000;
+
+/// Estimated CPU-instruction cost of a single `batch_reveal` item.
+/// Calibrated to `THRESHOLD_CREATE_TOKEN` in `gas_compute_thresholds.rs`.
+pub const REVEAL_ITEM_GAS_ESTIMATE: u64 = 6_000_000;
+
+/// Estimated CPU-instruction cost of a single `batch_settle` item.
+/// Calibrated above the `THRESHOLD_PAUSE_TOKEN` / `THRESHOLD_GET_TOKEN_INFO`
+/// bracket in `gas_compute_thresholds.rs` to also cover mint-event and
+/// balance/supply snapshot overhead.
+pub const SETTLE_ITEM_GAS_ESTIMATE: u64 = 2_500_000;
+
+/// Maximum items accepted by a single `schedule_batch_*` call. Much larger
+/// than `batch_operations::MAX_BATCH_SIZE` since the scheduler is explicitly
+/// designed to spread oversized batches across multiple ledgers.
+pub const MAX_SCHEDULED_BATCH_SIZE: u32 = 2000;
+
+/// Gas cost estimate for `item_count` `batch_reveal` items.
+pub fn estimate_reveal_batch_gas(item_count: u32) -> u64 {
+    REVEAL_ITEM_GAS_ESTIMATE.saturating_mul(item_count as u64)
+}
+
+/// Gas cost estimate for `item_count` `batch_settle` items.
+pub fn estimate_settle_batch_gas(item_count: u32) -> u64 {
+    SETTLE_ITEM_GAS_ESTIMATE.saturating_mul(item_count as u64)
+}
+
+// ── Admin configuration ──────────────────────────────────────────────────────
+
+/// Current per-ledger gas budget.
+pub fn get_ledger_gas_budget(env: &Env) -> u64 {
+    storage::get_ledger_gas_budget(env)
+}
+
+/// Admin-only: set the per-ledger gas budget shared by the fair-share scheduler.
+pub fn set_ledger_gas_budget(env: &Env, admin: Address, budget: u64) -> Result<(), Error> {
+    admin.require_auth();
+    let current_admin = storage::get_admin(env);
+    if admin != current_admin {
+        return Err(Error::Unauthorized);
+    }
+    if budget == 0 {
+        return Err(Error::InvalidParameters);
+    }
+    storage::set_ledger_gas_budget(env, budget);
+    Ok(())
+}
+
+/// Tenants currently holding a pending continuation (queued for fair-share allocation).
+pub fn pending_tenants(env: &Env) -> Vec<Address> {
+    storage::get_fair_share_queue(env)
+}
+
+// ── Fair-share budget accounting ─────────────────────────────────────────────
+
+fn queue_contains(queue: &Vec<Address>, addr: &Address) -> bool {
+    for t in queue.iter() {
+        if t == *addr {
+            return true;
+        }
+    }
+    false
+}
+
+/// How many items (bounded by `requested_items`) `tenant` may execute right
+/// now, given the ledger-wide gas budget, this tenant's fair share of it
+/// (the budget divided across every tenant currently queued with pending
+/// work, counting `tenant` itself even if not yet queued), and what both
+/// the tenant and the ledger as a whole have already spent this ledger.
+fn compute_allowed_items(
+    env: &Env,
+    tenant: &Address,
+    ledger_seq: u32,
+    per_item_gas: u64,
+    requested_items: u32,
+) -> u32 {
+    if requested_items == 0 {
+        return 0;
+    }
+
+    let ledger_budget = storage::get_ledger_gas_budget(env);
+    let queue = storage::get_fair_share_queue(env);
+    let cohort_size: u64 = if queue_contains(&queue, tenant) {
+        (queue.len() as u64).max(1)
+    } else {
+        queue.len() as u64 + 1
+    };
+    let fair_share = ledger_budget / cohort_size;
+
+    let tenant_used = storage::get_tenant_ledger_gas_used(env, tenant, ledger_seq);
+    let tenant_remaining = fair_share.saturating_sub(tenant_used);
+
+    let ledger_used = storage::get_ledger_gas_used(env, ledger_seq);
+    let ledger_remaining = ledger_budget.saturating_sub(ledger_used);
+
+    let effective_budget = tenant_remaining.min(ledger_remaining);
+    if per_item_gas == 0 {
+        return requested_items;
+    }
+    let max_items = (effective_budget / per_item_gas) as u32;
+    max_items.min(requested_items)
+}
+
+// ── batch_reveal scheduling ──────────────────────────────────────────────────
+
+/// Stage-and-commit exactly `chunk` reveal items (no partial items). Mirrors
+/// `batch_operations::batch_reveal`'s two-phase atomicity for the slice only.
+fn execute_reveal_chunk(
+    env: &Env,
+    creator: &Address,
+    chunk: &Vec<TokenCreationParams>,
+    fee_payment: i128,
+) -> Result<(Vec<u32>, i128), Error> {
+    let base_fee = storage::get_base_fee(env);
+    let metadata_fee = storage::get_metadata_fee(env);
+    let start_index = storage::get_token_count(env);
+
+    // Phase 1 (stage): validate every item and compute its fee + index.
+    let mut required_fee: i128 = 0;
+    let mut staged_indices: Vec<u32> = Vec::new(env);
+    for (i, token) in chunk.iter().enumerate() {
+        crate::batch_operations::validate_token_params(env, &token)?;
+
+        let token_fee = if token.metadata_uri.is_some() {
+            base_fee
+                .checked_add(metadata_fee)
+                .ok_or(Error::ArithmeticError)?
+        } else {
+            base_fee
+        };
+        required_fee = required_fee
+            .checked_add(token_fee)
+            .ok_or(Error::ArithmeticError)?;
+
+        let token_index = start_index
+            .checked_add(i as u32)
+            .ok_or(Error::ArithmeticError)?;
+        staged_indices.push_back(token_index);
+    }
+
+    if fee_payment < required_fee {
+        return Err(Error::InsufficientFee);
+    }
+
+    // Phase 2 (commit): every value here was already validated above.
+    let mut indices = Vec::new(env);
+    for (token, token_index) in chunk.iter().zip(staged_indices.iter()) {
+        crate::token_creation::create_token_internal(env, creator, &token, token_index)
+            .unwrap_or_else(|e| panic!("schedule_batch_reveal: chunk commit failed after validation passed: {:?}", e));
+        indices.push_back(token_index);
+    }
+
+    let new_count = start_index
+        .checked_add(chunk.len())
+        .ok_or(Error::ArithmeticError)?;
+    env.storage()
+        .instance()
+        .set(&crate::types::DataKey::TokenCount, &new_count);
+
+    Ok((indices, required_fee))
+}
+
+/// Gas-bounded, fair-share-scheduled version of `batch_reveal`.
+///
+/// Executes as many leading items of `tokens` as fit in this ledger's
+/// remaining gas budget (and this tenant's fair share of it). Any remainder
+/// is persisted as a continuation and must be finished with
+/// `resume_batch_reveal` on a later ledger. Only one reveal continuation may
+/// be pending per tenant at a time.
+pub fn schedule_batch_reveal(
+    env: &Env,
+    creator: Address,
+    tokens: Vec<TokenCreationParams>,
+    total_fee_payment: i128,
+) -> Result<BatchScheduleResult, Error> {
+    if storage::is_paused(env) {
+        return Err(Error::ContractPaused);
+    }
+    creator.require_auth();
+
+    let batch_len = tokens.len();
+    if batch_len == 0 {
+        return Err(Error::InvalidParameters);
+    }
+    if batch_len > MAX_SCHEDULED_BATCH_SIZE {
+        return Err(Error::BatchTooLarge);
+    }
+    if storage::get_reveal_continuation(env, &creator).is_some() {
+        return Err(Error::ContinuationAlreadyPending);
+    }
+
+    let ledger_seq = env.ledger().sequence();
+    let chunk_len = compute_allowed_items(env, &creator, ledger_seq, REVEAL_ITEM_GAS_ESTIMATE, batch_len);
+
+    let chunk: Vec<TokenCreationParams> = tokens.slice(0..chunk_len);
+    let fee_used = if chunk_len > 0 {
+        let (_, fee_used) = execute_reveal_chunk(env, &creator, &chunk, total_fee_payment)?;
+        storage::record_gas_used(
+            env,
+            &creator,
+            ledger_seq,
+            REVEAL_ITEM_GAS_ESTIMATE.saturating_mul(chunk_len as u64),
+        );
+        events::emit_batch_tokens_created(env, &creator, chunk_len);
+        fee_used
+    } else {
+        0
+    };
+
+    let remaining_count = batch_len - chunk_len;
+    if remaining_count > 0 {
+        let remaining_tokens: Vec<TokenCreationParams> = tokens.slice(chunk_len..batch_len);
+        let continuation = RevealBatchContinuation {
+            creator: creator.clone(),
+            remaining_tokens,
+            remaining_fee_payment: total_fee_payment - fee_used,
+            last_activity_ledger: ledger_seq,
+        };
+        storage::set_reveal_continuation(env, &creator, &continuation);
+        storage::enqueue_tenant(env, &creator);
+        events::emit_batch_scheduled(env, &creator, chunk_len, remaining_count);
+    }
+
+    Ok(BatchScheduleResult {
+        executed_count: chunk_len,
+        remaining_count,
+        continuation_pending: remaining_count > 0,
+    })
+}
+
+/// Resume a pending `batch_reveal` continuation for `creator`. Must be
+/// called on a ledger after the one the continuation last made progress on.
+pub fn resume_batch_reveal(env: &Env, creator: Address) -> Result<BatchScheduleResult, Error> {
+    if storage::is_paused(env) {
+        return Err(Error::ContractPaused);
+    }
+    creator.require_auth();
+
+    let continuation = storage::get_reveal_continuation(env, &creator).ok_or(Error::NoContinuationPending)?;
+
+    let ledger_seq = env.ledger().sequence();
+    if ledger_seq <= continuation.last_activity_ledger {
+        return Err(Error::ContinuationNotYetEligible);
+    }
+
+    let remaining = continuation.remaining_tokens.clone();
+    let batch_len = remaining.len();
+    let chunk_len = compute_allowed_items(env, &creator, ledger_seq, REVEAL_ITEM_GAS_ESTIMATE, batch_len);
+
+    let chunk: Vec<TokenCreationParams> = remaining.slice(0..chunk_len);
+    let fee_used = if chunk_len > 0 {
+        let (_, fee_used) = execute_reveal_chunk(env, &creator, &chunk, continuation.remaining_fee_payment)?;
+        storage::record_gas_used(
+            env,
+            &creator,
+            ledger_seq,
+            REVEAL_ITEM_GAS_ESTIMATE.saturating_mul(chunk_len as u64),
+        );
+        events::emit_batch_tokens_created(env, &creator, chunk_len);
+        fee_used
+    } else {
+        0
+    };
+
+    let remaining_count = batch_len - chunk_len;
+    if remaining_count > 0 {
+        let remaining_tokens: Vec<TokenCreationParams> = remaining.slice(chunk_len..batch_len);
+        let updated = RevealBatchContinuation {
+            creator: creator.clone(),
+            remaining_tokens,
+            remaining_fee_payment: continuation.remaining_fee_payment - fee_used,
+            last_activity_ledger: ledger_seq,
+        };
+        storage::set_reveal_continuation(env, &creator, &updated);
+        storage::rotate_tenant_to_back(env, &creator);
+        events::emit_batch_scheduled(env, &creator, chunk_len, remaining_count);
+    } else {
+        storage::clear_reveal_continuation(env, &creator);
+        storage::dequeue_tenant(env, &creator);
+        events::emit_batch_continuation_completed(env, &creator);
+    }
+
+    Ok(BatchScheduleResult {
+        executed_count: chunk_len,
+        remaining_count,
+        continuation_pending: remaining_count > 0,
+    })
+}
+
+// ── batch_settle scheduling ──────────────────────────────────────────────────
+
+/// Stage-and-commit exactly `chunk` (recipient, amount) mints against
+/// `token_index` (no partial items). Mirrors `batch_operations::batch_settle`'s
+/// two-phase atomicity for the slice only.
+fn execute_settle_chunk(
+    env: &Env,
+    token_index: u32,
+    chunk: &Vec<(Address, i128)>,
+) -> Result<i128, Error> {
+    use soroban_sdk::Map;
+
+    let token_info = storage::get_token_info(env, token_index).ok_or(Error::TokenNotFound)?;
+
+    // Phase 1 (stage).
+    let mut total_mint: i128 = 0;
+    let mut deltas: Map<Address, i128> = Map::new(env);
+    for (recipient, amount) in chunk.iter() {
+        if amount <= 0 {
+            return Err(Error::InvalidParameters);
+        }
+        total_mint = total_mint
+            .checked_add(amount)
+            .ok_or(Error::ArithmeticError)?;
+
+        let prior = deltas.get(recipient.clone()).unwrap_or(0);
+        let combined = prior.checked_add(amount).ok_or(Error::ArithmeticError)?;
+        deltas.set(recipient.clone(), combined);
+    }
+
+    let new_supply = token_info
+        .total_supply
+        .checked_add(total_mint)
+        .ok_or(Error::ArithmeticError)?;
+    if let Some(max) = token_info.max_supply {
+        if new_supply > max {
+            return Err(Error::MaxSupplyExceeded);
+        }
+    }
+
+    let mut staged_balances: Map<Address, i128> = Map::new(env);
+    for (recipient, delta) in deltas.iter() {
+        let current_balance = storage::get_balance(env, token_index, &recipient);
+        let new_balance = current_balance
+            .checked_add(delta)
+            .ok_or(Error::ArithmeticError)?;
+        staged_balances.set(recipient, new_balance);
+    }
+
+    // Phase 2 (commit).
+    let mut updated_info = token_info;
+    updated_info.total_supply = new_supply;
+    storage::set_token_info(env, token_index, &updated_info);
+
+    for (recipient, _) in deltas.iter() {
+        let new_balance = staged_balances
+            .get(recipient.clone())
+            .unwrap_or_else(|| panic!("schedule_batch_settle: chunk commit missing staged balance"));
+        storage::set_balance(env, token_index, &recipient, new_balance);
+        let _ = crate::snapshot::record_balance_snapshot(env, token_index, &recipient, new_balance);
+    }
+    let _ = crate::snapshot::record_supply_snapshot(env, token_index, new_supply);
+
+    for (recipient, amount) in chunk.iter() {
+        events::emit_mint(env, token_index, &recipient, amount);
+    }
+
+    Ok(total_mint)
+}
+
+/// Gas-bounded, fair-share-scheduled version of `batch_settle`.
+///
+/// Executes as many leading `(recipient, amount)` pairs of `recipients` as
+/// fit in this ledger's remaining gas budget (and this tenant's fair
+/// share of it). Any remainder is persisted as a continuation and must be
+/// finished with `resume_batch_settle` on a later ledger. Only one settle
+/// continuation may be pending per tenant at a time.
+pub fn schedule_batch_settle(
+    env: &Env,
+    creator: Address,
+    token_index: u32,
+    recipients: Vec<(Address, i128)>,
+) -> Result<BatchScheduleResult, Error> {
+    if storage::is_paused(env) {
+        return Err(Error::ContractPaused);
+    }
+    creator.require_auth();
+
+    let batch_len = recipients.len();
+    if batch_len == 0 {
+        return Err(Error::InvalidParameters);
+    }
+    if batch_len > MAX_SCHEDULED_BATCH_SIZE {
+        return Err(Error::BatchTooLarge);
+    }
+    if storage::get_settle_continuation(env, &creator).is_some() {
+        return Err(Error::ContinuationAlreadyPending);
+    }
+
+    let token_info = storage::get_token_info(env, token_index).ok_or(Error::TokenNotFound)?;
+    if token_info.creator != creator {
+        return Err(Error::Unauthorized);
+    }
+    if storage::is_token_paused(env, token_index) {
+        return Err(Error::TokenPaused);
+    }
+
+    let ledger_seq = env.ledger().sequence();
+    let chunk_len = compute_allowed_items(env, &creator, ledger_seq, SETTLE_ITEM_GAS_ESTIMATE, batch_len);
+
+    let chunk: Vec<(Address, i128)> = recipients.slice(0..chunk_len);
+    let minted_so_far = if chunk_len > 0 {
+        let minted = execute_settle_chunk(env, token_index, &chunk)?;
+        storage::record_gas_used(
+            env,
+            &creator,
+            ledger_seq,
+            SETTLE_ITEM_GAS_ESTIMATE.saturating_mul(chunk_len as u64),
+        );
+        events::emit_batch_settle(env, token_index, &creator, chunk_len, minted);
+        minted
+    } else {
+        0
+    };
+
+    let remaining_count = batch_len - chunk_len;
+    if remaining_count > 0 {
+        let remaining_recipients: Vec<(Address, i128)> = recipients.slice(chunk_len..batch_len);
+        let continuation = SettleBatchContinuation {
+            creator: creator.clone(),
+            token_index,
+            remaining_recipients,
+            minted_so_far,
+            last_activity_ledger: ledger_seq,
+        };
+        storage::set_settle_continuation(env, &creator, &continuation);
+        storage::enqueue_tenant(env, &creator);
+        events::emit_batch_scheduled(env, &creator, chunk_len, remaining_count);
+    }
+
+    Ok(BatchScheduleResult {
+        executed_count: chunk_len,
+        remaining_count,
+        continuation_pending: remaining_count > 0,
+    })
+}
+
+/// Resume a pending `batch_settle` continuation for `creator`. Must be
+/// called on a ledger after the one the continuation last made progress on.
+/// Returns the total minted by this resume call (not the running total).
+pub fn resume_batch_settle(env: &Env, creator: Address) -> Result<BatchScheduleResult, Error> {
+    if storage::is_paused(env) {
+        return Err(Error::ContractPaused);
+    }
+    creator.require_auth();
+
+    let continuation = storage::get_settle_continuation(env, &creator).ok_or(Error::NoContinuationPending)?;
+
+    let ledger_seq = env.ledger().sequence();
+    if ledger_seq <= continuation.last_activity_ledger {
+        return Err(Error::ContinuationNotYetEligible);
+    }
+
+    if storage::is_token_paused(env, continuation.token_index) {
+        return Err(Error::TokenPaused);
+    }
+
+    let remaining = continuation.remaining_recipients.clone();
+    let batch_len = remaining.len();
+    let chunk_len = compute_allowed_items(env, &creator, ledger_seq, SETTLE_ITEM_GAS_ESTIMATE, batch_len);
+
+    let chunk: Vec<(Address, i128)> = remaining.slice(0..chunk_len);
+    let minted_this_chunk = if chunk_len > 0 {
+        let minted = execute_settle_chunk(env, continuation.token_index, &chunk)?;
+        storage::record_gas_used(
+            env,
+            &creator,
+            ledger_seq,
+            SETTLE_ITEM_GAS_ESTIMATE.saturating_mul(chunk_len as u64),
+        );
+        events::emit_batch_settle(env, continuation.token_index, &creator, chunk_len, minted);
+        minted
+    } else {
+        0
+    };
+
+    let remaining_count = batch_len - chunk_len;
+    if remaining_count > 0 {
+        let remaining_recipients: Vec<(Address, i128)> = remaining.slice(chunk_len..batch_len);
+        let updated = SettleBatchContinuation {
+            creator: creator.clone(),
+            token_index: continuation.token_index,
+            remaining_recipients,
+            minted_so_far: continuation.minted_so_far + minted_this_chunk,
+            last_activity_ledger: ledger_seq,
+        };
+        storage::set_settle_continuation(env, &creator, &updated);
+        storage::rotate_tenant_to_back(env, &creator);
+        events::emit_batch_scheduled(env, &creator, chunk_len, remaining_count);
+    } else {
+        storage::clear_settle_continuation(env, &creator);
+        storage::dequeue_tenant(env, &creator);
+        events::emit_batch_continuation_completed(env, &creator);
+    }
+
+    Ok(BatchScheduleResult {
+        executed_count: chunk_len,
+        remaining_count,
+        continuation_pending: remaining_count > 0,
+    })
+}

--- a/contracts/token-factory/src/events.rs
+++ b/contracts/token-factory/src/events.rs
@@ -1842,3 +1842,55 @@ pub fn emit_batch_continuation_completed(env: &Env, tenant: &Address) {
     env.events()
         .publish((symbol_short!("bch_don1"), tenant.clone()), (ledger,));
 }
+
+// ── Cross-contract atomic settlement (#1624) ────────────────────────────────
+
+/// Emitted when a reservation is created by `prepare_settlement`.
+///
+/// **Schema Version**: 1
+/// **Event Name**: stl_prep1
+pub fn emit_settlement_prepared(
+    env: &Env,
+    reservation_id: u64,
+    proposal_id: u64,
+    token_index: u32,
+    recipient: &Address,
+    amount: i128,
+) {
+    env.events().publish(
+        (symbol_short!("stl_prep1"), reservation_id),
+        (proposal_id, token_index, recipient.clone(), amount),
+    );
+}
+
+/// Emitted when a reservation is finalized (minted) by `commit_settlement`.
+///
+/// **Schema Version**: 1
+/// **Event Name**: stl_cmt1
+pub fn emit_settlement_committed(env: &Env, reservation_id: u64, proposal_id: u64) {
+    env.events()
+        .publish((symbol_short!("stl_cmt1"), reservation_id), (proposal_id,));
+}
+
+/// Emitted when a reservation is released without minting — via an explicit
+/// `abort_settlement` call (`reason_code == 0`) or because
+/// `commit_settlement` itself failed (`reason_code` is the mint error code).
+///
+/// **Schema Version**: 1
+/// **Event Name**: stl_abrt1
+pub fn emit_settlement_aborted(env: &Env, reservation_id: u64, proposal_id: u64, reason_code: u32) {
+    env.events().publish(
+        (symbol_short!("stl_abrt1"), reservation_id),
+        (proposal_id, reason_code),
+    );
+}
+
+/// Emitted when a stuck (never committed or aborted) reservation is
+/// force-released by `cleanup_stuck_reservation` after its timeout window.
+///
+/// **Schema Version**: 1
+/// **Event Name**: stl_tmo1
+pub fn emit_settlement_timeout_cleanup(env: &Env, reservation_id: u64, proposal_id: u64) {
+    env.events()
+        .publish((symbol_short!("stl_tmo1"), reservation_id), (proposal_id,));
+}

--- a/contracts/token-factory/src/events.rs
+++ b/contracts/token-factory/src/events.rs
@@ -1817,3 +1817,28 @@ pub fn emit_multisig_executed(env: &Env, proposal_id: u64, executor: &Address) {
     env.events()
         .publish((symbol_short!("ms_exe_v1"), proposal_id), (executor,));
 }
+
+// ── Gas-bounded batch scheduler (#1625) ─────────────────────────────────────
+
+/// Emitted when a scheduled batch is split by the gas-bounded scheduler: a
+/// chunk of `executed_count` items committed now, `remaining_count` deferred
+/// to a continuation the tenant can resume on a later ledger.
+///
+/// **Schema Version**: 1
+/// **Event Name**: bch_sch1
+pub fn emit_batch_scheduled(env: &Env, tenant: &Address, executed_count: u32, remaining_count: u32) {
+    env.events().publish(
+        (symbol_short!("bch_sch1"), tenant.clone()),
+        (executed_count, remaining_count),
+    );
+}
+
+/// Emitted when a batch continuation finishes draining (its last chunk committed).
+///
+/// **Schema Version**: 1
+/// **Event Name**: bch_don1
+pub fn emit_batch_continuation_completed(env: &Env, tenant: &Address) {
+    let ledger = env.ledger().sequence();
+    env.events()
+        .publish((symbol_short!("bch_don1"), tenant.clone()), (ledger,));
+}

--- a/contracts/token-factory/src/lib.rs
+++ b/contracts/token-factory/src/lib.rs
@@ -16,6 +16,7 @@ mod ipfs_pinning;
 mod referral;
 
 mod batch_operations;
+mod batch_scheduler;
 mod burn;
 mod clawback;
 mod campaign;
@@ -184,9 +185,10 @@ mod vault_balance_invariant_proptest;
 
 use soroban_sdk::{contract, contractimpl, symbol_short, Address, Bytes, BytesN, Env, String, Symbol, Vec};
 use types::{
-    AuctionStatus, BurnAuction, BuybackCampaign, CampaignStatus, ContractMetadata,
-    DynamicQuorumConfig, Error, FactoryState, PaginationCursor, PreflightItemResult, StreamInfo,
-    StreamPage, StreamParams, TokenCreationParams, TokenInfo, TokenStats, Vault, VaultStatus,
+    AuctionStatus, BatchScheduleResult, BurnAuction, BuybackCampaign, CampaignStatus,
+    ContractMetadata, DynamicQuorumConfig, Error, FactoryState, PaginationCursor,
+    PreflightItemResult, StreamInfo, StreamPage, StreamParams, TokenCreationParams, TokenInfo,
+    TokenStats, Vault, VaultStatus,
 };
 use crate::milestone_verification::MilestoneVerifier;
 
@@ -1538,6 +1540,101 @@ impl TokenFactory {
         recipients: Vec<(Address, i128)>,
     ) -> Result<Vec<PreflightItemResult>, Error> {
         batch_operations::preflight_batch_settle(&env, creator, token_index, recipients)
+    }
+
+    // ── Gas-bounded batch scheduler (#1625) ──────────────────────────────
+
+    /// Gas-bounded, fair-share-scheduled version of `batch_reveal`.
+    ///
+    /// Executes as many leading `tokens` as fit under the current ledger's
+    /// gas budget and this tenant's fair share of it (the budget divided
+    /// across every tenant with pending scheduled work this ledger). Any
+    /// remainder is persisted as a continuation — call `resume_batch_reveal`
+    /// on a later ledger to finish it. Only one reveal continuation may be
+    /// pending per tenant at a time.
+    ///
+    /// # Errors
+    /// `ContractPaused`, `InvalidParameters`, `BatchTooLarge`,
+    /// `ContinuationAlreadyPending`, `InvalidTokenParams`, `InsufficientFee`.
+    pub fn schedule_batch_reveal(
+        env: Env,
+        creator: Address,
+        tokens: Vec<TokenCreationParams>,
+        total_fee_payment: i128,
+    ) -> Result<BatchScheduleResult, Error> {
+        storage::acquire_reentrancy_lock(&env)?;
+        let result = batch_scheduler::schedule_batch_reveal(&env, creator, tokens, total_fee_payment);
+        storage::release_reentrancy_lock(&env);
+        result
+    }
+
+    /// Resume a pending `schedule_batch_reveal` continuation for `creator`.
+    /// Must be called on a ledger after the one the continuation last made
+    /// progress on.
+    ///
+    /// # Errors
+    /// `ContractPaused`, `NoContinuationPending`, `ContinuationNotYetEligible`,
+    /// `InvalidTokenParams`, `InsufficientFee`.
+    pub fn resume_batch_reveal(env: Env, creator: Address) -> Result<BatchScheduleResult, Error> {
+        storage::acquire_reentrancy_lock(&env)?;
+        let result = batch_scheduler::resume_batch_reveal(&env, creator);
+        storage::release_reentrancy_lock(&env);
+        result
+    }
+
+    /// Gas-bounded, fair-share-scheduled version of `batch_settle`.
+    ///
+    /// Executes as many leading `recipients` as fit under the current
+    /// ledger's gas budget and this tenant's fair share of it. Any
+    /// remainder is persisted as a continuation — call `resume_batch_settle`
+    /// on a later ledger to finish it. Only one settle continuation may be
+    /// pending per tenant at a time.
+    ///
+    /// # Errors
+    /// `ContractPaused`, `InvalidParameters`, `BatchTooLarge`,
+    /// `ContinuationAlreadyPending`, `TokenNotFound`, `Unauthorized`,
+    /// `TokenPaused`, `MaxSupplyExceeded`.
+    pub fn schedule_batch_settle(
+        env: Env,
+        creator: Address,
+        token_index: u32,
+        recipients: Vec<(Address, i128)>,
+    ) -> Result<BatchScheduleResult, Error> {
+        storage::acquire_reentrancy_lock(&env)?;
+        let result = batch_scheduler::schedule_batch_settle(&env, creator, token_index, recipients);
+        storage::release_reentrancy_lock(&env);
+        result
+    }
+
+    /// Resume a pending `schedule_batch_settle` continuation for `creator`.
+    /// Must be called on a ledger after the one the continuation last made
+    /// progress on.
+    ///
+    /// # Errors
+    /// `ContractPaused`, `NoContinuationPending`, `ContinuationNotYetEligible`,
+    /// `TokenPaused`, `MaxSupplyExceeded`.
+    pub fn resume_batch_settle(env: Env, creator: Address) -> Result<BatchScheduleResult, Error> {
+        storage::acquire_reentrancy_lock(&env)?;
+        let result = batch_scheduler::resume_batch_settle(&env, creator);
+        storage::release_reentrancy_lock(&env);
+        result
+    }
+
+    /// Admin-only: set the per-ledger gas budget (CPU instructions) shared
+    /// by the fair-share batch scheduler across all tenants.
+    pub fn set_batch_gas_budget(env: Env, admin: Address, budget: u64) -> Result<(), Error> {
+        batch_scheduler::set_ledger_gas_budget(&env, admin, budget)
+    }
+
+    /// Current per-ledger gas budget used by the fair-share batch scheduler.
+    pub fn get_batch_gas_budget(env: Env) -> u64 {
+        batch_scheduler::get_ledger_gas_budget(&env)
+    }
+
+    /// Tenants currently holding a pending batch continuation, queued for
+    /// fair-share gas allocation on the next eligible ledger.
+    pub fn get_pending_batch_tenants(env: Env) -> Vec<Address> {
+        batch_scheduler::pending_tenants(&env)
     }
 
     /// Set metadata URI for a token by index (creator-only convenience function)

--- a/contracts/token-factory/src/lib.rs
+++ b/contracts/token-factory/src/lib.rs
@@ -18,6 +18,7 @@ mod referral;
 mod batch_operations;
 mod batch_scheduler;
 mod burn;
+mod settlement;
 mod clawback;
 mod campaign;
 #[cfg(feature = "legacy-tests")]
@@ -187,8 +188,8 @@ use soroban_sdk::{contract, contractimpl, symbol_short, Address, Bytes, BytesN, 
 use types::{
     AuctionStatus, BatchScheduleResult, BurnAuction, BuybackCampaign, CampaignStatus,
     ContractMetadata, DynamicQuorumConfig, Error, FactoryState, PaginationCursor,
-    PreflightItemResult, StreamInfo, StreamPage, StreamParams, TokenCreationParams, TokenInfo,
-    TokenStats, Vault, VaultStatus,
+    PreflightItemResult, Reservation, StreamInfo, StreamPage, StreamParams, TokenCreationParams,
+    TokenInfo, TokenStats, Vault, VaultStatus,
 };
 use crate::milestone_verification::MilestoneVerifier;
 
@@ -1635,6 +1636,66 @@ impl TokenFactory {
     /// fair-share gas allocation on the next eligible ledger.
     pub fn get_pending_batch_tenants(env: Env) -> Vec<Address> {
         batch_scheduler::pending_tenants(&env)
+    }
+
+    // ── Cross-contract atomic settlement (#1624) ─────────────────────────
+
+    /// Phase 1: reserve `amount` of `token_index` for `proposal_id`, without
+    /// minting anything yet. Callable only by the configured governance
+    /// contract (`governance.require_auth()` plus a match against
+    /// `set_governance`). Returns the new reservation's id.
+    pub fn prepare_settlement(
+        env: Env,
+        governance: Address,
+        proposal_id: u64,
+        recipient: Address,
+        token_index: u32,
+        amount: i128,
+    ) -> Result<u64, Error> {
+        settlement::prepare(&env, governance, proposal_id, recipient, token_index, amount)
+    }
+
+    /// Phase 2 (success path): finalize a `Prepared` reservation by minting
+    /// to its recipient. On failure the reservation is left `Prepared` so
+    /// the caller can explicitly `abort_settlement` it — never silently
+    /// dropped.
+    pub fn commit_settlement(env: Env, governance: Address, reservation_id: u64) -> Result<(), Error> {
+        settlement::commit(&env, governance, reservation_id)
+    }
+
+    /// Release a `Prepared` reservation without minting, returning its
+    /// amount to the token's available max-supply headroom.
+    pub fn abort_settlement(env: Env, governance: Address, reservation_id: u64) -> Result<(), Error> {
+        settlement::abort(&env, governance, reservation_id)
+    }
+
+    /// Permissionless watchdog: force-release a reservation that has sat
+    /// `Prepared` past the configured timeout window, guaranteeing no
+    /// reservation is ever stuck indefinitely.
+    pub fn cleanup_stuck_reservation(env: Env, reservation_id: u64) -> Result<(), Error> {
+        settlement::cleanup_stuck_reservation(&env, reservation_id)
+    }
+
+    /// Look up a settlement reservation by id.
+    pub fn get_reservation(env: Env, reservation_id: u64) -> Option<Reservation> {
+        storage::get_reservation(&env, reservation_id)
+    }
+
+    /// Admin-only: configure how many ledgers a reservation may sit
+    /// `Prepared` before `cleanup_stuck_reservation` may force-release it.
+    pub fn set_reservation_timeout_ledgers(env: Env, admin: Address, ledgers: u32) -> Result<(), Error> {
+        admin.require_auth();
+        let stored_admin = storage::get_admin(&env);
+        if admin != stored_admin {
+            return Err(Error::Unauthorized);
+        }
+        storage::set_reservation_timeout_ledgers(&env, ledgers);
+        Ok(())
+    }
+
+    /// Current reservation timeout (in ledgers).
+    pub fn get_reservation_timeout_ledgers(env: Env) -> u32 {
+        storage::get_reservation_timeout_ledgers(&env)
     }
 
     /// Set metadata URI for a token by index (creator-only convenience function)

--- a/contracts/token-factory/src/settlement.rs
+++ b/contracts/token-factory/src/settlement.rs
@@ -1,0 +1,209 @@
+/// Cross-contract atomic settlement protocol. (#1624)
+///
+/// Governance treasury payouts must never be lost: previously, a governance
+/// proposal calling into token-factory to disburse tokens had no atomicity
+/// guarantee — if the token-factory call failed after governance already
+/// marked the proposal executed, the disbursement was silently lost with no
+/// compensating mechanism.
+///
+/// This module implements the token-factory side of a two-phase commit
+/// protocol, callable only by the configured governance contract
+/// (`storage::get_governance`):
+///
+/// - `prepare` reserves `amount` of `token_index` against the token's
+///   max-supply headroom and records a `Reservation`, without minting
+///   anything yet.
+/// - `commit` finalizes a `Prepared` reservation by minting to the
+///   recipient. On success the reservation is marked `Committed`; on
+///   failure the reservation is left `Prepared` (untouched) so the caller
+///   can explicitly release it via `abort`.
+/// - `abort` releases a `Prepared` reservation's hold on max-supply
+///   headroom without minting anything, marking it `Aborted`.
+/// - `cleanup_stuck_reservation` is a permissionless watchdog: once a
+///   `Prepared` reservation has sat unresolved past the configured timeout
+///   (e.g. because the caller's transaction reverted between `prepare` and
+///   `commit`/`abort`), anyone may force-release it the same way `abort`
+///   would.
+use soroban_sdk::{Address, Env};
+
+use crate::events;
+use crate::storage;
+use crate::types::{Error, Reservation, ReservationStatus};
+
+fn assert_governance_caller(env: &Env, caller: &Address) -> Result<(), Error> {
+    caller.require_auth();
+    let governance = storage::get_governance(env).ok_or(Error::Unauthorized)?;
+    if *caller != governance {
+        return Err(Error::Unauthorized);
+    }
+    Ok(())
+}
+
+fn release_hold(env: &Env, reservation: &Reservation) {
+    let current = storage::get_reserved_total(env, reservation.token_index);
+    storage::set_reserved_total(env, reservation.token_index, current.saturating_sub(reservation.amount));
+}
+
+/// Phase 1: reserve `amount` of `token_index` for `proposal_id`, without
+/// minting anything yet. Callable only by the configured governance
+/// contract. Returns the new reservation's id.
+///
+/// # Errors
+/// * `Unauthorized`      – `governance` isn't the configured governance address.
+/// * `ContractPaused`    – Factory is paused.
+/// * `TokenPaused`       – Token is individually paused.
+/// * `TokenNotFound`     – `token_index` does not exist.
+/// * `InvalidAmount`     – `amount <= 0`.
+/// * `MaxSupplyExceeded` – `amount`, combined with already-reserved and
+///   already-minted supply, would exceed the token's max supply.
+/// * `ArithmeticError`   – Overflow computing projected supply.
+pub fn prepare(
+    env: &Env,
+    governance: Address,
+    proposal_id: u64,
+    recipient: Address,
+    token_index: u32,
+    amount: i128,
+) -> Result<u64, Error> {
+    assert_governance_caller(env, &governance)?;
+
+    if amount <= 0 {
+        return Err(Error::InvalidAmount);
+    }
+    if storage::is_paused(env) {
+        return Err(Error::ContractPaused);
+    }
+    if storage::is_token_paused(env, token_index) {
+        return Err(Error::TokenPaused);
+    }
+    let token_info = storage::get_token_info(env, token_index).ok_or(Error::TokenNotFound)?;
+
+    // Reserve against max-supply headroom so concurrent prepares can't
+    // collectively over-commit beyond the cap.
+    let reserved_total = storage::get_reserved_total(env, token_index);
+    if let Some(max) = token_info.max_supply {
+        let projected = token_info
+            .total_supply
+            .checked_add(reserved_total)
+            .ok_or(Error::ArithmeticError)?
+            .checked_add(amount)
+            .ok_or(Error::ArithmeticError)?;
+        if projected > max {
+            return Err(Error::MaxSupplyExceeded);
+        }
+    }
+
+    let id = storage::next_reservation_id(env);
+    let reservation = Reservation {
+        id,
+        proposal_id,
+        recipient: recipient.clone(),
+        token_index,
+        amount,
+        status: ReservationStatus::Prepared,
+        created_ledger: env.ledger().sequence(),
+    };
+    storage::set_reservation(env, id, &reservation);
+    storage::set_reserved_total(
+        env,
+        token_index,
+        reserved_total.checked_add(amount).ok_or(Error::ArithmeticError)?,
+    );
+
+    events::emit_settlement_prepared(env, id, proposal_id, token_index, &recipient, amount);
+
+    Ok(id)
+}
+
+/// Phase 2 (success path): finalize a `Prepared` reservation by minting
+/// `amount` of `token_index` to its recipient, marking it `Committed`.
+///
+/// If the mint itself fails (e.g. the token was paused after `prepare`, or a
+/// concurrent commit consumed shared max-supply headroom first), the
+/// reservation is left `Prepared` — untouched — so the caller can decide to
+/// retry or explicitly release it via `abort`. It is never silently dropped.
+///
+/// # Errors
+/// * `Unauthorized`           – `governance` isn't the configured governance address.
+/// * `ReservationNotFound`    – No reservation with this id.
+/// * `ReservationNotPending`  – Reservation already committed or aborted.
+/// * (mint errors)            – `TokenPaused`, `MaxSupplyExceeded`, `ArithmeticError`, etc.
+pub fn commit(env: &Env, governance: Address, reservation_id: u64) -> Result<(), Error> {
+    assert_governance_caller(env, &governance)?;
+
+    let mut reservation =
+        storage::get_reservation(env, reservation_id).ok_or(Error::ReservationNotFound)?;
+    if reservation.status != ReservationStatus::Prepared {
+        return Err(Error::ReservationNotPending);
+    }
+
+    crate::mint::mint(env, reservation.token_index, &reservation.recipient, reservation.amount)?;
+
+    // The hold is only released once real supply has taken its place —
+    // never before the mint has actually succeeded.
+    release_hold(env, &reservation);
+    reservation.status = ReservationStatus::Committed;
+    storage::set_reservation(env, reservation_id, &reservation);
+
+    events::emit_settlement_committed(env, reservation_id, reservation.proposal_id);
+
+    Ok(())
+}
+
+/// Release a `Prepared` reservation's hold on max-supply headroom without
+/// minting anything, marking it `Aborted`. Safe to call after a failed
+/// `commit` (which leaves the reservation `Prepared`) to guarantee no
+/// reservation is ever left stuck indefinitely.
+///
+/// # Errors
+/// * `Unauthorized`          – `governance` isn't the configured governance address.
+/// * `ReservationNotFound`   – No reservation with this id.
+/// * `ReservationNotPending` – Reservation already committed or aborted.
+pub fn abort(env: &Env, governance: Address, reservation_id: u64) -> Result<(), Error> {
+    assert_governance_caller(env, &governance)?;
+    abort_internal(env, reservation_id, 0)
+}
+
+fn abort_internal(env: &Env, reservation_id: u64, reason_code: u32) -> Result<(), Error> {
+    let mut reservation =
+        storage::get_reservation(env, reservation_id).ok_or(Error::ReservationNotFound)?;
+    if reservation.status != ReservationStatus::Prepared {
+        return Err(Error::ReservationNotPending);
+    }
+
+    release_hold(env, &reservation);
+    reservation.status = ReservationStatus::Aborted;
+    storage::set_reservation(env, reservation_id, &reservation);
+
+    events::emit_settlement_aborted(env, reservation_id, reservation.proposal_id, reason_code);
+
+    Ok(())
+}
+
+/// Permissionless watchdog: force-release a reservation that has sat
+/// `Prepared` past the configured timeout window (see
+/// `set_reservation_timeout_ledgers`), guaranteeing no reservation is stuck
+/// forever even if the contract that prepared it never follows up with a
+/// `commit` or `abort` call.
+///
+/// # Errors
+/// * `ReservationNotFound`    – No reservation with this id.
+/// * `ReservationNotPending`  – Reservation already committed or aborted.
+/// * `ReservationNotYetStuck` – The timeout window hasn't elapsed yet.
+pub fn cleanup_stuck_reservation(env: &Env, reservation_id: u64) -> Result<(), Error> {
+    let reservation =
+        storage::get_reservation(env, reservation_id).ok_or(Error::ReservationNotFound)?;
+    if reservation.status != ReservationStatus::Prepared {
+        return Err(Error::ReservationNotPending);
+    }
+
+    let timeout = storage::get_reservation_timeout_ledgers(env);
+    let current_ledger = env.ledger().sequence();
+    if current_ledger < reservation.created_ledger.saturating_add(timeout) {
+        return Err(Error::ReservationNotYetStuck);
+    }
+
+    abort_internal(env, reservation_id, 0)?;
+    events::emit_settlement_timeout_cleanup(env, reservation_id, reservation.proposal_id);
+    Ok(())
+}

--- a/contracts/token-factory/src/storage.rs
+++ b/contracts/token-factory/src/storage.rs
@@ -1,6 +1,9 @@
-use soroban_sdk::{Address, Env};
+use soroban_sdk::{Address, Env, Vec};
 
-use crate::types::{BuybackCampaign, DataKey, Error, FactoryState, StreamCursor, TokenInfo};
+use crate::types::{
+    BuybackCampaign, DataKey, Error, FactoryState, RevealBatchContinuation,
+    SettleBatchContinuation, StreamCursor, TokenInfo,
+};
 
 // ============================================================
 // TTL Bump Constants (#1128)
@@ -2108,4 +2111,150 @@ pub fn add_creator_recurring_stream(env: &Env, creator: &Address, stream_id: u64
         &new_count,
     );
     Ok(())
+}
+
+// ============================================================
+// Gas-Bounded Batch Scheduler (#1625)
+// ============================================================
+
+/// Configurable per-ledger gas budget (CPU instructions), shared across all
+/// tenants by the fair-share scheduler. Falls back to
+/// `batch_scheduler::DEFAULT_LEDGER_GAS_BUDGET` until an admin overrides it.
+pub fn get_ledger_gas_budget(env: &Env) -> u64 {
+    env.storage()
+        .instance()
+        .get(&DataKey::BatchGasBudget)
+        .unwrap_or(crate::batch_scheduler::DEFAULT_LEDGER_GAS_BUDGET)
+}
+
+/// Admin-configurable override of the per-ledger gas budget.
+pub fn set_ledger_gas_budget(env: &Env, budget: u64) {
+    env.storage().instance().set(&DataKey::BatchGasBudget, &budget);
+}
+
+/// Ordered set of tenants with a pending batch continuation. Front of the
+/// vector is served first; a tenant is moved to the back after being served
+/// so no tenant can monopolize consecutive ledgers.
+pub fn get_fair_share_queue(env: &Env) -> Vec<Address> {
+    env.storage()
+        .instance()
+        .get(&DataKey::FairShareQueue)
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+pub fn set_fair_share_queue(env: &Env, queue: &Vec<Address>) {
+    env.storage().instance().set(&DataKey::FairShareQueue, queue);
+}
+
+/// Add a tenant to the back of the fair-share queue if not already present.
+pub fn enqueue_tenant(env: &Env, tenant: &Address) {
+    let mut queue = get_fair_share_queue(env);
+    let mut already_present = false;
+    for t in queue.iter() {
+        if t == *tenant {
+            already_present = true;
+            break;
+        }
+    }
+    if !already_present {
+        queue.push_back(tenant.clone());
+        set_fair_share_queue(env, &queue);
+    }
+}
+
+/// Remove a tenant from the fair-share queue (it has no more pending work).
+pub fn dequeue_tenant(env: &Env, tenant: &Address) {
+    let queue = get_fair_share_queue(env);
+    let mut new_queue = Vec::new(env);
+    for t in queue.iter() {
+        if t != *tenant {
+            new_queue.push_back(t.clone());
+        }
+    }
+    set_fair_share_queue(env, &new_queue);
+}
+
+/// Move a served-but-still-pending tenant to the back of the queue so the
+/// next ledger's fair share is offered to the next tenant in line first.
+pub fn rotate_tenant_to_back(env: &Env, tenant: &Address) {
+    dequeue_tenant(env, tenant);
+    enqueue_tenant(env, tenant);
+}
+
+/// Gas a tenant has already consumed on the given ledger.
+pub fn get_tenant_ledger_gas_used(env: &Env, tenant: &Address, ledger_seq: u32) -> u64 {
+    env.storage()
+        .temporary()
+        .get(&DataKey::TenantLedgerGasUsed(tenant.clone(), ledger_seq))
+        .unwrap_or(0)
+}
+
+/// Total gas consumed by all tenants on the given ledger.
+pub fn get_ledger_gas_used(env: &Env, ledger_seq: u32) -> u64 {
+    env.storage()
+        .temporary()
+        .get(&DataKey::LedgerGasUsed(ledger_seq))
+        .unwrap_or(0)
+}
+
+/// Record `gas` as consumed by `tenant` on `ledger_seq`, updating both the
+/// per-tenant and ledger-wide running totals.
+pub fn record_gas_used(env: &Env, tenant: &Address, ledger_seq: u32, gas: u64) {
+    let tenant_used = get_tenant_ledger_gas_used(env, tenant, ledger_seq).saturating_add(gas);
+    env.storage().temporary().set(
+        &DataKey::TenantLedgerGasUsed(tenant.clone(), ledger_seq),
+        &tenant_used,
+    );
+    // Keep the accounting entry alive for the rest of this ledger.
+    env.storage().temporary().extend_ttl(
+        &DataKey::TenantLedgerGasUsed(tenant.clone(), ledger_seq),
+        1,
+        1,
+    );
+
+    let ledger_used = get_ledger_gas_used(env, ledger_seq).saturating_add(gas);
+    env.storage()
+        .temporary()
+        .set(&DataKey::LedgerGasUsed(ledger_seq), &ledger_used);
+    env.storage()
+        .temporary()
+        .extend_ttl(&DataKey::LedgerGasUsed(ledger_seq), 1, 1);
+}
+
+pub fn get_reveal_continuation(env: &Env, tenant: &Address) -> Option<RevealBatchContinuation> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::RevealContinuation(tenant.clone()))
+}
+
+pub fn set_reveal_continuation(env: &Env, tenant: &Address, continuation: &RevealBatchContinuation) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::RevealContinuation(tenant.clone()), continuation);
+    bump_persistent(env, &DataKey::RevealContinuation(tenant.clone()));
+}
+
+pub fn clear_reveal_continuation(env: &Env, tenant: &Address) {
+    env.storage()
+        .persistent()
+        .remove(&DataKey::RevealContinuation(tenant.clone()));
+}
+
+pub fn get_settle_continuation(env: &Env, tenant: &Address) -> Option<SettleBatchContinuation> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::SettleContinuation(tenant.clone()))
+}
+
+pub fn set_settle_continuation(env: &Env, tenant: &Address, continuation: &SettleBatchContinuation) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::SettleContinuation(tenant.clone()), continuation);
+    bump_persistent(env, &DataKey::SettleContinuation(tenant.clone()));
+}
+
+pub fn clear_settle_continuation(env: &Env, tenant: &Address) {
+    env.storage()
+        .persistent()
+        .remove(&DataKey::SettleContinuation(tenant.clone()));
 }

--- a/contracts/token-factory/src/storage.rs
+++ b/contracts/token-factory/src/storage.rs
@@ -1,7 +1,7 @@
 use soroban_sdk::{Address, Env, Vec};
 
 use crate::types::{
-    BuybackCampaign, DataKey, Error, FactoryState, RevealBatchContinuation,
+    BuybackCampaign, DataKey, Error, FactoryState, Reservation, RevealBatchContinuation,
     SettleBatchContinuation, StreamCursor, TokenInfo,
 };
 
@@ -2257,4 +2257,64 @@ pub fn clear_settle_continuation(env: &Env, tenant: &Address) {
     env.storage()
         .persistent()
         .remove(&DataKey::SettleContinuation(tenant.clone()));
+}
+
+// ============================================================
+// Cross-contract atomic settlement (#1624)
+// ============================================================
+
+/// Default timeout (in ledgers) before a `Prepared` reservation is
+/// considered stuck and eligible for `cleanup_stuck_reservation`.
+/// ~1 day at Stellar's ~5s average ledger close time.
+pub const DEFAULT_RESERVATION_TIMEOUT_LEDGERS: u32 = 17_280;
+
+pub fn next_reservation_id(env: &Env) -> u64 {
+    let id = env
+        .storage()
+        .instance()
+        .get(&DataKey::NextReservationId)
+        .unwrap_or(0u64);
+    env.storage()
+        .instance()
+        .set(&DataKey::NextReservationId, &(id + 1));
+    id
+}
+
+pub fn get_reservation(env: &Env, id: u64) -> Option<Reservation> {
+    env.storage().persistent().get(&DataKey::Reservation(id))
+}
+
+pub fn set_reservation(env: &Env, id: u64, reservation: &Reservation) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Reservation(id), reservation);
+    bump_persistent(env, &DataKey::Reservation(id));
+}
+
+/// Total currently reserved (prepared, not yet committed/aborted) against a
+/// token's max-supply headroom.
+pub fn get_reserved_total(env: &Env, token_index: u32) -> i128 {
+    env.storage()
+        .instance()
+        .get(&DataKey::ReservedTotal(token_index))
+        .unwrap_or(0)
+}
+
+pub fn set_reserved_total(env: &Env, token_index: u32, total: i128) {
+    env.storage()
+        .instance()
+        .set(&DataKey::ReservedTotal(token_index), &total);
+}
+
+pub fn get_reservation_timeout_ledgers(env: &Env) -> u32 {
+    env.storage()
+        .instance()
+        .get(&DataKey::ReservationTimeoutLedgers)
+        .unwrap_or(DEFAULT_RESERVATION_TIMEOUT_LEDGERS)
+}
+
+pub fn set_reservation_timeout_ledgers(env: &Env, ledgers: u32) {
+    env.storage()
+        .instance()
+        .set(&DataKey::ReservationTimeoutLedgers, &ledgers);
 }

--- a/contracts/token-factory/src/types.rs
+++ b/contracts/token-factory/src/types.rs
@@ -185,6 +185,50 @@ pub struct PreflightItemResult {
     pub error_code: u32,
 }
 
+/// Outcome of a single `schedule_batch_reveal` / `resume_batch_reveal` /
+/// `schedule_batch_settle` / `resume_batch_settle` call.
+///
+/// A batch is only ever split at item boundaries — `executed_count` items
+/// were fully committed to storage, `remaining_count` were not touched at
+/// all. `continuation_pending` is `true` when `remaining_count > 0`, in
+/// which case the tenant must call the matching `resume_*` entry point on a
+/// later ledger to make further progress.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct BatchScheduleResult {
+    pub executed_count: u32,
+    pub remaining_count: u32,
+    pub continuation_pending: bool,
+}
+
+/// Pending, gas-budget-deferred continuation of a `batch_reveal` call.
+///
+/// Persists the still-unexecuted tail of the batch so it can resume on a
+/// later ledger without re-validating or re-executing already-committed
+/// items.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RevealBatchContinuation {
+    pub creator: Address,
+    pub remaining_tokens: Vec<TokenCreationParams>,
+    /// Fee payment remaining to cover `remaining_tokens`.
+    pub remaining_fee_payment: i128,
+    /// Ledger sequence this continuation last executed a chunk on.
+    pub last_activity_ledger: u32,
+}
+
+/// Pending, gas-budget-deferred continuation of a `batch_settle` call.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SettleBatchContinuation {
+    pub creator: Address,
+    pub token_index: u32,
+    pub remaining_recipients: Vec<(Address, i128)>,
+    pub minted_so_far: i128,
+    /// Ledger sequence this continuation last executed a chunk on.
+    pub last_activity_ledger: u32,
+}
+
 /// Timelock configuration
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -843,6 +887,20 @@ pub enum DataKey {
     BurnScheduleCount,
     // Metadata update history count: token_index
     MetadataHistoryCount(u32),
+    // Gas-bounded batch scheduler (#1625)
+    /// Configurable per-ledger gas budget (CPU instructions) shared by all tenants.
+    BatchGasBudget,
+    /// Ordered set of tenant addresses with a pending batch continuation,
+    /// used for round-robin fair-share scheduling.
+    FairShareQueue,
+    /// Gas already consumed by a tenant on a given ledger: (tenant, ledger_seq).
+    TenantLedgerGasUsed(Address, u32),
+    /// Total gas consumed by all tenants on a given ledger.
+    LedgerGasUsed(u32),
+    /// Pending `batch_reveal` continuation for a tenant.
+    RevealContinuation(Address),
+    /// Pending `batch_settle` continuation for a tenant.
+    SettleContinuation(Address),
 }
 
 /// A point-in-time record of a token holder's balance.
@@ -1159,6 +1217,13 @@ impl Error {
     pub const DistributionZeroSupply: Self = Self(105);
     // Multisig errors
     pub const DuplicateSigners: Self = Self(106);
+    // Gas-bounded batch scheduler errors (#1625)
+    /// No batch continuation is pending for this tenant.
+    pub const NoContinuationPending: Self = Self(107);
+    /// A continuation can only be resumed on a ledger after the one it last made progress on.
+    pub const ContinuationNotYetEligible: Self = Self(108);
+    /// Tenant already has an in-flight continuation of this kind; resume or wait for it to drain first.
+    pub const ContinuationAlreadyPending: Self = Self(109);
 }
 
 impl From<Error> for soroban_sdk::Error {

--- a/contracts/token-factory/src/types.rs
+++ b/contracts/token-factory/src/types.rs
@@ -217,6 +217,36 @@ pub struct RevealBatchContinuation {
     pub last_activity_ledger: u32,
 }
 
+/// Lifecycle state of a cross-contract settlement `Reservation` (#1624).
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ReservationStatus {
+    /// Amount reserved against max-supply headroom; not yet minted.
+    Prepared = 0,
+    /// Reservation finalized — tokens minted to `recipient`.
+    Committed = 1,
+    /// Reservation released without minting (explicit abort, failed commit,
+    /// or timeout cleanup).
+    Aborted = 2,
+}
+
+/// A two-phase-commit reservation for a cross-contract treasury
+/// disbursement, created by `prepare_settlement` and resolved by exactly one
+/// of `commit_settlement`, `abort_settlement`, or `cleanup_stuck_reservation`.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Reservation {
+    pub id: u64,
+    /// Governance-side proposal id this reservation was created for.
+    pub proposal_id: u64,
+    pub recipient: Address,
+    pub token_index: u32,
+    pub amount: i128,
+    pub status: ReservationStatus,
+    /// Ledger sequence the reservation was created (`prepare`d) on.
+    pub created_ledger: u32,
+}
+
 /// Pending, gas-budget-deferred continuation of a `batch_settle` call.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -887,6 +917,17 @@ pub enum DataKey {
     BurnScheduleCount,
     // Metadata update history count: token_index
     MetadataHistoryCount(u32),
+    // Cross-contract atomic settlement (#1624)
+    /// Auto-incrementing counter for reservation ids.
+    NextReservationId,
+    /// A prepare/commit/abort reservation, keyed by its id.
+    Reservation(u64),
+    /// Sum of amounts currently reserved (prepared but not yet committed or
+    /// aborted) against a token's max-supply headroom: token_index -> total.
+    ReservedTotal(u32),
+    /// Admin-configurable timeout (in ledgers) after which a reservation
+    /// stuck in `Prepared` may be force-released via `cleanup_stuck_reservation`.
+    ReservationTimeoutLedgers,
     // Gas-bounded batch scheduler (#1625)
     /// Configurable per-ledger gas budget (CPU instructions) shared by all tenants.
     BatchGasBudget,
@@ -1224,6 +1265,13 @@ impl Error {
     pub const ContinuationNotYetEligible: Self = Self(108);
     /// Tenant already has an in-flight continuation of this kind; resume or wait for it to drain first.
     pub const ContinuationAlreadyPending: Self = Self(109);
+    // Cross-contract atomic settlement errors (#1624)
+    /// No reservation exists for the given id.
+    pub const ReservationNotFound: Self = Self(110);
+    /// The reservation is not in `Prepared` state (already committed/aborted).
+    pub const ReservationNotPending: Self = Self(111);
+    /// The reservation's timeout window has not yet elapsed; cleanup is not allowed yet.
+    pub const ReservationNotYetStuck: Self = Self(112);
 }
 
 impl From<Error> for soroban_sdk::Error {


### PR DESCRIPTION
## Summary

Four related hard/complex issues, implemented on one branch:

### #1625 — Gas-bounded batch execution scheduler with fair cross-tenant scheduling
- Adds `schedule_batch_reveal`/`resume_batch_reveal` and `schedule_batch_settle`/`resume_batch_settle` in `token-factory`, alongside the existing atomic `batch_reveal`/`batch_settle`.
- Per-item gas is estimated (calibrated against the CPU-instruction thresholds in `gas_compute_thresholds.rs`) and execution is capped at item boundaries by a configurable per-ledger gas budget (`set_batch_gas_budget`/`get_batch_gas_budget`).
- Any remainder is persisted as a per-tenant continuation (`RevealBatchContinuation`/`SettleBatchContinuation`) resumable on a later ledger — never a partial item.
- When multiple tenants have pending continuations in the same ledger, the ledger's gas budget is split evenly across them (fair-share), so one tenant's oversized batch can't starve another's queued batch.

### #1622 — Zero-downtime live schema migration framework with dual-write shadow verification
- Adds `MigrationOrchestrator` (`backend/src/services/migrationOrchestrator.ts`) managing the dual-write / backfill / verify / cutover / cleanup lifecycle for migrating a live Postgres table without blocking writers or losing in-flight writes.
- Dual-writes are mirrored transparently through a Prisma middleware (`$use`) — no per-call-site changes required.
- Parity verification compares every row (not a sample) and hard-blocks cutover on any mismatch.
- Cutover and rollback are both single atomic `CREATE OR REPLACE VIEW` statements — never a data copy.
- `recordPostCutoverOutcome` tracks a rolling post-cutover error rate and automatically rolls back if it crosses a configurable threshold.

### #1624 — Cross-contract atomic settlement protocol between token-factory and governance
- Adds a `Reservation`-backed prepare/commit/abort protocol in `token-factory`, callable only by the configured governance contract: `prepare_settlement` reserves an amount against a token's max-supply headroom, `commit_settlement` finalizes it by minting, `abort_settlement` releases it.
- A failed commit leaves the reservation `Prepared` (untouched) so the caller can explicitly abort rather than lose the funds — never silently dropped.
- A permissionless `cleanup_stuck_reservation` force-releases any reservation left unresolved past a configurable timeout.
- Wires governance's `execute_proposal` to call prepare → commit (via `Env::try_invoke_contract`, since governance and token-factory pin different soroban-sdk major versions and share no generated client) and to abort on any commit failure, before setting proposal state to `Executed` — never before. Proposals attach a disbursement via a new `attach_disbursement` entry point, keeping `create_proposal`'s existing signature untouched.

### #1623 — Cross-contract invariant fuzzing harness for token supply and voting power
- Adds a cargo-fuzz target under `token-factory/fuzz/` that deploys token-factory natively and governance from its pre-built wasm artifact (via `soroban_sdk::contractimport!`) in one `Env`.
- Generates arbitrary interleaved sequences of mint/burn/delegate/undelegate/vote and asserts the cross-contract invariant — total governance voting power must never exceed token-factory's real total supply — after every single operation, not just at the end.
- Wires `cross_contract_invariants` into `fuzz-testing.yml` (builds `governance.wasm` first, then runs `cargo fuzz run ... -max_total_time=120`).
- Design writeup in `contracts/token-factory/docs/CROSS_CONTRACT_INVARIANT_FUZZING.txt`.

## Notes for reviewers
- Per the requester's instructions for this batch, tests were not written or run for these changes, and no build/test proof-of-work screenshots are attached — please run the full suites before merging.
- While implementing, I found a **pre-existing** compile break unrelated to this PR: `storage.rs` on `main` references `DataKey::RecurringStream*` variants that don't exist in the `DataKey` enum. Left untouched (out of scope) but flagging for visibility.
- The #1623 fuzz target requires `governance.wasm` to be built first (`cargo build -p governance --release --target wasm32-unknown-unknown`) since `contractimport!` reads it at compile time — documented in the txt file above and wired into the CI job.

Closes #1625
Closes #1622
Closes #1624
Closes #1623