### PR TITLE
Chore/contract reenable batch mint concurrency tests

### DIFF
--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -1,4 +1,16 @@
+//! Governance contract — public entry points.
+//!
+//! This crate provides an on-chain governance system for the Nova Launch
+//! platform. It supports:
+//!
+//! - **Vote-power delegation** (`delegate`, `undelegate`)
+//! - **Proposal lifecycle** (`create_proposal`, `cast_vote`, `finalize_proposal`,
+//!   `execute_proposal`)
+//! - **Vote-power snapshots** (`take_snapshot`, `get_snapshot_power`)
+//! - **Admin controls** (`initialize`, `set_balance`, `transfer_admin`,
+//!   `pause`, `unpause`)
 #![no_std]
+#![warn(missing_docs)]
 
 mod delegation;
 mod events;
@@ -13,10 +25,27 @@ use types::{
 };
 
 #[contract]
+/// The governance contract struct.
 pub struct GovernanceContract;
 
 #[contractimpl]
 impl GovernanceContract {
+    /// Initialize the governance contract.
+    ///
+    /// Must be called exactly once before any other operation. Sets the
+    /// contract admin and the total token supply used for vote-power
+    /// calculations.
+    ///
+    /// # Arguments
+    /// * `admin`        – Address that will have admin privileges.
+    /// * `total_supply` – Total token supply (must be positive).
+    ///
+    /// # Returns
+    /// `Ok(())` on success.
+    ///
+    /// # Errors
+    /// * [`Error::AlreadyInitialized`] – Contract has already been initialized.
+    /// * [`Error::InvalidParameters`] – `total_supply` is zero or negative.
     pub fn initialize(env: Env, admin: Address, total_supply: i128) -> Result<(), Error> {
         if storage::has_admin(&env) {
             return Err(Error::AlreadyInitialized);
@@ -30,34 +59,138 @@ impl GovernanceContract {
         Ok(())
     }
 
+    /// Delegate vote power from `delegator` to `delegatee`.
+    ///
+    /// The delegator's current balance is transferred to the delegatee's
+    /// vote-power tally. A delegator may only delegate to one address at a
+    /// time; calling this again replaces the previous delegation.
+    ///
+    /// # Arguments
+    /// * `delegator` – Address delegating its vote power (must authorize).
+    /// * `delegatee` – Address receiving the delegated vote power.
+    ///
+    /// # Returns
+    /// `Ok(())` on success.
+    ///
+    /// # Errors
+    /// * [`Error::InvalidParameters`] – `delegator == delegatee` (self-delegation).
+    /// * [`Error::CircularDelegation`] – Delegation would create a cycle.
+    /// * [`Error::DelegationChainTooDeep`] – Chain length would exceed the limit.
+    /// * [`Error::ContractPaused`] – Contract is paused.
     pub fn delegate(env: Env, delegator: Address, delegatee: Address) -> Result<(), Error> {
         delegation::delegate(&env, delegator, delegatee)
     }
 
+    /// Remove the active delegation for `delegator`.
+    ///
+    /// Returns the delegator's vote power back to itself. Has no effect if
+    /// no active delegation exists.
+    ///
+    /// # Arguments
+    /// * `delegator` – Address revoking its delegation (must authorize).
+    ///
+    /// # Returns
+    /// `Ok(())` on success.
+    ///
+    /// # Errors
+    /// * [`Error::ContractPaused`] – Contract is paused.
     pub fn undelegate(env: Env, delegator: Address) -> Result<(), Error> {
         delegation::undelegate(&env, delegator)
     }
 
+    /// Get the current voting power of an address.
+    ///
+    /// Returns the address's own balance plus any vote power delegated to it
+    /// by other holders.
+    ///
+    /// # Arguments
+    /// * `address` – The address to query.
+    ///
+    /// # Returns
+    /// Voting power as a non-negative `i128`. Returns `0` if the address
+    /// is unknown.
     pub fn get_vote_power(env: Env, address: Address) -> i128 {
         delegation::get_vote_power(&env, &address)
     }
 
+    /// Retrieve the active delegation record for `delegator`, if any.
+    ///
+    /// # Arguments
+    /// * `delegator` – The address to query.
+    ///
+    /// # Returns
+    /// `Some(DelegationRecord)` if the address has an active delegation,
+    /// `None` otherwise.
     pub fn get_delegation(env: Env, delegator: Address) -> Option<DelegationRecord> {
         delegation::get_delegation(&env, &delegator)
     }
 
+    /// Get the raw token balance of a holder.
+    ///
+    /// This is the holder's own token balance, independent of any delegated
+    /// vote power.
+    ///
+    /// # Arguments
+    /// * `holder` – The address to query.
+    ///
+    /// # Returns
+    /// Balance as a non-negative `i128`. Returns `0` if the address is unknown.
     pub fn get_balance(env: Env, holder: Address) -> i128 {
         storage::get_balance(&env, &holder)
     }
 
+    /// Record a vote-power snapshot for `address` at the current ledger.
+    ///
+    /// Snapshots are used to determine an address's vote power at a fixed
+    /// point in time, preventing manipulation by moving tokens between the
+    /// proposal creation and the vote.
+    ///
+    /// # Arguments
+    /// * `address` – The address to snapshot (must authorize).
+    ///
+    /// # Returns
+    /// `Ok(())` on success.
+    ///
+    /// # Errors
+    /// * [`Error::ContractPaused`] – Contract is paused.
     pub fn take_snapshot(env: Env, address: Address) -> Result<(), Error> {
         delegation::take_snapshot(&env, &address)
     }
 
+    /// Query the vote power of `address` at a past ledger sequence number.
+    ///
+    /// # Arguments
+    /// * `address` – The address to query.
+    /// * `ledger`  – The ledger sequence number of the desired snapshot.
+    ///
+    /// # Returns
+    /// `Ok(i128)` — vote power at the given ledger.
+    ///
+    /// # Errors
+    /// * [`Error::SnapshotNotFound`] – No snapshot exists for the given
+    ///   address/ledger combination.
     pub fn get_snapshot_power(env: Env, address: Address, ledger: u32) -> Result<i128, Error> {
         delegation::get_snapshot_power(&env, &address, ledger)
     }
 
+    /// Set the token balance of a holder (admin only).
+    ///
+    /// Updates `holder`'s balance and propagates the delta to the vote-power
+    /// tally of the holder (or their delegatee, if a delegation is active).
+    ///
+    /// # Arguments
+    /// * `admin`       – Contract admin address (must authorize).
+    /// * `holder`      – Address whose balance is being updated.
+    /// * `new_balance` – New balance value (must be ≥ 0).
+    ///
+    /// # Returns
+    /// `Ok(())` on success.
+    ///
+    /// # Errors
+    /// * [`Error::ContractPaused`] – Contract is paused.
+    /// * [`Error::Unauthorized`]   – Caller is not the stored admin.
+    /// * [`Error::InvalidParameters`] – `new_balance` is negative.
+    /// * [`Error::ArithmeticError`]   – Overflow computing the vote-power delta.
     pub fn set_balance(
         env: Env,
         admin: Address,
@@ -97,6 +230,21 @@ impl GovernanceContract {
         Ok(())
     }
 
+    /// Transfer admin privileges to a new address.
+    ///
+    /// The current admin must authorize this call. The new admin address must
+    /// differ from the current admin.
+    ///
+    /// # Arguments
+    /// * `current_admin` – The existing admin (must authorize).
+    /// * `new_admin`     – The address to grant admin privileges to.
+    ///
+    /// # Returns
+    /// `Ok(())` on success.
+    ///
+    /// # Errors
+    /// * [`Error::Unauthorized`]      – Caller is not the stored admin.
+    /// * [`Error::InvalidParameters`] – `new_admin == current_admin`.
     pub fn transfer_admin(
         env: Env,
         current_admin: Address,
@@ -115,6 +263,19 @@ impl GovernanceContract {
         Ok(())
     }
 
+    /// Pause the contract, disabling all write operations.
+    ///
+    /// While paused, any function that would modify state returns
+    /// [`Error::ContractPaused`]. Read-only queries continue to work.
+    ///
+    /// # Arguments
+    /// * `admin` – Contract admin (must authorize).
+    ///
+    /// # Returns
+    /// `Ok(())` on success.
+    ///
+    /// # Errors
+    /// * [`Error::Unauthorized`] – Caller is not the stored admin.
     pub fn pause(env: Env, admin: Address) -> Result<(), Error> {
         admin.require_auth();
         let stored_admin = storage::get_admin(&env);
@@ -126,6 +287,16 @@ impl GovernanceContract {
         Ok(())
     }
 
+    /// Resume a paused contract, re-enabling write operations.
+    ///
+    /// # Arguments
+    /// * `admin` – Contract admin (must authorize).
+    ///
+    /// # Returns
+    /// `Ok(())` on success.
+    ///
+    /// # Errors
+    /// * [`Error::Unauthorized`] – Caller is not the stored admin.
     pub fn unpause(env: Env, admin: Address) -> Result<(), Error> {
         admin.require_auth();
         let stored_admin = storage::get_admin(&env);
@@ -137,12 +308,33 @@ impl GovernanceContract {
         Ok(())
     }
 
+    /// Return whether the contract is currently paused.
+    ///
+    /// # Returns
+    /// `true` if paused, `false` otherwise.
     pub fn is_paused(env: Env) -> bool {
         storage::is_paused(&env)
     }
 
-    // Proposals
+    // ── Proposals ───────────────────────────────────────────────────────────
 
+    /// Create a new governance proposal.
+    ///
+    /// Opens a new proposal in [`ProposalStatus::Active`] state. Voting begins
+    /// immediately and closes at `env.ledger().timestamp() + voting_period`.
+    ///
+    /// # Arguments
+    /// * `creator`           – Address creating the proposal (must authorize).
+    /// * `description`       – Human-readable description of the proposal.
+    /// * `payload`           – Arbitrary bytes to be executed if the proposal passes.
+    /// * `voting_period`     – Duration in seconds from now until voting closes.
+    /// * `quorum`            – Minimum total votes (for + against) required for
+    ///                         the result to be valid.
+    /// * `threshold_percent` – Percentage of *total* votes that must be *for*
+    ///                         the proposal for it to pass (0–100).
+    ///
+    /// # Returns
+    /// The newly created proposal's numeric ID.
     pub fn create_proposal(
         env: Env,
         creator: Address,
@@ -172,7 +364,23 @@ impl GovernanceContract {
         proposal_id
     }
 
-    /// Execute a passed proposal (atomically with state change)
+    /// Execute a passed proposal atomically with the status change.
+    ///
+    /// Marks the proposal as [`ProposalStatus::Executed`] and emits an
+    /// `exec_prop` event. Actual side-effects encoded in `payload` are
+    /// expected to be dispatched by the caller after this function succeeds.
+    ///
+    /// # Arguments
+    /// * `proposal_id` – The ID of the proposal to execute.
+    ///
+    /// # Returns
+    /// `Ok(())` on success.
+    ///
+    /// # Errors
+    /// * [`FinalizationError::ProposalNotFound`]  – No proposal with this ID.
+    /// * [`FinalizationError::AlreadyExecuted`]   – Proposal was already executed.
+    /// * [`FinalizationError::ProposalNotPassed`] – Proposal has not reached
+    ///   [`ProposalStatus::Passed`] status yet.
     pub fn execute_proposal(env: Env, proposal_id: u32) -> Result<(), FinalizationError> {
         let mut proposal = storage::get_proposal(&env, proposal_id)
             .ok_or(FinalizationError::ProposalNotFound)?;
@@ -198,6 +406,28 @@ impl GovernanceContract {
         Ok(())
     }
 
+    /// Cast a vote on an active proposal.
+    ///
+    /// Each address may vote at most once per proposal. The vote weight equals
+    /// the voter's current vote power (delegated + own), falling back to their
+    /// raw balance if no vote power is recorded.
+    ///
+    /// # Arguments
+    /// * `voter`       – Address casting the vote (must authorize).
+    /// * `proposal_id` – ID of the proposal to vote on.
+    /// * `in_favor`    – `true` to vote for the proposal, `false` to vote against.
+    ///
+    /// # Returns
+    /// `Ok(())` on success.
+    ///
+    /// # Errors
+    /// * [`VoteError::ProposalNotFound`]    – No proposal with this ID.
+    /// * [`VoteError::ProposalNotActive`]   – Proposal is not in Active state.
+    /// * [`VoteError::VotingPeriodEnded`]   – The voting deadline has passed.
+    /// * [`VoteError::AlreadyVoted`]        – This address has already voted.
+    /// * [`VoteError::InsufficientBalance`] – Voter has zero vote power and
+    ///   zero balance.
+    /// * [`VoteError::Overflow`]            – Arithmetic overflow accumulating votes.
     pub fn cast_vote(
         env: Env,
         voter: Address,
@@ -248,10 +478,37 @@ impl GovernanceContract {
         Ok(())
     }
 
+    /// Check whether an address has already voted on a proposal.
+    ///
+    /// # Arguments
+    /// * `proposal_id` – ID of the proposal.
+    /// * `voter`       – Address to check.
+    ///
+    /// # Returns
+    /// `true` if the address has cast a vote, `false` otherwise.
     pub fn has_voted(env: Env, proposal_id: u32, voter: Address) -> bool {
         storage::has_voted(&env, proposal_id, &voter)
     }
 
+    /// Finalize the outcome of a proposal after its voting period ends.
+    ///
+    /// Transitions the proposal from [`ProposalStatus::Active`] to one of:
+    /// * [`ProposalStatus::Failed`]   – Total votes did not meet quorum.
+    /// * [`ProposalStatus::Rejected`] – Quorum met but `votes_for` did not
+    ///   exceed `threshold_percent` of total votes.
+    /// * [`ProposalStatus::Passed`]   – Quorum met and threshold was reached.
+    ///
+    /// # Arguments
+    /// * `proposal_id` – ID of the proposal to finalize.
+    ///
+    /// # Returns
+    /// `Ok(ProposalStatus)` – The final status of the proposal.
+    ///
+    /// # Errors
+    /// * [`FinalizationError::ProposalNotFound`]     – No proposal with this ID.
+    /// * [`FinalizationError::AlreadyFinalized`]     – Proposal is not Active.
+    /// * [`FinalizationError::VotingPeriodNotEnded`] – Voting deadline has not
+    ///   passed yet.
     pub fn finalize_proposal(
         env: Env,
         proposal_id: u32,
@@ -281,10 +538,25 @@ impl GovernanceContract {
         Ok(final_status)
     }
 
+    /// Retrieve a proposal by ID.
+    ///
+    /// # Arguments
+    /// * `proposal_id` – The proposal's numeric ID.
+    ///
+    /// # Returns
+    /// `Some(GovernanceProposal)` if the proposal exists, `None` otherwise.
     pub fn get_proposal(env: Env, proposal_id: u32) -> Option<GovernanceProposal> {
         storage::get_proposal(&env, proposal_id)
     }
 
+    /// Retrieve the vote cast by a specific address on a proposal.
+    ///
+    /// # Arguments
+    /// * `proposal_id` – The proposal's numeric ID.
+    /// * `voter`       – The address whose vote to retrieve.
+    ///
+    /// # Returns
+    /// `Some(ProposalVote)` if the address has voted, `None` otherwise.
     pub fn get_proposal_vote(env: Env, proposal_id: u32, voter: Address) -> Option<ProposalVote> {
         storage::get_vote(&env, proposal_id, &voter)
     }

--- a/contracts/token-factory/src/lib.rs
+++ b/contracts/token-factory/src/lib.rs
@@ -158,23 +158,22 @@ mod dividend_distribution_multi_epoch_integration_test;
 // #[cfg(test)]
 // mod metadata_versioning_property_test; // Temporarily disabled due to pre-existing compilation errors (stale vs. current contract API)
 
-// #[cfg(test)]
-// mod mint_concurrency_stress_test; // Temporarily disabled due to pre-existing compilation errors (stale vs. current contract API)
+#[cfg(test)]
+mod mint_concurrency_stress_test;
 
 #[cfg(test)]
 const _ISOLATED_DISABLED_multisig_auth_fuzz_test: () = ();
 #[cfg(all(test, feature = "legacy-tests"))]
 const _ISOLATED_DISABLED_burn_integration_test: () = ();
-#[cfg(test)]
-const _ISOLATED_DISABLED_batch_atomicity_test: () = ();
+
 #[cfg(test)]
 const _ISOLATED_DISABLED_vault_deposit_withdraw_test: () = ();
 /// Tests for structured vault error codes / diagnostic context (#1384).
 #[cfg(test)]
 mod vault_error_test;
 
-// #[cfg(test)]
-// mod batch_atomicity_test; // Temporarily disabled due to pre-existing compilation errors (stale vs. current contract API)
+#[cfg(test)]
+mod batch_atomicity_test;
 
 // #[cfg(test)]
 // mod vault_deposit_withdraw_test; // Temporarily disabled due to pre-existing compilation errors (stale vs. current contract API)

--- a/contracts/token-factory/src/mint_concurrency_stress_test.rs
+++ b/contracts/token-factory/src/mint_concurrency_stress_test.rs
@@ -8,6 +8,7 @@
 
 use soroban_sdk::{testutils::Address as _, Address, Env, String, Vec};
 
+use crate::types::TokenCreationParams;
 use crate::{TokenFactory, TokenFactoryClient};
 
 // ─────────────────────────────────────────────
@@ -35,20 +36,25 @@ fn setup() -> (Env, Address, Address, Address) {
 
 #[test]
 fn test_mint_large_batch_supply_accounting() {
-    let (env, contract_id, admin, creator) = setup();
+    let (env, contract_id, _admin, creator) = setup();
     let client = TokenFactoryClient::new(&env, &contract_id);
 
-    // Create token with initial supply
+    // Create token with initial supply.
+    // `create_token` now requires metadata_uri and fee_payment.
     let initial_supply = 1_000_000i128;
-    let token_address = client.create_token(
+    client.create_token(
         &creator,
         &String::from_str(&env, "Stress Token"),
         &String::from_str(&env, "STR"),
         &7,
         &initial_supply,
+        &None,
+        &70_000_000,
     );
+    let token_index: u32 = 0;
 
-    // Perform 50 mint operations
+    // Perform 50 sequential mint operations.
+    // `mint` now takes (creator, token_index, to, amount).
     let mint_amount = 10_000i128;
     let num_mints = 50;
     let mut total_minted = 0i128;
@@ -57,17 +63,17 @@ fn test_mint_large_batch_supply_accounting() {
         let recipient = if i % 3 == 0 {
             creator.clone()
         } else if i % 3 == 1 {
-            admin.clone()
+            Address::generate(&env)
         } else {
             Address::generate(&env)
         };
 
-        client.mint_tokens(&token_address, &admin, &recipient, &mint_amount);
+        client.mint(&creator, &token_index, &recipient, &mint_amount);
         total_minted += mint_amount;
     }
 
-    // Verify final supply equals initial + all mints
-    let info = client.get_token_info(&0);
+    // Verify final supply equals initial + all mints.
+    let info = client.get_token_info(&token_index).unwrap();
     let expected_supply = initial_supply + total_minted;
     assert_eq!(
         info.total_supply, expected_supply,
@@ -78,311 +84,358 @@ fn test_mint_large_batch_supply_accounting() {
 
 #[test]
 fn test_mint_authorization_enforced_every_call() {
-    let (env, contract_id, admin, creator) = setup();
+    let (env, contract_id, _admin, creator) = setup();
     let client = TokenFactoryClient::new(&env, &contract_id);
 
-    let token_address = client.create_token(
+    client.create_token(
         &creator,
         &String::from_str(&env, "Auth Token"),
         &String::from_str(&env, "AUTH"),
         &7,
         &1_000_000,
+        &None,
+        &70_000_000,
     );
+    let token_index: u32 = 0;
 
     let unauthorized = Address::generate(&env);
     let recipient = Address::generate(&env);
 
-    // Unauthorized mint should fail
-    let result = client.try_mint_tokens(&token_address, &unauthorized, &recipient, &100_000);
+    // Unauthorized caller (not the token creator) should fail.
+    let result = client.try_mint(&unauthorized, &token_index, &recipient, &100_000);
     assert!(result.is_err(), "Unauthorized mint should fail");
 
-    // Verify state unchanged
-    let info = client.get_token_info(&0);
+    // Verify state unchanged.
+    let info = client.get_token_info(&token_index).unwrap();
     assert_eq!(info.total_supply, 1_000_000);
 }
 
 #[test]
 fn test_mint_randomized_ordering_consistency() {
-    let (env, contract_id, admin, creator) = setup();
+    let (env, contract_id, _admin, creator) = setup();
     let client = TokenFactoryClient::new(&env, &contract_id);
 
     let initial_supply = 5_000_000i128;
-    let token_address = client.create_token(
+    client.create_token(
         &creator,
         &String::from_str(&env, "Order Token"),
         &String::from_str(&env, "ORD"),
         &7,
         &initial_supply,
+        &None,
+        &70_000_000,
     );
+    let token_index: u32 = 0;
 
-    // Create multiple recipients
-    let recipients: Vec<Address> = (0..5).map(|_| Address::generate(&env)).collect();
+    // Create multiple recipients.
+    let mut recipients = Vec::new(&env);
+    for _ in 0..5 {
+        recipients.push_back(Address::generate(&env));
+    }
 
-    // Mint in various orders
-    let mint_amounts = vec![&env, 100_000, 250_000, 75_000, 150_000, 200_000];
+    // Mint in various amounts and orderings.
+    let amounts: [i128; 5] = [100_000, 250_000, 75_000, 150_000, 200_000];
     let mut total_minted = 0i128;
 
-    for amount in mint_amounts.iter() {
-        for recipient in recipients.iter() {
-            client.mint_tokens(&token_address, &admin, recipient, amount);
+    for &amount in &amounts {
+        for j in 0..(recipients.len() as usize) {
+            let recipient = recipients.get(j as u32).unwrap();
+            client.mint(&creator, &token_index, &recipient, &amount);
             total_minted += amount;
         }
     }
 
-    // Verify accounting is correct regardless of order
-    let info = client.get_token_info(&0);
+    // Verify accounting is correct regardless of order.
+    let info = client.get_token_info(&token_index).unwrap();
     let expected_supply = initial_supply + total_minted;
     assert_eq!(info.total_supply, expected_supply);
 }
 
 #[test]
 fn test_mint_events_emitted_for_each_operation() {
-    let (env, contract_id, admin, creator) = setup();
+    let (env, contract_id, _admin, creator) = setup();
     let client = TokenFactoryClient::new(&env, &contract_id);
 
-    let token_address = client.create_token(
+    client.create_token(
         &creator,
         &String::from_str(&env, "Event Token"),
         &String::from_str(&env, "EVT"),
         &7,
         &1_000_000,
+        &None,
+        &70_000_000,
     );
+    let token_index: u32 = 0;
 
     let recipient = Address::generate(&env);
 
-    // Perform multiple mints
+    // Perform multiple mints.
     for i in 1..=5 {
-        client.mint_tokens(&token_address, &admin, &recipient, &(i as i128 * 10_000));
+        client.mint(&creator, &token_index, &recipient, &(i as i128 * 10_000));
     }
 
-    // Verify final supply reflects all mints
-    let info = client.get_token_info(&0);
+    // Verify final supply reflects all mints.
+    let info = client.get_token_info(&token_index).unwrap();
     let expected_supply = 1_000_000 + (1 + 2 + 3 + 4 + 5) * 10_000;
     assert_eq!(info.total_supply, expected_supply);
 }
 
 #[test]
 fn test_mint_zero_amount_fails() {
-    let (env, contract_id, admin, creator) = setup();
+    let (env, contract_id, _admin, creator) = setup();
     let client = TokenFactoryClient::new(&env, &contract_id);
 
-    let token_address = client.create_token(
+    client.create_token(
         &creator,
         &String::from_str(&env, "Zero Token"),
         &String::from_str(&env, "ZRO"),
         &7,
         &1_000_000,
+        &None,
+        &70_000_000,
     );
+    let token_index: u32 = 0;
 
     let recipient = Address::generate(&env);
 
-    // Mint zero should fail
-    let result = client.try_mint_tokens(&token_address, &admin, &recipient, &0);
+    // Mint zero should fail.
+    let result = client.try_mint(&creator, &token_index, &recipient, &0);
     assert!(result.is_err());
 
-    // Verify state unchanged
-    let info = client.get_token_info(&0);
+    // Verify state unchanged.
+    let info = client.get_token_info(&token_index).unwrap();
     assert_eq!(info.total_supply, 1_000_000);
 }
 
 #[test]
 fn test_mint_negative_amount_fails() {
-    let (env, contract_id, admin, creator) = setup();
+    let (env, contract_id, _admin, creator) = setup();
     let client = TokenFactoryClient::new(&env, &contract_id);
 
-    let token_address = client.create_token(
+    client.create_token(
         &creator,
         &String::from_str(&env, "Neg Token"),
         &String::from_str(&env, "NEG"),
         &7,
         &1_000_000,
+        &None,
+        &70_000_000,
     );
+    let token_index: u32 = 0;
 
     let recipient = Address::generate(&env);
 
-    // Mint negative should fail
-    let result = client.try_mint_tokens(&token_address, &admin, &recipient, &-100_000);
+    // Mint negative should fail.
+    let result = client.try_mint(&creator, &token_index, &recipient, &-100_000);
     assert!(result.is_err());
 
-    // Verify state unchanged
-    let info = client.get_token_info(&0);
+    // Verify state unchanged.
+    let info = client.get_token_info(&token_index).unwrap();
     assert_eq!(info.total_supply, 1_000_000);
 }
 
 #[test]
 fn test_mint_to_same_recipient_accumulates() {
-    let (env, contract_id, admin, creator) = setup();
+    let (env, contract_id, _admin, creator) = setup();
     let client = TokenFactoryClient::new(&env, &contract_id);
 
-    let token_address = client.create_token(
+    client.create_token(
         &creator,
         &String::from_str(&env, "Accum Token"),
         &String::from_str(&env, "ACC"),
         &7,
         &1_000_000,
+        &None,
+        &70_000_000,
     );
+    let token_index: u32 = 0;
 
     let recipient = Address::generate(&env);
 
-    // Mint to same recipient multiple times
+    // Mint to same recipient multiple times.
     for _ in 0..10 {
-        client.mint_tokens(&token_address, &admin, &recipient, &50_000);
+        client.mint(&creator, &token_index, &recipient, &50_000);
     }
 
-    // Verify supply increased by total minted
-    let info = client.get_token_info(&0);
+    // Verify supply increased by total minted.
+    let info = client.get_token_info(&token_index).unwrap();
     assert_eq!(info.total_supply, 1_000_000 + (10 * 50_000));
 }
 
 #[test]
 fn test_mint_max_supply_enforcement() {
-    let (env, contract_id, admin, creator) = setup();
+    let (env, contract_id, _admin, creator) = setup();
     let client = TokenFactoryClient::new(&env, &contract_id);
 
+    // `create_token` alone does not accept a max_supply cap.
+    // Use `batch_reveal` with a single TokenCreationParams that has max_supply set.
     let initial_supply = 1_000_000i128;
     let max_supply = 2_000_000i128;
 
-    let token_address = client.create_token_with_max_supply(
-        &creator,
-        &String::from_str(&env, "Max Token"),
-        &String::from_str(&env, "MAX"),
-        &7,
-        &initial_supply,
-        &Some(max_supply),
-    );
+    let mut params = soroban_sdk::Vec::new(&env);
+    params.push_back(TokenCreationParams {
+        name: String::from_str(&env, "Max Token"),
+        symbol: String::from_str(&env, "MAX"),
+        decimals: 7,
+        initial_supply,
+        max_supply: Some(max_supply),
+        metadata_uri: None,
+    });
+
+    // base_fee * 1 token
+    client.batch_reveal(&creator, &params, &70_000_000);
+    let token_index: u32 = 0;
 
     let recipient = Address::generate(&env);
 
-    // Mint up to max should succeed
-    client.mint_tokens(&token_address, &admin, &recipient, &999_999);
-    let info1 = client.get_token_info(&0);
+    // Mint up to max should succeed.
+    client.mint(&creator, &token_index, &recipient, &999_999);
+    let info1 = client.get_token_info(&token_index).unwrap();
     assert_eq!(info1.total_supply, 1_999_999);
 
-    // Mint exceeding max should fail
-    let result = client.try_mint_tokens(&token_address, &admin, &recipient, &2);
+    // Mint exceeding max should fail.
+    let result = client.try_mint(&creator, &token_index, &recipient, &2);
     assert!(result.is_err());
 
-    // Verify state unchanged
-    let info2 = client.get_token_info(&0);
+    // Verify state unchanged.
+    let info2 = client.get_token_info(&token_index).unwrap();
     assert_eq!(info2.total_supply, 1_999_999);
 }
 
 #[test]
 fn test_mint_large_amounts_near_i128_max() {
-    let (env, contract_id, admin, creator) = setup();
+    let (env, contract_id, _admin, creator) = setup();
     let client = TokenFactoryClient::new(&env, &contract_id);
 
     let large_initial = 1_000_000_000_000_000i128;
-    let token_address = client.create_token(
+    client.create_token(
         &creator,
         &String::from_str(&env, "Large Token"),
         &String::from_str(&env, "LRG"),
         &0,
         &large_initial,
+        &None,
+        &70_000_000,
     );
+    let token_index: u32 = 0;
 
     let recipient = Address::generate(&env);
     let large_mint = 500_000_000_000_000i128;
 
-    client.mint_tokens(&token_address, &admin, &recipient, &large_mint);
+    client.mint(&creator, &token_index, &recipient, &large_mint);
 
-    let info = client.get_token_info(&0);
+    let info = client.get_token_info(&token_index).unwrap();
     assert_eq!(info.total_supply, large_initial + large_mint);
 }
 
 #[test]
 fn test_mint_interleaved_with_different_recipients() {
-    let (env, contract_id, admin, creator) = setup();
+    let (env, contract_id, _admin, creator) = setup();
     let client = TokenFactoryClient::new(&env, &contract_id);
 
-    let token_address = client.create_token(
+    client.create_token(
         &creator,
         &String::from_str(&env, "Interleave Token"),
         &String::from_str(&env, "INT"),
         &7,
         &1_000_000,
+        &None,
+        &70_000_000,
     );
+    let token_index: u32 = 0;
 
-    let recipients: Vec<Address> = (0..10).map(|_| Address::generate(&env)).collect();
+    let mut recipients = soroban_sdk::Vec::new(&env);
+    for _ in 0..10 {
+        recipients.push_back(Address::generate(&env));
+    }
 
     let mut total_minted = 0i128;
 
-    // Interleave mints to different recipients
-    for i in 0..100 {
-        let recipient = &recipients[i % recipients.len()];
+    // Interleave mints to different recipients.
+    for i in 0..100usize {
+        let recipient = recipients.get((i % recipients.len() as usize) as u32).unwrap();
         let amount = ((i as i128 + 1) * 1_000) % 100_000 + 1_000;
-        client.mint_tokens(&token_address, &admin, recipient, &amount);
+        client.mint(&creator, &token_index, &recipient, &amount);
         total_minted += amount;
     }
 
-    // Verify final supply
-    let info = client.get_token_info(&0);
+    // Verify final supply.
+    let info = client.get_token_info(&token_index).unwrap();
     assert_eq!(info.total_supply, 1_000_000 + total_minted);
 }
 
 #[test]
 fn test_mint_state_isolation_between_tokens() {
-    let (env, contract_id, admin, creator) = setup();
+    let (env, contract_id, _admin, creator) = setup();
     let client = TokenFactoryClient::new(&env, &contract_id);
 
-    // Create two tokens
-    let token1 = client.create_token(
+    // Create two tokens — they receive indices 0 and 1 respectively.
+    client.create_token(
         &creator,
         &String::from_str(&env, "Token 1"),
         &String::from_str(&env, "T1"),
         &7,
         &1_000_000,
+        &None,
+        &70_000_000,
     );
-
-    let token2 = client.create_token(
+    client.create_token(
         &creator,
         &String::from_str(&env, "Token 2"),
         &String::from_str(&env, "T2"),
         &7,
         &2_000_000,
+        &None,
+        &70_000_000,
     );
+
+    let token0: u32 = 0;
+    let token1: u32 = 1;
 
     let recipient = Address::generate(&env);
 
-    // Mint to token1
-    client.mint_tokens(&token1, &admin, &recipient, &100_000);
+    // Mint to token 0.
+    client.mint(&creator, &token0, &recipient, &100_000);
 
-    // Mint to token2
-    client.mint_tokens(&token2, &admin, &recipient, &200_000);
+    // Mint to token 1.
+    client.mint(&creator, &token1, &recipient, &200_000);
 
-    // Verify each token's supply is independent
-    let info1 = client.get_token_info(&0);
-    let info2 = client.get_token_info(&1);
+    // Verify each token's supply is independent.
+    let info0 = client.get_token_info(&token0).unwrap();
+    let info1 = client.get_token_info(&token1).unwrap();
 
-    assert_eq!(info1.total_supply, 1_100_000);
-    assert_eq!(info2.total_supply, 2_200_000);
+    assert_eq!(info0.total_supply, 1_100_000);
+    assert_eq!(info1.total_supply, 2_200_000);
 }
 
 #[test]
 fn test_mint_rapid_sequential_operations() {
-    let (env, contract_id, admin, creator) = setup();
+    let (env, contract_id, _admin, creator) = setup();
     let client = TokenFactoryClient::new(&env, &contract_id);
 
-    let token_address = client.create_token(
+    client.create_token(
         &creator,
         &String::from_str(&env, "Rapid Token"),
         &String::from_str(&env, "RPD"),
         &7,
         &1_000_000,
+        &None,
+        &70_000_000,
     );
+    let token_index: u32 = 0;
 
     let recipient = Address::generate(&env);
 
-    // Perform 100 rapid mints
+    // Perform 100 rapid mints.
     let mut total_minted = 0i128;
-    for i in 0..100 {
+    for i in 0..100usize {
         let amount = (i as i128 + 1) * 100;
-        client.mint_tokens(&token_address, &admin, &recipient, &amount);
+        client.mint(&creator, &token_index, &recipient, &amount);
         total_minted += amount;
     }
 
-    // Verify supply accounting
-    let info = client.get_token_info(&0);
+    // Verify supply accounting.
+    let info = client.get_token_info(&token_index).unwrap();
     let expected = 1_000_000 + total_minted;
     assert_eq!(info.total_supply, expected);
 }


### PR DESCRIPTION
re-enable batch/concurrency test suites & document governance entry points
  
  What this PR does
  
  Closes #1687
  Closes #1688
  
  ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
  #1687 — Re-enable batch atomicity & mint concurrency test suites
  
  Both batch_atomicity_test and mint_concurrency_stress_test were disabled with a stale-API comment after the batch_mint/create_mint API was migrated. This
  PR brings them back.
  
  Changes:
  
  - Re-enabled mod batch_atomicity_test and mod mint_concurrency_stress_test in contracts/token-factory/src/lib.rs
  - Updated mint_concurrency_stress_test.rs to match the current create_token signature (metadata_uri: Option<String> + fee_payment: i128) and the current
  mint(creator, token_index, to, amount) signature
  - batch_atomicity_test.rs already matched the current batch_reveal / preflight_batch_reveal API — no changes needed there
  
  Both suites still exercise the scenarios they were written for:
  
  - Atomicity — invalid element mid-batch reverts the entire batch; state before and after a failed batch is identical
  - Concurrency — supply accounting holds across 100 rapid sequential mints; authorization is enforced on every call; state is isolated between tokens
  
  ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
  #1688 — Rustdoc on public governance entry points
  
  contracts/governance/src/lib.rs had no /// doc comments on any of its 20 public functions, making the crate's API opaque to integrators.
  
  Changes:
  
  - Added #![warn(missing_docs)] at the crate level so future undocumented public items surface as compiler warnings
  - Added full /// doc comments to every public function covering parameters, return values, and error conditions:
  
    initialize, delegate, undelegate, get_vote_power, get_delegation, get_balance, take_snapshot, get_snapshot_power, set_balance, transfer_admin, pause,
  unpause, is_paused, create_proposal, execute_proposal, cast_vote, has_voted, finalize_proposal, get_proposal, get_proposal_vote
  
  ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
  Testing
  
  # #1687 — batch and concurrency suites
  cargo test --package token-factory batch_atomicity
  cargo test --package token-factory mint_concurrency_stress
  
  # #1688 — docs build clean, no missing-docs warnings
  cargo doc --package governance --no-deps
  
  # Full test suite still passes
  cargo test --package governance
  cargo test --package token-factory