### PR TITLE
feat(contracts): add permissioned oracle price-feed primitive

### DIFF
--- a/contracts/token-factory/src/events.rs
+++ b/contracts/token-factory/src/events.rs
@@ -1894,3 +1894,60 @@ pub fn emit_settlement_timeout_cleanup(env: &Env, reservation_id: u64, proposal_
     env.events()
         .publish((symbol_short!("stl_tmo1"), reservation_id), (proposal_id,));
 }
+
+// ── Oracle price feed events ────────────────────────────────────────────────
+
+/// Emitted when the admin (re)configures the oracle's max staleness window.
+///
+/// **Schema Version**: 1
+/// **Event Name**: orc_cfg1
+pub fn emit_oracle_configured(env: &Env, admin: &Address, max_age_seconds: u64) {
+    env.events().publish(
+        (symbol_short!("orc_cfg1"),),
+        (admin.clone(), max_age_seconds),
+    );
+}
+
+/// Emitted when the admin authorizes or deauthorizes an oracle price source.
+///
+/// **Schema Version**: 1
+/// **Event Name**: orc_src1
+pub fn emit_oracle_source_authorized(
+    env: &Env,
+    admin: &Address,
+    source: &Address,
+    authorized: bool,
+) {
+    env.events().publish(
+        (symbol_short!("orc_src1"),),
+        (admin.clone(), source.clone(), authorized),
+    );
+}
+
+/// Emitted when an authorized source submits a new price for `asset`.
+///
+/// **Schema Version**: 1
+/// **Event Name**: orc_pr1
+///
+/// **Topics** (indexed):
+/// - Event name: "orc_pr1"
+/// - asset: Address - The asset the price was submitted for
+///
+/// **Payload** (non-indexed):
+/// - source: Address - The authorized source that submitted the price
+/// - price: i128 - The raw submitted price
+/// - decimals: u32 - Decimal places in `price`
+/// - timestamp: u64 - Ledger timestamp the price was recorded at
+pub fn emit_price_submitted(
+    env: &Env,
+    asset: &Address,
+    source: &Address,
+    price: i128,
+    decimals: u32,
+    timestamp: u64,
+) {
+    env.events().publish(
+        (symbol_short!("orc_pr1"), asset.clone()),
+        (source.clone(), price, decimals, timestamp),
+    );
+}

--- a/contracts/token-factory/src/lib.rs
+++ b/contracts/token-factory/src/lib.rs
@@ -23,6 +23,7 @@ mod differential_engine;
 mod event_versions;
 mod events;
 mod milestone_verification;
+mod oracle;
 #[cfg(all(test, feature = "legacy-tests"))]
 const _ISOLATED_DISABLED_milestone_verification_test: () = ();
 #[cfg(all(test, feature = "legacy-tests"))]
@@ -48,6 +49,8 @@ mod game_history_test;
 mod proposal_queue_test;
 #[cfg(test)]
 mod event_versions_test;
+#[cfg(test)]
+mod oracle_integration_test;
 mod timelock;
 mod token_creation;
 mod treasury;
@@ -4147,6 +4150,58 @@ impl TokenFactory {
         Ok(())
     }
 
+    // ── Oracle price feed ─────────────────────────────────────────────
+
+    /// Configure the oracle's max staleness window, in seconds (admin only).
+    ///
+    /// # Errors
+    /// * `MissingAdmin` - Factory has not been initialized
+    /// * `Unauthorized` - Caller is not the factory admin
+    /// * `OracleInvalidConfig` - `max_age_seconds` is zero
+    pub fn configure_oracle(env: Env, admin: Address, max_age_seconds: u64) -> Result<(), Error> {
+        oracle::configure_oracle(&env, &admin, max_age_seconds)
+    }
+
+    /// Authorize or deauthorize `source` as an oracle price submitter (admin only).
+    ///
+    /// # Errors
+    /// * `MissingAdmin` - Factory has not been initialized
+    /// * `Unauthorized` - Caller is not the factory admin
+    pub fn set_oracle_authorized(
+        env: Env,
+        admin: Address,
+        source: Address,
+        authorized: bool,
+    ) -> Result<(), Error> {
+        oracle::set_oracle_authorized(&env, &admin, &source, authorized)
+    }
+
+    /// Submit a price observation for `asset` (authorized sources only).
+    ///
+    /// # Errors
+    /// * `OracleUnauthorizedSource` - `source` has not been authorized by the admin
+    /// * `OracleInvalidPrice` - `price` is not strictly positive
+    pub fn submit_price(
+        env: Env,
+        source: Address,
+        asset: Address,
+        price: i128,
+        decimals: u32,
+    ) -> Result<(), Error> {
+        oracle::submit_price(&env, &source, &asset, price, decimals)
+    }
+
+    /// Read the latest price for `asset`, enforcing the configured staleness
+    /// window and rejecting non-positive values.
+    ///
+    /// # Errors
+    /// * `OraclePriceNotFound` - No price has ever been submitted for `asset`
+    /// * `OracleNotConfigured` - The oracle max-staleness window has not been set
+    /// * `OracleInvalidPrice` - The stored price is not strictly positive
+    /// * `OraclePriceStale` - The stored price is older than the configured max age
+    pub fn get_price(env: Env, asset: Address) -> Result<types::PriceData, Error> {
+        oracle::get_price(&env, &asset)
+    }
 }
 
 // Temporarily disabled - requires create_token implementation

--- a/contracts/token-factory/src/oracle.rs
+++ b/contracts/token-factory/src/oracle.rs
@@ -1,0 +1,114 @@
+//! Lightweight, permissioned price-feed oracle primitive.
+//!
+//! Admin configures a max staleness window and authorizes/deauthorizes
+//! price sources. Authorized sources push prices for an `asset` address;
+//! consumers read the latest price via `get_price`, which enforces the
+//! staleness window and rejects non-positive values.
+//!
+//! Scope: this module is the oracle primitive only. Any feature that wants
+//! to consume these prices (e.g. an AMM or liquidation flow) must wire that
+//! consumption explicitly in its own PR.
+
+use soroban_sdk::{Address, Env};
+
+use crate::types::{Error, OracleConfig, PriceData};
+use crate::{events, storage};
+
+/// Configure the oracle's max staleness window (admin only).
+///
+/// # Errors
+/// * `MissingAdmin` - Factory has not been initialized
+/// * `Unauthorized` - Caller is not the factory admin
+/// * `OracleInvalidConfig` - `max_age_seconds` is zero
+pub fn configure_oracle(env: &Env, admin: &Address, max_age_seconds: u64) -> Result<(), Error> {
+    admin.require_auth();
+    let stored_admin = storage::get_admin(env).ok_or(Error::MissingAdmin)?;
+    if *admin != stored_admin {
+        return Err(Error::Unauthorized);
+    }
+    if max_age_seconds == 0 {
+        return Err(Error::OracleInvalidConfig);
+    }
+
+    storage::set_oracle_config(env, &OracleConfig { max_age_seconds });
+    events::emit_oracle_configured(env, admin, max_age_seconds);
+    Ok(())
+}
+
+/// Authorize or deauthorize `source` as an oracle price submitter (admin only).
+///
+/// # Errors
+/// * `MissingAdmin` - Factory has not been initialized
+/// * `Unauthorized` - Caller is not the factory admin
+pub fn set_oracle_authorized(
+    env: &Env,
+    admin: &Address,
+    source: &Address,
+    authorized: bool,
+) -> Result<(), Error> {
+    admin.require_auth();
+    let stored_admin = storage::get_admin(env).ok_or(Error::MissingAdmin)?;
+    if *admin != stored_admin {
+        return Err(Error::Unauthorized);
+    }
+
+    storage::set_oracle_source_authorized(env, source, authorized);
+    events::emit_oracle_source_authorized(env, admin, source, authorized);
+    Ok(())
+}
+
+/// Submit a price observation for `asset` (authorized sources only).
+///
+/// # Errors
+/// * `OracleUnauthorizedSource` - `source` has not been authorized by the admin
+/// * `OracleInvalidPrice` - `price` is not strictly positive
+pub fn submit_price(
+    env: &Env,
+    source: &Address,
+    asset: &Address,
+    price: i128,
+    decimals: u32,
+) -> Result<(), Error> {
+    source.require_auth();
+
+    if !storage::is_oracle_source_authorized(env, source) {
+        return Err(Error::OracleUnauthorizedSource);
+    }
+    if price <= 0 {
+        return Err(Error::OracleInvalidPrice);
+    }
+
+    let timestamp = env.ledger().timestamp();
+    let data = PriceData {
+        price,
+        decimals,
+        timestamp,
+    };
+    storage::set_oracle_price(env, asset, &data);
+    events::emit_price_submitted(env, asset, source, price, decimals, timestamp);
+    Ok(())
+}
+
+/// Read the latest price for `asset`, enforcing the configured staleness
+/// window and rejecting non-positive values.
+///
+/// # Errors
+/// * `OraclePriceNotFound` - No price has ever been submitted for `asset`
+/// * `OracleNotConfigured` - The oracle max-staleness window has not been set
+/// * `OracleInvalidPrice` - The stored price is not strictly positive
+/// * `OraclePriceStale` - The stored price is older than the configured max age
+pub fn get_price(env: &Env, asset: &Address) -> Result<PriceData, Error> {
+    let data = storage::get_oracle_price(env, asset).ok_or(Error::OraclePriceNotFound)?;
+    if data.price <= 0 {
+        return Err(Error::OracleInvalidPrice);
+    }
+
+    let config = storage::get_oracle_config(env).ok_or(Error::OracleNotConfigured)?;
+    let now = env.ledger().timestamp();
+    let age = now.saturating_sub(data.timestamp);
+    if age > config.max_age_seconds {
+        return Err(Error::OraclePriceStale);
+    }
+
+    Ok(data)
+}

--- a/contracts/token-factory/src/oracle_integration_test.rs
+++ b/contracts/token-factory/src/oracle_integration_test.rs
@@ -1,0 +1,152 @@
+//! Oracle price-feed integration tests.
+//!
+//! Covers the acceptance criteria for the oracle primitive: submit/read
+//! happy path, staleness rejection, unauthorized-source rejection,
+//! non-positive-price rejection, and admin authorize/deauthorize.
+
+#![cfg(test)]
+extern crate std;
+
+use soroban_sdk::{
+    testutils::{Address as _, Ledger as _},
+    Address, Env,
+};
+
+use crate::{types::Error, TokenFactory, TokenFactoryClient};
+
+const BASE_FEE: i128 = 100_000_000;
+const METADATA_FEE: i128 = 50_000_000;
+const MAX_AGE_SECONDS: u64 = 300;
+
+/// Deploy and initialize the factory, returning `(env, client, admin)`.
+fn setup(env: &Env) -> (TokenFactoryClient<'_>, Address) {
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, TokenFactory);
+    let client = TokenFactoryClient::new(env, &contract_id);
+    let admin = Address::generate(env);
+    let treasury = Address::generate(env);
+    client.initialize(&admin, &treasury, &BASE_FEE, &METADATA_FEE);
+    (client, admin)
+}
+
+#[test]
+fn submit_and_read_price_happy_path() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+    let source = Address::generate(&env);
+    let asset = Address::generate(&env);
+
+    client.configure_oracle(&admin, &MAX_AGE_SECONDS);
+    client.set_oracle_authorized(&admin, &source, &true);
+
+    client.submit_price(&source, &asset, &12_345_i128, &7u32);
+
+    let price = client.get_price(&asset);
+    assert_eq!(price.price, 12_345_i128);
+    assert_eq!(price.decimals, 7);
+    assert_eq!(price.timestamp, env.ledger().timestamp());
+}
+
+#[test]
+fn get_price_rejects_stale_submission() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+    let source = Address::generate(&env);
+    let asset = Address::generate(&env);
+
+    client.configure_oracle(&admin, &MAX_AGE_SECONDS);
+    client.set_oracle_authorized(&admin, &source, &true);
+    client.submit_price(&source, &asset, &1_000_i128, &2u32);
+
+    // Advance the ledger clock past the staleness window.
+    env.ledger().with_mut(|li| {
+        li.timestamp += MAX_AGE_SECONDS + 1;
+    });
+
+    let result = client.try_get_price(&asset);
+    assert_eq!(
+        result,
+        Err(Ok(Error::OraclePriceStale)),
+        "price older than max_age_seconds must be rejected as stale"
+    );
+}
+
+#[test]
+fn submit_price_rejects_unauthorized_source() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+    let unauthorized_source = Address::generate(&env);
+    let asset = Address::generate(&env);
+
+    client.configure_oracle(&admin, &MAX_AGE_SECONDS);
+    // Note: unauthorized_source is never authorized.
+
+    let result = client.try_submit_price(&unauthorized_source, &asset, &1_000_i128, &2u32);
+    assert_eq!(
+        result,
+        Err(Ok(Error::OracleUnauthorizedSource)),
+        "unauthorized source must not be able to submit a price"
+    );
+}
+
+#[test]
+fn submit_price_rejects_non_positive_price() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+    let source = Address::generate(&env);
+    let asset = Address::generate(&env);
+
+    client.configure_oracle(&admin, &MAX_AGE_SECONDS);
+    client.set_oracle_authorized(&admin, &source, &true);
+
+    let zero_result = client.try_submit_price(&source, &asset, &0_i128, &2u32);
+    assert_eq!(zero_result, Err(Ok(Error::OracleInvalidPrice)));
+
+    let negative_result = client.try_submit_price(&source, &asset, &(-5_i128), &2u32);
+    assert_eq!(negative_result, Err(Ok(Error::OracleInvalidPrice)));
+}
+
+#[test]
+fn admin_can_authorize_and_deauthorize_sources() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+    let source = Address::generate(&env);
+    let asset = Address::generate(&env);
+
+    client.configure_oracle(&admin, &MAX_AGE_SECONDS);
+
+    // Authorize, submission succeeds.
+    client.set_oracle_authorized(&admin, &source, &true);
+    client.submit_price(&source, &asset, &500_i128, &2u32);
+
+    // Deauthorize, further submissions are rejected.
+    client.set_oracle_authorized(&admin, &source, &false);
+    let result = client.try_submit_price(&source, &asset, &600_i128, &2u32);
+    assert_eq!(result, Err(Ok(Error::OracleUnauthorizedSource)));
+}
+
+#[test]
+fn non_admin_cannot_authorize_sources_or_configure_oracle() {
+    let env = Env::default();
+    let (client, _admin) = setup(&env);
+    let impostor = Address::generate(&env);
+    let source = Address::generate(&env);
+
+    let configure_result = client.try_configure_oracle(&impostor, &MAX_AGE_SECONDS);
+    assert_eq!(configure_result, Err(Ok(Error::Unauthorized)));
+
+    let authorize_result = client.try_set_oracle_authorized(&impostor, &source, &true);
+    assert_eq!(authorize_result, Err(Ok(Error::Unauthorized)));
+}
+
+#[test]
+fn get_price_before_any_submission_is_not_found() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+    let asset = Address::generate(&env);
+
+    client.configure_oracle(&admin, &MAX_AGE_SECONDS);
+
+    let result = client.try_get_price(&asset);
+    assert_eq!(result, Err(Ok(Error::OraclePriceNotFound)));
+}

--- a/contracts/token-factory/src/storage.rs
+++ b/contracts/token-factory/src/storage.rs
@@ -2210,6 +2210,51 @@ pub fn set_reservation_timeout_ledgers(env: &Env, ledgers: u32) {
         .set(&DataKey::ReservationTimeoutLedgers, &ledgers);
 }
 
+// ── Oracle price feed storage ─────────────────────────────────────────────
+
+/// Get the global oracle configuration, if it has been set via `configure_oracle`.
+pub fn get_oracle_config(env: &Env) -> Option<crate::types::OracleConfig> {
+    env.storage().instance().get(&DataKey::OracleConfig)
+}
+
+/// Set the global oracle configuration.
+pub fn set_oracle_config(env: &Env, config: &crate::types::OracleConfig) {
+    env.storage().instance().set(&DataKey::OracleConfig, config);
+}
+
+/// Returns `true` if `source` is authorized to submit oracle prices.
+pub fn is_oracle_source_authorized(env: &Env, source: &Address) -> bool {
+    env.storage()
+        .instance()
+        .get(&DataKey::OracleAuthorizedSource(source.clone()))
+        .unwrap_or(false)
+}
+
+/// Authorize or deauthorize `source` as an oracle price submitter.
+pub fn set_oracle_source_authorized(env: &Env, source: &Address, authorized: bool) {
+    env.storage().instance().set(
+        &DataKey::OracleAuthorizedSource(source.clone()),
+        &authorized,
+    );
+}
+
+/// Get the latest submitted price for `asset`, if any.
+pub fn get_oracle_price(env: &Env, asset: &Address) -> Option<crate::types::PriceData> {
+    let key = DataKey::OraclePrice(asset.clone());
+    let val = env.storage().persistent().get(&key);
+    if val.is_some() {
+        bump_persistent(env, &key);
+    }
+    val
+}
+
+/// Store the latest submitted price for `asset`.
+pub fn set_oracle_price(env: &Env, asset: &Address, price: &crate::types::PriceData) {
+    let key = DataKey::OraclePrice(asset.clone());
+    env.storage().persistent().set(&key, price);
+    bump_persistent(env, &key);
+}
+
 // ── Tests — Issue #1681: panic-free core storage getters ─────────────────────
 //
 // Each test calls a getter *before* `initialize()` has been invoked and

--- a/contracts/token-factory/src/types.rs
+++ b/contracts/token-factory/src/types.rs
@@ -689,12 +689,10 @@ pub struct PriceData {
 ///
 /// # Fields
 /// * `max_age_seconds` - Maximum acceptable age of a price before it is considered stale
-/// * `min_sources` - Minimum number of authorized sources that must have submitted a price
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct OracleConfig {
     pub max_age_seconds: u64,
-    pub min_sources: u32,
 }
 
 /// Batch fee update structure for Phase 2 optimization
@@ -962,6 +960,13 @@ pub enum DataKey {
     Reservation(u64),
     /// Ledgers a reservation may sit `Prepared` before it can be force-released
     ReservationTimeoutLedgers,
+    // ── Oracle price feed ─────────────────────────────────────────────────
+    /// Global oracle configuration (max staleness window).
+    OracleConfig,
+    /// Whether `source` is authorized to submit oracle prices.
+    OracleAuthorizedSource(Address),
+    /// Latest price observation submitted for `asset`.
+    OraclePrice(Address),
 }
 
 /// A point-in-time record of a token holder's balance.
@@ -1310,6 +1315,13 @@ impl Error {
     pub const MetadataImmutable: Self = Self(131);
     // Multisig admin-change errors
     pub const DuplicateSigners: Self = Self(132);
+    // Oracle price feed errors
+    pub const OracleUnauthorizedSource: Self = Self(133);
+    pub const OraclePriceStale: Self = Self(134);
+    pub const OracleInvalidPrice: Self = Self(135);
+    pub const OraclePriceNotFound: Self = Self(136);
+    pub const OracleInvalidConfig: Self = Self(137);
+    pub const OracleNotConfigured: Self = Self(138);
 
     /// Stable string name for this error code, for off-chain event payloads
     /// (see `emit_operation_failed`). Covers the vault entry-point error
@@ -1333,6 +1345,12 @@ impl Error {
             98 => "VaultOwnerChangeNotFound",
             99 => "VaultOwnerChangeAlreadyApproved",
             130 => "VaultCircuitBreakerActive",
+            133 => "OracleUnauthorizedSource",
+            134 => "OraclePriceStale",
+            135 => "OracleInvalidPrice",
+            136 => "OraclePriceNotFound",
+            137 => "OracleInvalidConfig",
+            138 => "OracleNotConfigured",
             _ => "UnknownError",
         }
     }


### PR DESCRIPTION
## Summary

Adds a lightweight, permissioned price-feed mechanism to the token-factory contract, as scoped in #1761:

- Admin configures the oracle (max staleness window) via `configure_oracle` and authorizes/deauthorizes price sources via `set_oracle_authorized`.
- Authorized sources push prices on-chain via `submit_price`.
- Consumers read prices via `get_price`, which enforces the staleness window and rejects non-positive values.

## Integration points

- New `contracts/token-factory/src/oracle.rs`, declared via `mod oracle;` in `lib.rs`.
- 4 new `#[contractimpl]` entry points on `TokenFactory`: `configure_oracle`, `set_oracle_authorized`, `submit_price`, `get_price`.
- New `DataKey` variants (`OracleConfig`, `OracleAuthorizedSource`, `OraclePrice`) — new discriminants, nothing reused. Reuses the existing (previously orphaned) `PriceData`/`OracleConfig` structs in `types.rs`, trimming the unused `min_sources` field from `OracleConfig` since it had no callers.
- New `Error` variants `133..=138` (`OracleUnauthorizedSource`, `OraclePriceStale`, `OracleInvalidPrice`, `OraclePriceNotFound`, `OracleInvalidConfig`, `OracleNotConfigured`), with matching `Error::name()` entries.
- Storage getters/setters in `storage.rs` and events in `events.rs` (`orc_cfg1`, `orc_src1`, `orc_pr1` — within Soroban's 9-char `symbol_short!` limit), following existing conventions.
- `oracle_integration_test.rs`: submit/read happy path, staleness rejection, unauthorized-source rejection, non-positive-price rejection, admin authorize/deauthorize.

Scope: contract only, per the issue. No consuming feature (AMM/liquidation) is wired to this primitive here.

## Test plan

- [x] `cargo check --lib` — clean
- [x] `cargo build --target wasm32v1-none --release --lib` — succeeds
- [x] Diff scoped to exactly the 6 oracle-related files (`oracle.rs`, `oracle_integration_test.rs`, `lib.rs`, `types.rs`, `storage.rs`, `events.rs`) — no unrelated changes included
- [x] `cargo test --lib` — the oracle code introduces **zero** new errors (verified the pre/post error count is identical: 156), but the crate's test target does not compile cleanly on `main` independent of this change — pre-existing, unrelated breakage across ~20 other test files (stale `testutils` imports, missing `create_vault` arg, etc.), already called out as separate/out-of-scope tech debt in a prior commit (`fd982a28`, "Fix pre-existing token-factory compile errors"). None of the failing lines fall inside code this PR added.

Closes #1761

