### PR TITLE
fix(monitoring,gateway): implement health-check retries/status codes and honor per-route auth flag

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -27,7 +27,8 @@
     "type-check": "tsc --noEmit",
     "docs:generate": "tsx scripts/generate-openapi.ts && tsx scripts/generate-docs.ts",
     "generate:event-types": "tsx scripts/generate-event-types.ts",
-    "incident:test": "vitest run --config ../monitoring/pagerduty/vitest.config.ts ../monitoring/pagerduty/incident-response.test.ts"
+    "incident:test": "vitest run --config ../monitoring/pagerduty/vitest.config.ts ../monitoring/pagerduty/incident-response.test.ts",
+    "test:health-monitor": "vitest run --root ../monitoring/health-checks"
   },
   "dependencies": {
     "@asteasolutions/zod-to-openapi": "^8.5.0",

--- a/gateway/src/__tests__/app.test.ts
+++ b/gateway/src/__tests__/app.test.ts
@@ -76,9 +76,9 @@ describe("Authentication middleware", () => {
   // We only care about the auth layer (401 vs not-401).
   const app = createApp({ env: ENV, redis: mockRedis() });
 
-  it("returns 401 for /api/tokens without a token", async () => {
+  it("allows unauthenticated access to /api/tokens (requiresAuth: false)", async () => {
     const res = await request(app).get("/api/tokens");
-    expect(res.status).toBe(401);
+    expect(res.status).not.toBe(401);
   });
 
   it("returns 401 for /api/admin without a token", async () => {
@@ -86,9 +86,9 @@ describe("Authentication middleware", () => {
     expect(res.status).toBe(401);
   });
 
-  it("returns 401 for an invalid token", async () => {
+  it("returns 401 for an invalid token on a protected route (/api/admin)", async () => {
     const res = await request(app)
-      .get("/api/tokens")
+      .get("/api/admin")
       .set("Authorization", "Bearer invalid.token");
     expect(res.status).toBe(401);
   });
@@ -98,6 +98,50 @@ describe("Authentication middleware", () => {
       .get("/api/tokens")
       .set("Authorization", `Bearer ${validToken()}`);
     // Auth passed; proxy to non-existent backend → 502 or ECONNREFUSED → 502
+    expect(res.status).not.toBe(401);
+  });
+});
+
+// ── Per-route requiresAuth flag matrix ───────────────────────────────────────
+
+describe("Per-route requiresAuth flag", () => {
+  const app = createApp({ env: ENV, redis: mockRedis() });
+
+  // requiresAuth: false — reachable without a token
+  it("allows unauthenticated GET /api/leaderboard (requiresAuth: false)", async () => {
+    const res = await request(app).get("/api/leaderboard");
+    expect(res.status).not.toBe(401);
+  });
+
+  it("allows unauthenticated GET /api/search (requiresAuth: false)", async () => {
+    const res = await request(app).get("/api/search");
+    expect(res.status).not.toBe(401);
+  });
+
+  // requiresAuth: false — also works with a valid token
+  it("accepts a valid token on a public route (/api/tokens)", async () => {
+    const res = await request(app)
+      .get("/api/tokens")
+      .set("Authorization", `Bearer ${validToken()}`);
+    expect(res.status).not.toBe(401);
+  });
+
+  // requiresAuth: true — rejects without a token
+  it("rejects unauthenticated GET /api/governance (requiresAuth: true)", async () => {
+    const res = await request(app).get("/api/governance");
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects unauthenticated GET /api/webhooks (requiresAuth: true)", async () => {
+    const res = await request(app).get("/api/webhooks");
+    expect(res.status).toBe(401);
+  });
+
+  // requiresAuth: true — passes with a valid token
+  it("allows authenticated GET /api/admin (requiresAuth: true)", async () => {
+    const res = await request(app)
+      .get("/api/admin")
+      .set("Authorization", `Bearer ${validToken()}`);
     expect(res.status).not.toBe(401);
   });
 });

--- a/gateway/src/app.ts
+++ b/gateway/src/app.ts
@@ -57,8 +57,8 @@ export function createApp({ env, redis: injectedRedis }: GatewayDeps) {
   app.get("/health/live",  (_req, res) => res.json({ status: "ok" }));
   app.get("/health/ready", (_req, res) => res.json({ status: "ok" }));
 
-  // ── Authentication ───────────────────────────────────────────────────────────
-  app.use(createAuthMiddleware(env.JWT_SECRET));
+  // ── Authentication (applied per-route based on requiresAuth flag) ───────────
+  const authMiddleware = createAuthMiddleware(env.JWT_SECRET);
 
   // ── Idempotency key propagation ──────────────────────────────────────────────
   app.use(createIdempotencyMiddleware());
@@ -89,7 +89,11 @@ export function createApp({ env, redis: injectedRedis }: GatewayDeps) {
   });
 
   for (const route of ROUTES) {
-    app.use(route.prefix, getLimiter(route.tier), proxy);
+    if (route.requiresAuth) {
+      app.use(route.prefix, authMiddleware, getLimiter(route.tier), proxy);
+    } else {
+      app.use(route.prefix, getLimiter(route.tier), proxy);
+    }
   }
 
   // ── 404 fallback ─────────────────────────────────────────────────────────────

--- a/monitoring/health-checks/__tests__/health-monitor.test.ts
+++ b/monitoring/health-checks/__tests__/health-monitor.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('axios', () => ({
+  default: { get: vi.fn() },
+}));
+
+vi.mock('../../logging/structured-logger', () => ({
+  structuredLogger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('../../metrics/prometheus-config', () => ({
+  MetricsCollector: { recordHealthCheck: vi.fn() },
+}));
+
+import axios from 'axios';
+import { HealthMonitor } from '../health-monitor';
+
+const BASE_CONFIG = {
+  name: 'test-svc',
+  type: 'http' as const,
+  url: 'http://test.internal/health',
+  interval: 30_000,
+  timeout: 5_000,
+  critical: false,
+};
+
+describe('HealthMonitor – retries and HTTP status code preservation', () => {
+  let monitor: HealthMonitor;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    monitor = new HealthMonitor();
+  });
+
+  afterEach(() => {
+    monitor.stopAll();
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('retries the configured number of times and succeeds on the final attempt', async () => {
+    const mockedGet = vi.mocked(axios.get);
+    mockedGet
+      .mockResolvedValueOnce({ status: 503, data: 'unavailable' })
+      .mockResolvedValueOnce({ status: 503, data: 'unavailable' })
+      .mockResolvedValueOnce({ status: 200, data: 'ok' });
+
+    const checkPromise = (monitor as any).performCheck({ ...BASE_CONFIG, retries: 2 });
+    await vi.runAllTimersAsync();
+    await checkPromise;
+
+    expect(mockedGet).toHaveBeenCalledTimes(3);
+    const result = monitor.getResults().find(r => r.name === 'test-svc');
+    expect(result?.healthy).toBe(true);
+    expect(result?.error).toBeUndefined();
+  });
+
+  it('carries the last HTTP status code in the error when all retries are exhausted', async () => {
+    const mockedGet = vi.mocked(axios.get);
+    mockedGet.mockResolvedValue({ status: 503, data: 'downstream unavailable' });
+
+    const checkPromise = (monitor as any).performCheck({
+      ...BASE_CONFIG,
+      name: 'failing-svc',
+      retries: 2,
+    });
+    await vi.runAllTimersAsync();
+    await checkPromise;
+
+    expect(mockedGet).toHaveBeenCalledTimes(3);
+    const result = monitor.getResults().find(r => r.name === 'failing-svc');
+    expect(result?.healthy).toBe(false);
+    expect(result?.error).toContain('503');
+    expect(result?.error).toContain('downstream unavailable');
+  });
+
+  it('does not retry when the first attempt succeeds', async () => {
+    const mockedGet = vi.mocked(axios.get);
+    mockedGet.mockResolvedValue({ status: 200, data: 'ok' });
+
+    const checkPromise = (monitor as any).performCheck({ ...BASE_CONFIG, retries: 2 });
+    await vi.runAllTimersAsync();
+    await checkPromise;
+
+    expect(mockedGet).toHaveBeenCalledTimes(1);
+    const result = monitor.getResults().find(r => r.name === 'test-svc');
+    expect(result?.healthy).toBe(true);
+  });
+
+  it('makes exactly one attempt when retries is 0', async () => {
+    const mockedGet = vi.mocked(axios.get);
+    mockedGet.mockResolvedValue({ status: 500, data: '' });
+
+    const checkPromise = (monitor as any).performCheck({ ...BASE_CONFIG, retries: 0 });
+    await vi.runAllTimersAsync();
+    await checkPromise;
+
+    expect(mockedGet).toHaveBeenCalledTimes(1);
+    const result = monitor.getResults().find(r => r.name === 'test-svc');
+    expect(result?.healthy).toBe(false);
+    expect(result?.error).toContain('500');
+  });
+});

--- a/monitoring/health-checks/health-monitor.ts
+++ b/monitoring/health-checks/health-monitor.ts
@@ -5,7 +5,7 @@
  */
 
 import { EventEmitter } from 'events';
-import axios, { AxiosResponse } from 'axios';
+import axios from 'axios';
 import { structuredLogger } from '../logging/structured-logger';
 import { MetricsCollector } from '../metrics/prometheus-config';
 
@@ -40,6 +40,10 @@ interface ProjectionLagHealthDetail {
   maxLag: number;
   measurementCount: number;
   status: 'healthy' | 'warning' | 'critical';
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
 }
 
 /**
@@ -83,7 +87,7 @@ export class HealthMonitor extends EventEmitter {
   }
 
   /**
-   * Perform a health check
+   * Perform a health check, honoring config.retries with bounded backoff.
    */
   private async performCheck(config: HealthCheckConfig): Promise<void> {
     const startTime = Date.now();
@@ -91,39 +95,59 @@ export class HealthMonitor extends EventEmitter {
     let error: string | undefined;
     let metadata: Record<string, unknown> | undefined;
 
-    try {
-      switch (config.type) {
-        case 'http':
-          if (config.url) {
-            const response = await axios.get(config.url, {
-              timeout: config.timeout,
-            });
-            healthy = response.status >= 200 && response.status < 300;
-          }
-          break;
+    const maxAttempts = (config.retries ?? 0) + 1;
 
-        case 'projection-lag':
-          // Projection lag health check
-          if (config.lagThresholdConfig?.queryFn) {
-            const result = await this.checkProjectionLag(config);
-            healthy = result.healthy;
-            metadata = result.metadata;
-            error = result.error;
-          }
-          break;
-
-        case 'custom':
-          if (config.customCheck) {
-            healthy = await config.customCheck();
-          }
-          break;
-
-        default:
-          healthy = true;
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      if (attempt > 0) {
+        await sleep(Math.min(200 * 2 ** (attempt - 1), 5000));
       }
-    } catch (err) {
-      healthy = false;
-      error = err instanceof Error ? err.message : 'Unknown error';
+
+      try {
+        switch (config.type) {
+          case 'http':
+            if (config.url) {
+              const response = await axios.get(config.url, {
+                timeout: config.timeout,
+                validateStatus: () => true,
+              });
+              if (response.status >= 200 && response.status < 300) {
+                healthy = true;
+                error = undefined;
+              } else {
+                healthy = false;
+                const rawBody = response.data;
+                const bodySnippet = (
+                  typeof rawBody === 'string' ? rawBody : JSON.stringify(rawBody)
+                ).slice(0, 200);
+                error = `HTTP ${response.status}: ${bodySnippet}`;
+              }
+            }
+            break;
+
+          case 'projection-lag':
+            if (config.lagThresholdConfig?.queryFn) {
+              const result = await this.checkProjectionLag(config);
+              healthy = result.healthy;
+              metadata = result.metadata;
+              error = result.error;
+            }
+            break;
+
+          case 'custom':
+            if (config.customCheck) {
+              healthy = await config.customCheck();
+            }
+            break;
+
+          default:
+            healthy = true;
+        }
+      } catch (err) {
+        healthy = false;
+        error = err instanceof Error ? err.message : 'Unknown error';
+      }
+
+      if (healthy) break;
     }
 
     const responseTime = Date.now() - startTime;

--- a/monitoring/health-checks/vitest.config.ts
+++ b/monitoring/health-checks/vitest.config.ts
@@ -1,0 +1,6 @@
+export default {
+  test: {
+    environment: "node",
+    include: ["**/__tests__/**/*.test.ts"],
+  },
+};


### PR DESCRIPTION
## Summary

- **#1707** — `HealthCheckConfig.retries` was declared but never read; HTTP failures swallowed the status code in a generic catch. Fixed by adding a bounded-backoff retry loop (200 ms base, capped at 5 s) and switching to `validateStatus: () => true` so the status code and a body snippet are preserved in the error string.
- **#1706** — `RouteConfig.requiresAuth` was a dead flag; the JWT middleware was applied globally, making public routes (e.g. `/api/tokens`, `/api/leaderboard`) require auth despite their config. Fixed by removing the global `app.use(authMiddleware)` and applying it per-route in the ROUTES loop.

## Changes

**monitoring/health-checks/health-monitor.ts**
- Added `sleep()` helper for bounded backoff
- `performCheck` now loops up to `config.retries + 1` times, sleeping between attempts
- HTTP case uses `validateStatus: () => true`; non-2xx error includes `HTTP <status>: <body snippet>`

**monitoring/health-checks/__tests__/health-monitor.test.ts** *(new)*
- Retry count matches `config.retries + 1`; final error carries status code; early exit on success; `retries: 0` makes exactly one attempt

**monitoring/health-checks/vitest.config.ts** *(new)*
- Vitest config scoped to health-checks; run via `cd backend && ./node_modules/.bin/vitest run --root ../monitoring/health-checks`

**backend/package.json**
- Added `test:health-monitor` script

**gateway/src/app.ts**
- Removed global `app.use(createAuthMiddleware(...))` — auth middleware now applied only on `requiresAuth: true` routes

**gateway/src/__tests__/app.test.ts**
- Corrected the stale `401 for /api/tokens` assertion to reflect public-route behaviour
- Added `Per-route requiresAuth flag` matrix (public + protected × authenticated + unauthenticated)

## Test plan

- [ ] `cd gateway && npx vitest run` — 74 tests pass (21 in app.test.ts)
- [ ] `cd backend && ./node_modules/.bin/vitest run --root ../monitoring/health-checks` — 4 tests pass
- [ ] Routes with `requiresAuth: false` return non-401 without a token
- [ ] Routes with `requiresAuth: true` return 401 without a token
- [ ] A check with `retries: 2` calls the endpoint 3 times on transient failure
- [ ] Final `HealthCheckResult.error` contains the HTTP status code

Closes #1707
Closes #1706