### PR TITLE
fix(contracts): campaign cancel, governance bounds, checked arithmetic, timelock overflow

### DIFF
--- a/contracts/governance/src/governance_bounds_test.rs
+++ b/contracts/governance/src/governance_bounds_test.rs
@@ -1,0 +1,225 @@
+//! Tests for issue #1678: bounds validation in create_proposal
+//! Tests for issue #1679: checked arithmetic in finalize_proposal
+
+#![cfg(test)]
+
+use crate::{GovernanceContract, GovernanceContractClient};
+use crate::types::ProposalStatus;
+use soroban_sdk::{testutils::Address as _, Address, Bytes, Env, String};
+
+// ─── Helpers ──────────────────────────────────────────────────────────────
+
+fn setup() -> (Env, GovernanceContractClient<'static>, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, GovernanceContract);
+    let client = GovernanceContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin, &10_000_000_i128);
+    (env, client, admin)
+}
+
+// ─── #1678 — create_proposal bounds validation ────────────────────────────
+
+/// threshold_percent > 100 must be rejected
+#[test]
+fn test_create_proposal_rejects_threshold_above_100() {
+    let (env, client, creator) = setup();
+    let result = client.try_create_proposal(
+        &creator,
+        &String::from_str(&env, "bad threshold"),
+        &Bytes::new(&env),
+        &3600_u64,   // valid voting_period
+        &1000_i128,  // valid quorum
+        &101_u32,    // invalid: > 100
+    );
+    assert!(result.is_err(), "threshold_percent=101 must be rejected");
+}
+
+/// threshold_percent == 100 must be accepted (exact boundary)
+#[test]
+fn test_create_proposal_accepts_threshold_100() {
+    let (env, client, creator) = setup();
+    let result = client.try_create_proposal(
+        &creator,
+        &String::from_str(&env, "max threshold"),
+        &Bytes::new(&env),
+        &3600_u64,
+        &1000_i128,
+        &100_u32,
+    );
+    assert!(result.is_ok(), "threshold_percent=100 is a valid boundary");
+}
+
+/// threshold_percent == 0 must be accepted (minimum valid boundary)
+#[test]
+fn test_create_proposal_accepts_threshold_0() {
+    let (env, client, creator) = setup();
+    let result = client.try_create_proposal(
+        &creator,
+        &String::from_str(&env, "zero threshold"),
+        &Bytes::new(&env),
+        &3600_u64,
+        &1000_i128,
+        &0_u32,
+    );
+    assert!(result.is_ok(), "threshold_percent=0 is a valid boundary");
+}
+
+/// quorum == 0 must be rejected
+#[test]
+fn test_create_proposal_rejects_zero_quorum() {
+    let (env, client, creator) = setup();
+    let result = client.try_create_proposal(
+        &creator,
+        &String::from_str(&env, "zero quorum"),
+        &Bytes::new(&env),
+        &3600_u64,
+        &0_i128,   // invalid: zero quorum
+        &50_u32,
+    );
+    assert!(result.is_err(), "quorum=0 must be rejected");
+}
+
+/// quorum < 0 must be rejected
+#[test]
+fn test_create_proposal_rejects_negative_quorum() {
+    let (env, client, creator) = setup();
+    let result = client.try_create_proposal(
+        &creator,
+        &String::from_str(&env, "negative quorum"),
+        &Bytes::new(&env),
+        &3600_u64,
+        &-1_i128,  // invalid: negative quorum
+        &50_u32,
+    );
+    assert!(result.is_err(), "quorum=-1 must be rejected");
+}
+
+/// quorum == 1 must be accepted (minimum valid positive boundary)
+#[test]
+fn test_create_proposal_accepts_quorum_1() {
+    let (env, client, creator) = setup();
+    let result = client.try_create_proposal(
+        &creator,
+        &String::from_str(&env, "quorum 1"),
+        &Bytes::new(&env),
+        &3600_u64,
+        &1_i128,
+        &50_u32,
+    );
+    assert!(result.is_ok(), "quorum=1 is the minimum valid positive boundary");
+}
+
+/// voting_period == 0 must be rejected
+#[test]
+fn test_create_proposal_rejects_zero_voting_period() {
+    let (env, client, creator) = setup();
+    let result = client.try_create_proposal(
+        &creator,
+        &String::from_str(&env, "zero period"),
+        &Bytes::new(&env),
+        &0_u64,     // invalid: zero voting_period
+        &1000_i128,
+        &50_u32,
+    );
+    assert!(result.is_err(), "voting_period=0 must be rejected");
+}
+
+/// voting_period == 1 must be accepted (minimum valid boundary)
+#[test]
+fn test_create_proposal_accepts_voting_period_1() {
+    let (env, client, creator) = setup();
+    let result = client.try_create_proposal(
+        &creator,
+        &String::from_str(&env, "period 1"),
+        &Bytes::new(&env),
+        &1_u64,
+        &1000_i128,
+        &50_u32,
+    );
+    assert!(result.is_ok(), "voting_period=1 is the minimum valid positive boundary");
+}
+
+// ─── #1679 — finalize_proposal checked arithmetic ─────────────────────────
+
+/// Normal finalization should still succeed (regression guard)
+#[test]
+fn test_finalize_proposal_normal_path() {
+    let (env, client, admin) = setup();
+    let creator = Address::generate(&env);
+
+    // Give creator some balance so they can vote
+    client.set_balance(&admin, &creator, &1_000_i128);
+
+    let proposal_id = client.create_proposal(
+        &creator,
+        &String::from_str(&env, "normal proposal"),
+        &Bytes::new(&env),
+        &100_u64,    // voting_period = 100 seconds
+        &1_i128,     // quorum = 1
+        &50_u32,     // threshold = 50%
+    );
+
+    // Cast a vote
+    client.cast_vote(&creator, &proposal_id, &true);
+
+    // Advance ledger past voting end
+    env.ledger().with_mut(|li| {
+        li.timestamp += 200;
+    });
+
+    let status = client.finalize_proposal(&proposal_id);
+    assert_eq!(status, ProposalStatus::Passed);
+}
+
+/// Finalization with votes_for + votes_against overflow must return ArithmeticOverflow,
+/// not panic. We simulate this by injecting a proposal with i128::MAX in both fields
+/// through the storage layer directly, then finalising it.
+#[test]
+fn test_finalize_proposal_overflow_returns_typed_error() {
+    use crate::storage;
+    use crate::types::{GovernanceProposal, ProposalStatus};
+    use soroban_sdk::Bytes;
+
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, GovernanceContract);
+
+    // Initialize the contract
+    let admin = Address::generate(&env);
+    let client = GovernanceContractClient::new(&env, &contract_id);
+    client.initialize(&admin, &10_000_000_i128);
+
+    // Build a proposal where votes_for + votes_against would overflow i128
+    let overflowing_proposal = GovernanceProposal {
+        id: 0,
+        creator: admin.clone(),
+        description: String::from_str(&env, "overflow test"),
+        voting_end: 0,   // already ended (timestamp starts at 0)
+        quorum: 1_i128,
+        threshold_percent: 50,
+        votes_for: i128::MAX,
+        votes_against: 1,
+        payload: Bytes::new(&env),
+        status: ProposalStatus::Active,
+    };
+
+    // Write directly to storage inside the contract's context
+    env.as_contract(&contract_id, || {
+        storage::set_proposal(&env, 0, &overflowing_proposal);
+        storage::set_proposal_count(&env, 1);
+    });
+
+    // Advance time past voting_end so finalization is allowed
+    env.ledger().with_mut(|li| {
+        li.timestamp = 100;
+    });
+
+    // Should return a typed error, not panic
+    let result = client.try_finalize_proposal(&0_u32);
+    assert!(
+        result.is_err(),
+        "overflow during total_votes calculation must return an error, not panic"
+    );
+}

--- a/contracts/governance/src/governance_test.rs
+++ b/contracts/governance/src/governance_test.rs
@@ -555,10 +555,13 @@ fn proposal_finalize_after_voting_period_ends() {
         &creator,
         &String::from_str(&env, "Test proposal"),
         &soroban_sdk::Bytes::new(&env),
-        &0_u64, // Voting period ends immediately
+        &1_u64, // Minimum valid voting period
         &50_i128,
         &50_u32,
     );
+
+    // Advance past the voting period
+    env.ledger().with_mut(|li| { li.timestamp += 2; });
 
     // Finalization should succeed after voting period ends
     let status = c.finalize_proposal(&proposal_id);
@@ -581,12 +584,15 @@ fn proposal_state_active_to_passed() {
         &creator,
         &String::from_str(&env, "Test proposal"),
         &soroban_sdk::Bytes::new(&env),
-        &0_u64,
+        &1_u64,
         &50_i128,  // Quorum: 50
         &50_u32,   // Threshold: 50%
     );
 
     c.cast_vote(&voter, &proposal_id, &true);
+
+    // Advance past the voting period
+    env.ledger().with_mut(|li| { li.timestamp += 2; });
 
     let status = c.finalize_proposal(&proposal_id);
     assert_eq!(status, types::ProposalStatus::Passed);
@@ -607,13 +613,16 @@ fn proposal_state_active_to_rejected() {
         &creator,
         &String::from_str(&env, "Test proposal"),
         &soroban_sdk::Bytes::new(&env),
-        &0_u64,
+        &1_u64,
         &100_i128, // Quorum: 100
         &50_u32,   // Threshold: 50%
     );
 
     c.cast_vote(&voter1, &proposal_id, &true);  // 100 for
     c.cast_vote(&voter2, &proposal_id, &false); // 100 against
+
+    // Advance past the voting period
+    env.ledger().with_mut(|li| { li.timestamp += 2; });
 
     let status = c.finalize_proposal(&proposal_id);
     assert_eq!(status, types::ProposalStatus::Rejected);
@@ -632,12 +641,15 @@ fn proposal_state_active_to_failed_no_quorum() {
         &creator,
         &String::from_str(&env, "Test proposal"),
         &soroban_sdk::Bytes::new(&env),
-        &0_u64,
+        &1_u64,
         &100_i128, // Quorum: 100 (not met)
         &50_u32,
     );
 
     c.cast_vote(&voter, &proposal_id, &true);
+
+    // Advance past the voting period
+    env.ledger().with_mut(|li| { li.timestamp += 2; });
 
     let status = c.finalize_proposal(&proposal_id);
     assert_eq!(status, types::ProposalStatus::Failed);
@@ -778,13 +790,16 @@ fn proposal_vote_rounding_behavior() {
         &creator,
         &String::from_str(&env, "Test proposal"),
         &soroban_sdk::Bytes::new(&env),
-        &0_u64,
+        &1_u64,
         &150_i128,
         &33_u32, // 33% threshold
     );
 
     c.cast_vote(&voter1, &proposal_id, &true);  // 100 for
     c.cast_vote(&voter2, &proposal_id, &false); // 100 against
+
+    // Advance past voting period
+    env.ledger().with_mut(|li| { li.timestamp += 2; });
 
     // Total: 200 votes, threshold: (200 * 33) / 100 = 66
     // For: 100 > 66, so should pass
@@ -809,7 +824,7 @@ fn proposal_lifecycle_creation_to_completion() {
         &creator,
         &String::from_str(&env, "Full lifecycle proposal"),
         &soroban_sdk::Bytes::new(&env),
-        &0_u64,
+        &1_u64,
         &50_i128,
         &50_u32,
     );
@@ -823,6 +838,9 @@ fn proposal_lifecycle_creation_to_completion() {
     // Verify proposal is still active
     let proposal = c.get_proposal(&proposal_id).unwrap();
     assert_eq!(proposal.status, types::ProposalStatus::Active);
+
+    // Advance past voting period
+    env.ledger().with_mut(|li| { li.timestamp += 2; });
 
     // Step 3: Finalize (transition to terminal state)
     let status = c.finalize_proposal(&proposal_id);

--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -151,8 +151,20 @@ impl GovernanceContract {
         voting_period: u64,
         quorum: i128,
         threshold_percent: u32,
-    ) -> u32 {
+    ) -> Result<u32, Error> {
         creator.require_auth();
+
+        // Bounds validation — reject malformed proposals before any storage write
+        if threshold_percent > 100 {
+            return Err(Error::InvalidParameters);
+        }
+        if quorum <= 0 {
+            return Err(Error::InvalidParameters);
+        }
+        if voting_period == 0 {
+            return Err(Error::InvalidParameters);
+        }
+
         let proposal_id = storage::get_proposal_count(&env);
         let voting_end = env.ledger().timestamp() + voting_period;
         let proposal = GovernanceProposal {
@@ -169,7 +181,7 @@ impl GovernanceContract {
         };
         storage::set_proposal(&env, proposal_id, &proposal);
         storage::set_proposal_count(&env, proposal_id + 1);
-        proposal_id
+        Ok(proposal_id)
     }
 
     /// Execute a passed proposal (atomically with state change)
@@ -264,12 +276,17 @@ impl GovernanceContract {
         if env.ledger().timestamp() <= proposal.voting_end {
             return Err(FinalizationError::VotingPeriodNotEnded);
         }
-        let total_votes = proposal.votes_for + proposal.votes_against;
+        let total_votes = proposal
+            .votes_for
+            .checked_add(proposal.votes_against)
+            .ok_or(FinalizationError::ArithmeticOverflow)?;
         let final_status = if total_votes < proposal.quorum {
             ProposalStatus::Failed
         } else {
-            let threshold_votes =
-                (total_votes * proposal.threshold_percent as i128) / 100;
+            let threshold_votes = total_votes
+                .checked_mul(proposal.threshold_percent as i128)
+                .ok_or(FinalizationError::ArithmeticOverflow)?
+                / 100;
             if proposal.votes_for > threshold_votes {
                 ProposalStatus::Passed
             } else {
@@ -295,3 +312,6 @@ mod governance_test;
 
 #[cfg(test)]
 mod governance_property_test;
+
+#[cfg(test)]
+mod governance_bounds_test;

--- a/contracts/governance/src/types.rs
+++ b/contracts/governance/src/types.rs
@@ -172,4 +172,6 @@ pub enum FinalizationError {
     AlreadyFinalized = 3,
     AlreadyExecuted = 4,
     ProposalNotPassed = 5,
+    /// Checked arithmetic overflow during vote-total or threshold computation
+    ArithmeticOverflow = 6,
 }

--- a/contracts/token-factory/src/campaign.rs
+++ b/contracts/token-factory/src/campaign.rs
@@ -165,6 +165,77 @@ pub fn resume_campaign(env: &Env, caller: &Address, campaign_id: u64) -> Result<
     Ok(())
 }
 
+/// Cancel a campaign
+///
+/// Permanently cancels a campaign, transitioning it to the Cancelled terminal
+/// state. Only the campaign owner or admin can cancel a campaign. Cancellation
+/// is accepted from Active or Paused; it is rejected from any terminal state
+/// (Completed, Cancelled, Expired).
+///
+/// # State Transitions
+/// Active -> Cancelled
+/// Paused -> Cancelled
+///
+/// # Arguments
+/// * `env` - The contract environment
+/// * `caller` - Address requesting cancellation (must be owner or admin)
+/// * `campaign_id` - ID of the campaign to cancel
+///
+/// # Returns
+/// * `Ok(())` - Campaign successfully cancelled
+/// * `Err(Error::CampaignNotFound)` - Campaign does not exist
+/// * `Err(Error::Unauthorized)` - Caller is not owner or admin
+/// * `Err(Error::CampaignCompleted)` - Cannot cancel a completed campaign
+/// * `Err(Error::CampaignCancelled)` - Campaign is already cancelled
+/// * `Err(Error::InvalidStateTransition)` - Invalid state transition
+///
+/// # Examples
+/// ```ignore
+/// cancel_campaign(&env, &admin, 1)?;
+/// ```
+pub fn cancel_campaign(env: &Env, caller: &Address, campaign_id: u64) -> Result<(), Error> {
+    caller.require_auth();
+
+    // Load campaign
+    let mut campaign = storage::get_campaign(env, campaign_id).ok_or(Error::CampaignNotFound)?;
+
+    // Authorization check: must be owner or admin
+    let admin = storage::get_admin(env);
+    if *caller != campaign.owner && *caller != admin {
+        return Err(Error::Unauthorized);
+    }
+
+    // State transition validation — reject terminal states
+    match campaign.status {
+        CampaignStatus::Active | CampaignStatus::Paused => {
+            // Valid transitions: Active -> Cancelled, Paused -> Cancelled
+            campaign.status = CampaignStatus::Cancelled;
+        }
+        CampaignStatus::Completed => {
+            // Terminal state: cannot cancel a completed campaign
+            return Err(Error::CampaignCompleted);
+        }
+        CampaignStatus::Cancelled => {
+            // Already in terminal state
+            return Err(Error::CampaignCancelled);
+        }
+        CampaignStatus::Expired => {
+            // Terminal state: cannot cancel an expired campaign
+            return Err(Error::CampaignExpiredError);
+        }
+    }
+
+    let budget_remaining = campaign.budget.saturating_sub(campaign.spent);
+
+    // Persist state change
+    storage::set_campaign(env, campaign_id, &campaign);
+
+    // Emit event consistent with other campaign state-change functions
+    events::emit_campaign_cancelled(env, campaign_id, caller, budget_remaining);
+
+    Ok(())
+}
+
 /// Finalize a campaign, transitioning it to Completed.
 ///
 /// Only the campaign owner or admin may finalize. The campaign must be Active
@@ -384,6 +455,98 @@ mod tests {
             storage::set_campaign(env, 1, &campaign);
 
             let result = pause_campaign(env, &attacker, 1);
+            assert_eq!(result, Err(Error::Unauthorized));
+        });
+    }
+
+    // ── cancel_campaign tests ────────────────────────────────────────────
+
+    #[test]
+    fn test_cancel_active_campaign() {
+        let test_env = TestEnv::new();
+        let env = &test_env.env;
+        let admin = &test_env.admin;
+
+        env.as_contract(&env.current_contract_address(), || {
+            let campaign = make_campaign(env, admin, CampaignStatus::Active);
+            storage::set_campaign(env, 1, &campaign);
+
+            let result = cancel_campaign(env, admin, 1);
+            assert!(result.is_ok(), "cancel from Active should succeed");
+
+            let updated = storage::get_campaign(env, 1).unwrap();
+            assert_eq!(updated.status, CampaignStatus::Cancelled);
+        });
+    }
+
+    #[test]
+    fn test_cancel_paused_campaign() {
+        let test_env = TestEnv::new();
+        let env = &test_env.env;
+        let admin = &test_env.admin;
+
+        env.as_contract(&env.current_contract_address(), || {
+            let campaign = make_campaign(env, admin, CampaignStatus::Paused);
+            storage::set_campaign(env, 1, &campaign);
+
+            let result = cancel_campaign(env, admin, 1);
+            assert!(result.is_ok(), "cancel from Paused should succeed");
+
+            let updated = storage::get_campaign(env, 1).unwrap();
+            assert_eq!(updated.status, CampaignStatus::Cancelled);
+        });
+    }
+
+    #[test]
+    fn test_cancel_completed_campaign_fails() {
+        let test_env = TestEnv::new();
+        let env = &test_env.env;
+        let admin = &test_env.admin;
+
+        env.as_contract(&env.current_contract_address(), || {
+            let campaign = make_campaign(env, admin, CampaignStatus::Completed);
+            storage::set_campaign(env, 1, &campaign);
+
+            let result = cancel_campaign(env, admin, 1);
+            assert_eq!(
+                result,
+                Err(Error::CampaignCompleted),
+                "cancel from Completed (terminal) must be rejected"
+            );
+        });
+    }
+
+    #[test]
+    fn test_cancel_already_cancelled_campaign_fails() {
+        let test_env = TestEnv::new();
+        let env = &test_env.env;
+        let admin = &test_env.admin;
+
+        env.as_contract(&env.current_contract_address(), || {
+            let campaign = make_campaign(env, admin, CampaignStatus::Cancelled);
+            storage::set_campaign(env, 1, &campaign);
+
+            let result = cancel_campaign(env, admin, 1);
+            assert_eq!(
+                result,
+                Err(Error::CampaignCancelled),
+                "cancel from Cancelled (terminal) must be rejected"
+            );
+        });
+    }
+
+    #[test]
+    fn test_cancel_unauthorized_fails() {
+        let test_env = TestEnv::new();
+        let env = &test_env.env;
+        let admin = &test_env.admin;
+        let attacker = Address::generate(env);
+
+        env.as_contract(&env.current_contract_address(), || {
+            let campaign = make_campaign(env, admin, CampaignStatus::Active);
+            storage::set_campaign(env, 1, &campaign);
+
+            let result = cancel_campaign(env, &attacker, 1);
             assert_eq!(result, Err(Error::Unauthorized));
         });
     }

--- a/contracts/token-factory/src/lib.rs
+++ b/contracts/token-factory/src/lib.rs
@@ -3911,6 +3911,14 @@ impl TokenFactory {
         storage::get_campaign(&env, campaign_id).ok_or(Error::CampaignNotFound)
     }
 
+    /// Cancel a campaign (Active or Paused → Cancelled).
+    ///
+    /// Permanently cancels the campaign, preventing any further state changes.
+    /// Rejected from terminal states (Completed, Cancelled, Expired).
+    pub fn cancel_campaign(env: Env, caller: Address, campaign_id: u64) -> Result<(), Error> {
+        campaign::cancel_campaign(&env, &caller, campaign_id)
+    }
+
     /// Finalize a campaign (Active or Paused → Completed). Safe to retry on failure.
     pub fn finalize_campaign(env: Env, caller: Address, campaign_id: u64) -> Result<(), Error> {
         campaign::finalize_campaign(&env, &caller, campaign_id)

--- a/contracts/token-factory/src/timelock.rs
+++ b/contracts/token-factory/src/timelock.rs
@@ -1123,19 +1123,19 @@ pub fn vote_proposal(
             proposal.votes_for = proposal
                 .votes_for
                 .checked_add(1)
-                .expect("Vote count overflow");
+                .ok_or(Error::ArithmeticError)?;
         }
         VoteChoice::Against => {
             proposal.votes_against = proposal
                 .votes_against
                 .checked_add(1)
-                .expect("Vote count overflow");
+                .ok_or(Error::ArithmeticError)?;
         }
         VoteChoice::Abstain => {
             proposal.votes_abstain = proposal
                 .votes_abstain
                 .checked_add(1)
-                .expect("Vote count overflow");
+                .ok_or(Error::ArithmeticError)?;
         }
     }
 

--- a/contracts/token-factory/src/timelock_test.rs
+++ b/contracts/token-factory/src/timelock_test.rs
@@ -3,6 +3,129 @@
 use crate::{TokenFactory, TokenFactoryClient};
 use soroban_sdk::{testutils::Address as _, Address, Env};
 
+// ── #1680: vote_proposal overflow returns typed error, not panic ───────────
+
+/// Inject a proposal whose vote counter is already at i128::MAX, then cast
+/// one more vote and verify that Error::ArithmeticError is returned instead
+/// of panicking.
+#[test]
+fn test_vote_proposal_overflow_returns_typed_error() {
+    use crate::storage;
+    use crate::timelock::vote_proposal;
+    use crate::types::{
+        ActionType, Bytes, Error, Proposal, ProposalState, String, VoteChoice,
+    };
+    use soroban_sdk::testutils::Ledger;
+
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, TokenFactory);
+
+    let admin = Address::generate(&env);
+    let voter = Address::generate(&env);
+
+    // Build an overflowing proposal directly in storage
+    env.as_contract(&contract_id, || {
+        storage::set_admin(&env, &admin);
+        storage::set_treasury(&env, &admin);
+        storage::set_base_fee(&env, 1_000_000);
+        storage::set_metadata_fee(&env, 500_000);
+
+        let now = env.ledger().timestamp();
+
+        let proposal = Proposal {
+            id: 0,
+            proposer: admin.clone(),
+            action_type: ActionType::FeeChange,
+            payload: Bytes::new(&env),
+            description: String::from_str(&env, "overflow test"),
+            created_at: now,
+            start_time: now,
+            // Set end_time far in the future so voting window is open
+            end_time: now + 86_400,
+            eta: now + 90_000,
+            timelock_delay: 0,
+            queued_at_ledger: 0,
+            // votes_for already at i128::MAX — next checked_add(1) overflows
+            votes_for: i128::MAX,
+            votes_against: 0,
+            votes_abstain: 0,
+            state: ProposalState::Active,
+            executed_at: None,
+            cancelled_at: None,
+            circulating_supply_snapshot: 1_000_000,
+        };
+
+        storage::set_proposal(&env, 0, &proposal);
+
+        // Voter must not have voted yet
+        let result = vote_proposal(&env, &voter, 0, VoteChoice::For);
+        assert_eq!(
+            result,
+            Err(Error::ArithmeticError),
+            "votes_for overflow must return ArithmeticError, not panic"
+        );
+    });
+}
+
+/// Same test for votes_against overflow path.
+#[test]
+fn test_vote_proposal_against_overflow_returns_typed_error() {
+    use crate::storage;
+    use crate::timelock::vote_proposal;
+    use crate::types::{
+        ActionType, Bytes, Error, Proposal, ProposalState, String, VoteChoice,
+    };
+    use soroban_sdk::testutils::Ledger;
+
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, TokenFactory);
+
+    let admin = Address::generate(&env);
+    let voter = Address::generate(&env);
+
+    env.as_contract(&contract_id, || {
+        storage::set_admin(&env, &admin);
+        storage::set_treasury(&env, &admin);
+        storage::set_base_fee(&env, 1_000_000);
+        storage::set_metadata_fee(&env, 500_000);
+
+        let now = env.ledger().timestamp();
+
+        let proposal = Proposal {
+            id: 1,
+            proposer: admin.clone(),
+            action_type: ActionType::FeeChange,
+            payload: Bytes::new(&env),
+            description: String::from_str(&env, "against overflow test"),
+            created_at: now,
+            start_time: now,
+            end_time: now + 86_400,
+            eta: now + 90_000,
+            timelock_delay: 0,
+            queued_at_ledger: 0,
+            votes_for: 0,
+            // votes_against already at i128::MAX — next checked_add(1) overflows
+            votes_against: i128::MAX,
+            votes_abstain: 0,
+            state: ProposalState::Active,
+            executed_at: None,
+            cancelled_at: None,
+            circulating_supply_snapshot: 1_000_000,
+        };
+
+        storage::set_proposal(&env, 1, &proposal);
+
+        let result = vote_proposal(&env, &voter, 1, VoteChoice::Against);
+        assert_eq!(
+            result,
+            Err(Error::ArithmeticError),
+            "votes_against overflow must return ArithmeticError, not panic"
+        );
+    });
+}
+
 fn setup() -> (Env, Address, Address, Address) {
     let env = Env::default();
     env.mock_all_auths();


### PR DESCRIPTION
## Summary

Fixes four independently-reported contract bugs in a single atomic PR.

---

### #1677 — Implement the missing `cancel_campaign` transition

**File:** `contracts/token-factory/src/campaign.rs`, `src/lib.rs`

- Added `cancel_campaign` function accepting `Active` or `Paused` state, matching the auth/storage/event pattern of `pause_campaign`.
- Wired into the `#[contractimpl]` block in `lib.rs`.
- Emits `emit_campaign_cancelled` (already defined in `events.rs`) with `budget_remaining`.
- Rejects all terminal states (`Completed`, `Cancelled`, `Expired`) with the appropriate typed error.

**Tests added:** cancel from Active ✓, cancel from Paused ✓, reject from Completed ✓, reject from Cancelled ✓, reject from unauthorized caller ✓

---

### #1678 — Close the missing bounds-validation gap in governance `create_proposal`

**File:** `contracts/governance/src/lib.rs`

- Rejects `threshold_percent > 100` with `Error::InvalidParameters`.
- Rejects `quorum <= 0` with `Error::InvalidParameters`.
- Rejects `voting_period == 0` with `Error::InvalidParameters`.
- Return type changed from bare `u32` to `Result<u32, Error>` so errors propagate correctly.
- Updated existing `governance_test.rs` callers that used `voting_period=0` in non-panicking tests to use `voting_period=1` with a ledger advance.

**Tests added:** boundary values 0/100/101 for threshold; quorum -1/0/1; period 0/1 (in `governance_bounds_test.rs`)

---

### #1679 — Harden `finalize_proposal` arithmetic against overflow panics

**File:** `contracts/governance/src/lib.rs`, `src/types.rs`

- Replaced plain `+` and `*` in `finalize_proposal` with `checked_add`/`checked_mul`.
- Added `FinalizationError::ArithmeticOverflow = 6` variant to the error enum.
- Consistent with the checked-arithmetic pattern already used by `cast_vote`.

**Tests added:** normal finalization regression ✓, overflow path returns `ArithmeticOverflow` typed error instead of panicking ✓

---

### #1680 — Replace silent panic path in timelock vote counting with typed error

**File:** `contracts/token-factory/src/timelock.rs`, `src/timelock_test.rs`

- Replaced all three `.checked_add(1).expect("Vote count overflow")` calls (for `votes_for`, `votes_against`, `votes_abstain`) with `.ok_or(Error::ArithmeticError)?`.
- Success-path behavior is unchanged; only the overflow branch differs.

**Tests added:** `votes_for` overflow returns `ArithmeticError` ✓, `votes_against` overflow returns `ArithmeticError` ✓

---

Closes #1677
Closes #1678
Closes #1679
Closes #1680