### PR TITLE
Add commit-reveal randomness scheme for auction tie-breaking

### DIFF
--- a/contracts/token-factory/src/commit_reveal.rs
+++ b/contracts/token-factory/src/commit_reveal.rs
@@ -1,0 +1,420 @@
+//! Commit-Reveal Randomness Scheme for Front-Running-Resistant Auction
+//! Tie-Breaking
+//!
+//! Bidders submit a hashed commitment during a bidding window, then reveal
+//! the pre-image during a separate reveal window. The final tie-break seed
+//! is derived from the hash-chain of all valid reveals, applied in
+//! deterministic submission order (commitment index, not reveal-arrival
+//! order), so no single participant can unilaterally determine the outcome.
+//!
+//! ```text
+//! 0 ──── commit_start ──── commit_end / reveal_start ──── reveal_end
+//!          [commit window]                [reveal window]
+//! ```
+//!
+//! This module is deliberately narrow in scope: it is the tie-breaking
+//! randomness primitive, not an auction implementation. `auction_id` is an
+//! opaque `u64` supplied by the caller for the consuming auction module to
+//! correlate a session with its own state; this module does not look up or
+//! validate against any auction record.
+//!
+//! ## Forfeiture rule
+//! A bidder who commits but never reveals forfeits their slot: they are
+//! silently excluded from tie-break resolution when the session is
+//! finalised. No refund advantage is granted to non-revealers — this module
+//! only tracks randomness contribution, not funds.
+//!
+//! ## Tie-break randomness derivation
+//! ```text
+//! state_0 = 32 zero bytes
+//! state_i = SHA256(state_{i-1} || pre_image_i)   for each revealed pre_image_i,
+//!                                                 taken in ascending commitment index
+//! seed    = state_n
+//! ```
+//! Bidders who never revealed contribute nothing and do not advance the
+//! chain — the ordering is fixed by commitment index (submission order), not
+//! by the order in which reveals happen to arrive, which is what prevents a
+//! late revealer from choosing their position to bias the outcome.
+
+use crate::{events, storage, types::Error};
+use soroban_sdk::{contracttype, Address, Bytes, BytesN, Env};
+
+/// Minimum commit window duration (seconds). Floors out griefing via an
+/// artificially short commit window that bidders have no realistic chance
+/// to participate in.
+pub const MIN_COMMIT_WINDOW: u64 = 60;
+/// Maximum commit window duration (seconds).
+pub const MAX_COMMIT_WINDOW: u64 = 7 * 24 * 3_600; // 7 days
+/// Minimum reveal window duration (seconds).
+pub const MIN_REVEAL_WINDOW: u64 = 60;
+/// Maximum reveal window duration (seconds).
+pub const MAX_REVEAL_WINDOW: u64 = 7 * 24 * 3_600; // 7 days
+/// Maximum number of bidders a single session accepts commitments from.
+pub const MAX_BIDDERS: u32 = 200;
+
+/// Lifecycle status of a commit-reveal session.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CommitRevealStatus {
+    /// Commit window is open (or has not started yet).
+    Committing = 0,
+    /// Reveal window is open.
+    Revealing = 1,
+    /// The tie-break seed has been derived; the session is terminal.
+    Finalised = 2,
+}
+
+/// A single bidder's commitment record.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CommitRecord {
+    /// Bidder address.
+    pub bidder: Address,
+    /// SHA-256 commitment: `H(pre_image)`, submitted during the commit window.
+    pub commitment: BytesN<32>,
+    /// Ledger timestamp the commitment was submitted.
+    pub committed_at: u64,
+    /// Whether the pre-image was successfully revealed.
+    pub revealed: bool,
+    /// The revealed pre-image. `None` until `revealed == true`.
+    pub pre_image: Option<BytesN<32>>,
+    /// Ledger timestamp of the reveal (`0` if not yet revealed).
+    pub revealed_at: u64,
+    /// Sequential index within the session (0-based, assigned at commit
+    /// time). This — not reveal-arrival order — is the order the hash-chain
+    /// is applied in.
+    pub index: u32,
+}
+
+/// A commit-reveal session.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CommitRevealSession {
+    /// Unique session ID.
+    pub id: u64,
+    /// Opaque identifier of the auction (or other mechanism) this session
+    /// resolves a tie-break for. Not validated by this module.
+    pub auction_id: u64,
+    /// Timestamp when bidders may start committing.
+    pub commit_start: u64,
+    /// Timestamp when the commit window closes.
+    pub commit_end: u64,
+    /// Timestamp when the reveal window opens (always equal to `commit_end`).
+    pub reveal_start: u64,
+    /// Timestamp when the reveal window closes.
+    pub reveal_end: u64,
+    /// Current session status.
+    pub status: CommitRevealStatus,
+    /// Number of commitments submitted so far.
+    pub commit_count: u32,
+    /// Number of valid reveals so far.
+    pub reveal_count: u32,
+    /// Final tie-break seed. `None` until finalisation.
+    pub final_seed: Option<BytesN<32>>,
+    /// Address that created the session (must match the factory admin).
+    pub creator: Address,
+    /// Ledger timestamp the session was created.
+    pub created_at: u64,
+}
+
+/// Create a new commit-reveal session (admin only).
+///
+/// `reveal_start` is always set to `commit_end` — reveals may not begin
+/// before commits stop being accepted.
+///
+/// # Errors
+/// * `Error::Unauthorized` — `admin` does not match the stored factory admin.
+/// * `Error::MissingAdmin` — no admin configured on the factory.
+/// * `Error::ContractPaused` — the factory is paused.
+/// * `Error::InvalidTimeWindow` — window ordering/duration is invalid (see
+///   `validate_windows`).
+pub fn create_commit_reveal_session(
+    env: &Env,
+    admin: &Address,
+    auction_id: u64,
+    commit_start: u64,
+    commit_end: u64,
+    reveal_end: u64,
+) -> Result<u64, Error> {
+    admin.require_auth();
+
+    if storage::is_paused(env) {
+        return Err(Error::ContractPaused);
+    }
+
+    let stored_admin = storage::get_admin(env).ok_or(Error::MissingAdmin)?;
+    if *admin != stored_admin {
+        return Err(Error::Unauthorized);
+    }
+
+    validate_windows(commit_start, commit_end, reveal_end)?;
+
+    let session_id = storage::get_next_commit_reveal_session_id(env)?;
+    let now = env.ledger().timestamp();
+
+    let session = CommitRevealSession {
+        id: session_id,
+        auction_id,
+        commit_start,
+        commit_end,
+        reveal_start: commit_end,
+        reveal_end,
+        status: CommitRevealStatus::Committing,
+        commit_count: 0,
+        reveal_count: 0,
+        final_seed: None,
+        creator: admin.clone(),
+        created_at: now,
+    };
+    storage::set_commit_reveal_session(env, &session);
+
+    events::emit_commit_reveal_session_created(
+        env,
+        session_id,
+        admin,
+        auction_id,
+        commit_start,
+        commit_end,
+        reveal_end,
+    );
+
+    Ok(session_id)
+}
+
+/// Submit a hashed commitment during the commit window.
+///
+/// `commitment` must equal `SHA256(pre_image)`; the contract stores only the
+/// hash and never sees the pre-image until `reveal_pre_image`. Each bidder
+/// may commit at most once per session; the assigned `index` is the position
+/// used for hash-chain ordering at finalisation.
+///
+/// # Errors
+/// * `Error::CommitRevealSessionNotFound` — no such session.
+/// * `Error::CommitWindowClosed` — outside `[commit_start, commit_end)`.
+/// * `Error::AlreadyCommitted` — `bidder` already has a commitment in this session.
+/// * `Error::TooManyBidders` — the session is at capacity (`MAX_BIDDERS`).
+pub fn submit_commitment(
+    env: &Env,
+    session_id: u64,
+    bidder: &Address,
+    commitment: BytesN<32>,
+) -> Result<u32, Error> {
+    bidder.require_auth();
+
+    let mut session = load_session(env, session_id)?;
+    let now = env.ledger().timestamp();
+
+    if now < session.commit_start || now >= session.commit_end {
+        return Err(Error::CommitWindowClosed);
+    }
+
+    if storage::has_commit_reveal_bidder(env, session_id, bidder) {
+        return Err(Error::AlreadyCommitted);
+    }
+
+    if session.commit_count >= MAX_BIDDERS {
+        return Err(Error::TooManyBidders);
+    }
+
+    let index = session.commit_count;
+    let record = CommitRecord {
+        bidder: bidder.clone(),
+        commitment,
+        committed_at: now,
+        revealed: false,
+        pre_image: None,
+        revealed_at: 0,
+        index,
+    };
+    storage::set_commit_record(env, session_id, index, &record);
+    storage::set_commit_reveal_bidder_index(env, session_id, bidder, index);
+
+    session.commit_count += 1;
+    storage::set_commit_reveal_session(env, &session);
+
+    events::emit_commitment_submitted(env, session_id, bidder, index);
+
+    Ok(index)
+}
+
+/// Reveal the pre-image committed to earlier, during the reveal window.
+///
+/// Verifies `SHA256(pre_image) == commitment` before accepting the reveal.
+/// On the first reveal in a session, the session status lazily transitions
+/// `Committing -> Revealing`.
+///
+/// # Errors
+/// * `Error::CommitRevealSessionNotFound` — no such session.
+/// * `Error::RevealWindowClosed` — outside `[reveal_start, reveal_end)`.
+/// * `Error::NoBidderCommitment` — `bidder` never committed in this session.
+/// * `Error::AlreadyRevealed` — `bidder` already revealed.
+/// * `Error::CommitmentMismatch` — `SHA256(pre_image)` does not match the
+///   stored commitment.
+pub fn reveal_pre_image(
+    env: &Env,
+    session_id: u64,
+    bidder: &Address,
+    pre_image: BytesN<32>,
+) -> Result<(), Error> {
+    bidder.require_auth();
+
+    let mut session = load_session(env, session_id)?;
+    let now = env.ledger().timestamp();
+
+    if now < session.reveal_start || now >= session.reveal_end {
+        return Err(Error::RevealWindowClosed);
+    }
+
+    let index = storage::get_commit_reveal_bidder_index(env, session_id, bidder)
+        .ok_or(Error::NoBidderCommitment)?;
+    let mut record =
+        storage::get_commit_record(env, session_id, index).ok_or(Error::NoBidderCommitment)?;
+
+    if record.revealed {
+        return Err(Error::AlreadyRevealed);
+    }
+
+    let pre_image_bytes: Bytes = pre_image.clone().into();
+    let digest: BytesN<32> = env.crypto().sha256(&pre_image_bytes).into();
+    if digest != record.commitment {
+        return Err(Error::CommitmentMismatch);
+    }
+
+    record.revealed = true;
+    record.pre_image = Some(pre_image);
+    record.revealed_at = now;
+    storage::set_commit_record(env, session_id, index, &record);
+
+    if session.status == CommitRevealStatus::Committing {
+        session.status = CommitRevealStatus::Revealing;
+    }
+    session.reveal_count += 1;
+    storage::set_commit_reveal_session(env, &session);
+
+    events::emit_pre_image_revealed(env, session_id, bidder, index);
+
+    Ok(())
+}
+
+/// Finalise the session and derive the combined tie-break seed.
+///
+/// Callable by anyone once the reveal window has closed. Walks every
+/// commitment in ascending index (submission) order and hash-chains only
+/// the revealed pre-images; bidders who never revealed are silently skipped
+/// (forfeited) and do not influence the seed or its position in the chain.
+///
+/// # Errors
+/// * `Error::CommitRevealSessionNotFound` — no such session.
+/// * `Error::RevealWindowOpen` — the reveal window has not closed yet.
+/// * `Error::AlreadyFinalised` — the session was already finalised.
+/// * `Error::NoValidReveals` — every bidder forfeited; no seed can be derived.
+pub fn finalise_session(env: &Env, session_id: u64) -> Result<BytesN<32>, Error> {
+    let mut session = load_session(env, session_id)?;
+    let now = env.ledger().timestamp();
+
+    if now < session.reveal_end {
+        return Err(Error::RevealWindowOpen);
+    }
+    if session.status == CommitRevealStatus::Finalised {
+        return Err(Error::AlreadyFinalised);
+    }
+
+    let seed = derive_seed(env, &session)?;
+
+    session.status = CommitRevealStatus::Finalised;
+    session.final_seed = Some(seed.clone());
+    storage::set_commit_reveal_session(env, &session);
+
+    events::emit_commit_reveal_finalised(
+        env,
+        session_id,
+        session.auction_id,
+        &seed,
+        session.reveal_count,
+    );
+
+    Ok(seed)
+}
+
+/// Look up a commit-reveal session by ID.
+pub fn get_session(env: &Env, session_id: u64) -> Option<CommitRevealSession> {
+    storage::get_commit_reveal_session(env, session_id)
+}
+
+/// Look up a bidder's commitment record within a session.
+pub fn get_commitment(env: &Env, session_id: u64, bidder: &Address) -> Option<CommitRecord> {
+    let index = storage::get_commit_reveal_bidder_index(env, session_id, bidder)?;
+    storage::get_commit_record(env, session_id, index)
+}
+
+fn load_session(env: &Env, session_id: u64) -> Result<CommitRevealSession, Error> {
+    storage::get_commit_reveal_session(env, session_id).ok_or(Error::CommitRevealSessionNotFound)
+}
+
+/// Validate commit/reveal window ordering and minimum/maximum durations.
+///
+/// `MIN_COMMIT_WINDOW` / `MIN_REVEAL_WINDOW` exist specifically to stop an
+/// admin (malicious or careless) from griefing bidders with a window too
+/// short to realistically act within.
+fn validate_windows(commit_start: u64, commit_end: u64, reveal_end: u64) -> Result<(), Error> {
+    if commit_end <= commit_start {
+        return Err(Error::InvalidTimeWindow);
+    }
+    let commit_dur = commit_end - commit_start;
+    if !(MIN_COMMIT_WINDOW..=MAX_COMMIT_WINDOW).contains(&commit_dur) {
+        return Err(Error::InvalidTimeWindow);
+    }
+
+    if reveal_end <= commit_end {
+        return Err(Error::InvalidTimeWindow);
+    }
+    let reveal_dur = reveal_end - commit_end;
+    if !(MIN_REVEAL_WINDOW..=MAX_REVEAL_WINDOW).contains(&reveal_dur) {
+        return Err(Error::InvalidTimeWindow);
+    }
+
+    Ok(())
+}
+
+/// Derive the final seed by hash-chaining all revealed pre-images in
+/// ascending commitment-index order:
+///
+/// ```text
+/// state_0 = [0u8; 32]
+/// state_i = SHA256(state_{i-1} || pre_image_i)   for each revealed pre_image_i
+/// seed    = state_n
+/// ```
+///
+/// Non-revealed commitments are skipped without breaking the chain — the
+/// order is fixed by commitment index, never by reveal-arrival order, which
+/// is what stops a bidder from timing their reveal to manipulate the seed.
+fn derive_seed(env: &Env, session: &CommitRevealSession) -> Result<BytesN<32>, Error> {
+    let mut state = Bytes::from_array(env, &[0u8; 32]);
+    let mut any_revealed = false;
+
+    for index in 0..session.commit_count {
+        let record = storage::get_commit_record(env, session.id, index)
+            .ok_or(Error::CommitRevealSessionNotFound)?;
+
+        if !record.revealed {
+            continue;
+        }
+        let pre_image = record.pre_image.ok_or(Error::CommitRevealSessionNotFound)?;
+
+        let pre_image_bytes: Bytes = pre_image.into();
+        let mut input = state.clone();
+        input.append(&pre_image_bytes);
+        state = env.crypto().sha256(&input).into();
+        any_revealed = true;
+    }
+
+    if !any_revealed {
+        return Err(Error::NoValidReveals);
+    }
+
+    // `state` is always exactly 32 bytes: seeded at 32 zero bytes and every
+    // update replaces it with a SHA-256 digest, so this conversion cannot fail.
+    Ok(state
+        .try_into()
+        .expect("hash-chain state is always 32 bytes"))
+}

--- a/contracts/token-factory/src/commit_reveal_test.rs
+++ b/contracts/token-factory/src/commit_reveal_test.rs
@@ -1,0 +1,424 @@
+#![cfg(test)]
+
+//! Tests for the commit-reveal randomness scheme (#1626)
+//!
+//! Covers:
+//! 1. Full commit-then-reveal happy path
+//! 2. Hash-chain derivation determinism
+//! 3. Non-revealer forfeiture
+//! 4. Reveal-outside-window rejection
+//! 5. Commit-outside-window rejection
+//! 6. Mismatched pre-image rejection
+
+use crate::commit_reveal::CommitRevealStatus;
+use crate::{TokenFactory, TokenFactoryClient};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    Address, Bytes, BytesN, Env,
+};
+
+const COMMIT_START: u64 = 100;
+const COMMIT_END: u64 = 200;
+const REVEAL_END: u64 = 300;
+
+/// Registers and initializes the factory, returning `(env, contract_id, admin)`.
+fn setup() -> (Env, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, TokenFactory);
+    let client = TokenFactoryClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    client.initialize(&admin, &treasury, &1_000_000, &500_000);
+
+    (env, contract_id, admin)
+}
+
+/// Builds a `(pre_image, commitment)` pair where `commitment = SHA256(pre_image)`.
+fn commitment_pair(env: &Env, seed: u8) -> (BytesN<32>, BytesN<32>) {
+    let mut raw = [0u8; 32];
+    raw[0] = seed;
+    let pre_image = BytesN::from_array(env, &raw);
+    let bytes: Bytes = pre_image.clone().into();
+    let commitment: BytesN<32> = env.crypto().sha256(&bytes).into();
+    (pre_image, commitment)
+}
+
+fn open_session(env: &Env, client: &TokenFactoryClient, admin: &Address, auction_id: u64) -> u64 {
+    env.ledger().with_mut(|l| l.timestamp = COMMIT_START);
+    client.create_commit_reveal_session(admin, &auction_id, &COMMIT_START, &COMMIT_END, &REVEAL_END)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1. Full commit-then-reveal happy path
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_commit_reveal_happy_path() {
+    let (env, contract_id, admin) = setup();
+    let client = TokenFactoryClient::new(&env, &contract_id);
+
+    let session_id = open_session(&env, &client, &admin, 1);
+
+    let bidder_a = Address::generate(&env);
+    let bidder_b = Address::generate(&env);
+    let bidder_c = Address::generate(&env);
+    let (pre_a, comm_a) = commitment_pair(&env, 0xAA);
+    let (pre_b, comm_b) = commitment_pair(&env, 0xBB);
+    let (pre_c, comm_c) = commitment_pair(&env, 0xCC);
+
+    env.ledger().with_mut(|l| l.timestamp = 150);
+    let idx_a = client.submit_commitment(&session_id, &bidder_a, &comm_a);
+    let idx_b = client.submit_commitment(&session_id, &bidder_b, &comm_b);
+    let idx_c = client.submit_commitment(&session_id, &bidder_c, &comm_c);
+    assert_eq!((idx_a, idx_b, idx_c), (0, 1, 2));
+
+    env.ledger().with_mut(|l| l.timestamp = 210);
+    client.reveal_pre_image(&session_id, &bidder_a, &pre_a);
+    client.reveal_pre_image(&session_id, &bidder_b, &pre_b);
+    client.reveal_pre_image(&session_id, &bidder_c, &pre_c);
+
+    env.ledger().with_mut(|l| l.timestamp = 310);
+    let seed = client.finalise_commit_reveal_session(&session_id);
+    assert_eq!(seed.len(), 32);
+
+    let session = client.get_commit_reveal_session(&session_id).unwrap();
+    assert_eq!(session.status, CommitRevealStatus::Finalised);
+    assert_eq!(session.commit_count, 3);
+    assert_eq!(session.reveal_count, 3);
+    assert_eq!(session.final_seed, Some(seed));
+
+    // A second finalise on an already-terminal session must fail.
+    let result = client.try_finalise_commit_reveal_session(&session_id);
+    assert!(result.is_err(), "double finalise must be rejected");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 2. Hash-chain derivation determinism
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_commit_reveal_seed_is_deterministic() {
+    let (env, contract_id, admin) = setup();
+    let client = TokenFactoryClient::new(&env, &contract_id);
+
+    let run = |auction_id: u64| -> BytesN<32> {
+        let session_id = open_session(&env, &client, &admin, auction_id);
+
+        let bidder_a = Address::generate(&env);
+        let bidder_b = Address::generate(&env);
+
+        // Fixed pre-images so both runs commit identical inputs.
+        let mut raw_a = [0u8; 32];
+        raw_a[0] = 0xDE;
+        let mut raw_b = [0u8; 32];
+        raw_b[0] = 0xAD;
+        let pre_a = BytesN::from_array(&env, &raw_a);
+        let pre_b = BytesN::from_array(&env, &raw_b);
+        let comm_a: BytesN<32> = env.crypto().sha256(&pre_a.clone().into()).into();
+        let comm_b: BytesN<32> = env.crypto().sha256(&pre_b.clone().into()).into();
+
+        env.ledger().with_mut(|l| l.timestamp = 150);
+        client.submit_commitment(&session_id, &bidder_a, &comm_a);
+        client.submit_commitment(&session_id, &bidder_b, &comm_b);
+
+        env.ledger().with_mut(|l| l.timestamp = 210);
+        client.reveal_pre_image(&session_id, &bidder_a, &pre_a);
+        client.reveal_pre_image(&session_id, &bidder_b, &pre_b);
+
+        env.ledger().with_mut(|l| l.timestamp = 310);
+        client.finalise_commit_reveal_session(&session_id)
+    };
+
+    let seed1 = run(1);
+    let seed2 = run(2);
+    assert_eq!(
+        seed1, seed2,
+        "identical commit/reveal inputs must produce identical seeds regardless of session id"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3. Non-revealer forfeiture
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_commit_reveal_non_revealer_forfeiture() {
+    let (env, contract_id, admin) = setup();
+    let client = TokenFactoryClient::new(&env, &contract_id);
+
+    let session_id = open_session(&env, &client, &admin, 1);
+
+    let honest = Address::generate(&env);
+    let forfeiter = Address::generate(&env);
+    let (pre_honest, comm_honest) = commitment_pair(&env, 0x01);
+    let (_pre_forfeiter, comm_forfeiter) = commitment_pair(&env, 0x02);
+
+    env.ledger().with_mut(|l| l.timestamp = 150);
+    client.submit_commitment(&session_id, &honest, &comm_honest);
+    client.submit_commitment(&session_id, &forfeiter, &comm_forfeiter);
+
+    // Only the honest bidder reveals; forfeiter never does.
+    env.ledger().with_mut(|l| l.timestamp = 210);
+    client.reveal_pre_image(&session_id, &honest, &pre_honest);
+
+    env.ledger().with_mut(|l| l.timestamp = 310);
+    let seed = client.finalise_commit_reveal_session(&session_id);
+    assert_eq!(seed.len(), 32);
+
+    let session = client.get_commit_reveal_session(&session_id).unwrap();
+    assert_eq!(session.status, CommitRevealStatus::Finalised);
+    assert_eq!(session.commit_count, 2);
+    // Only 1 valid reveal despite 2 commits — forfeiter excluded, no refund advantage.
+    assert_eq!(session.reveal_count, 1);
+
+    let forfeiter_record = client.get_commitment(&session_id, &forfeiter).unwrap();
+    assert!(!forfeiter_record.revealed);
+    assert!(forfeiter_record.pre_image.is_none());
+}
+
+#[test]
+fn test_commit_reveal_all_forfeit_has_no_valid_reveals() {
+    let (env, contract_id, admin) = setup();
+    let client = TokenFactoryClient::new(&env, &contract_id);
+
+    let session_id = open_session(&env, &client, &admin, 1);
+
+    let bidder = Address::generate(&env);
+    let (_pre, commitment) = commitment_pair(&env, 0x33);
+
+    env.ledger().with_mut(|l| l.timestamp = 150);
+    client.submit_commitment(&session_id, &bidder, &commitment);
+    // bidder never reveals
+
+    env.ledger().with_mut(|l| l.timestamp = 310);
+    let result = client.try_finalise_commit_reveal_session(&session_id);
+    assert!(
+        result.is_err(),
+        "finalising a session where every bidder forfeited must fail"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 4. Reveal-outside-window rejection
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_reveal_before_window_opens_rejected() {
+    let (env, contract_id, admin) = setup();
+    let client = TokenFactoryClient::new(&env, &contract_id);
+
+    let session_id = open_session(&env, &client, &admin, 1);
+
+    let bidder = Address::generate(&env);
+    let (pre_image, commitment) = commitment_pair(&env, 0x55);
+
+    env.ledger().with_mut(|l| l.timestamp = 150);
+    client.submit_commitment(&session_id, &bidder, &commitment);
+
+    // Still inside the commit window: reveal window has not opened yet.
+    env.ledger().with_mut(|l| l.timestamp = 199);
+    let result = client.try_reveal_pre_image(&session_id, &bidder, &pre_image);
+    assert!(result.is_err(), "reveal before commit_end must be rejected");
+}
+
+#[test]
+fn test_reveal_after_window_closes_rejected() {
+    let (env, contract_id, admin) = setup();
+    let client = TokenFactoryClient::new(&env, &contract_id);
+
+    let session_id = open_session(&env, &client, &admin, 1);
+
+    let bidder = Address::generate(&env);
+    let (pre_image, commitment) = commitment_pair(&env, 0x55);
+
+    env.ledger().with_mut(|l| l.timestamp = 150);
+    client.submit_commitment(&session_id, &bidder, &commitment);
+
+    env.ledger().with_mut(|l| l.timestamp = REVEAL_END + 1);
+    let result = client.try_reveal_pre_image(&session_id, &bidder, &pre_image);
+    assert!(result.is_err(), "reveal after reveal_end must be rejected");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 5. Commit-outside-window rejection
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_commit_before_window_opens_rejected() {
+    let (env, contract_id, admin) = setup();
+    let client = TokenFactoryClient::new(&env, &contract_id);
+
+    env.ledger().with_mut(|l| l.timestamp = COMMIT_START);
+    let session_id =
+        client.create_commit_reveal_session(&admin, &1u64, &COMMIT_START, &COMMIT_END, &REVEAL_END);
+
+    let bidder = Address::generate(&env);
+    let (_, commitment) = commitment_pair(&env, 0x66);
+
+    env.ledger().with_mut(|l| l.timestamp = COMMIT_START - 1);
+    let result = client.try_submit_commitment(&session_id, &bidder, &commitment);
+    assert!(
+        result.is_err(),
+        "commit before commit_start must be rejected"
+    );
+}
+
+#[test]
+fn test_commit_after_window_closes_rejected() {
+    let (env, contract_id, admin) = setup();
+    let client = TokenFactoryClient::new(&env, &contract_id);
+
+    let session_id = open_session(&env, &client, &admin, 1);
+
+    let bidder = Address::generate(&env);
+    let (_, commitment) = commitment_pair(&env, 0x77);
+
+    env.ledger().with_mut(|l| l.timestamp = COMMIT_END);
+    let result = client.try_submit_commitment(&session_id, &bidder, &commitment);
+    assert!(
+        result.is_err(),
+        "commit at/after commit_end must be rejected"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 6. Mismatched pre-image rejection
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_commitment_mismatch_rejected() {
+    let (env, contract_id, admin) = setup();
+    let client = TokenFactoryClient::new(&env, &contract_id);
+
+    let session_id = open_session(&env, &client, &admin, 1);
+
+    let bidder = Address::generate(&env);
+    let (_, commitment) = commitment_pair(&env, 0x11);
+    let (wrong_pre_image, _) = commitment_pair(&env, 0x22);
+
+    env.ledger().with_mut(|l| l.timestamp = 150);
+    client.submit_commitment(&session_id, &bidder, &commitment);
+
+    env.ledger().with_mut(|l| l.timestamp = 210);
+    let result = client.try_reveal_pre_image(&session_id, &bidder, &wrong_pre_image);
+    assert!(
+        result.is_err(),
+        "a pre-image that doesn't hash to the stored commitment must be rejected"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Additional coverage: duplicate commit, double reveal, unauthorized session
+// creation, and window-parameter validation.
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_duplicate_commit_rejected() {
+    let (env, contract_id, admin) = setup();
+    let client = TokenFactoryClient::new(&env, &contract_id);
+
+    let session_id = open_session(&env, &client, &admin, 1);
+    let bidder = Address::generate(&env);
+    let (_, commitment) = commitment_pair(&env, 0x99);
+
+    env.ledger().with_mut(|l| l.timestamp = 150);
+    client.submit_commitment(&session_id, &bidder, &commitment);
+
+    let result = client.try_submit_commitment(&session_id, &bidder, &commitment);
+    assert!(result.is_err(), "a bidder may only commit once per session");
+}
+
+#[test]
+fn test_double_reveal_rejected() {
+    let (env, contract_id, admin) = setup();
+    let client = TokenFactoryClient::new(&env, &contract_id);
+
+    let session_id = open_session(&env, &client, &admin, 1);
+    let bidder = Address::generate(&env);
+    let (pre_image, commitment) = commitment_pair(&env, 0x44);
+
+    env.ledger().with_mut(|l| l.timestamp = 150);
+    client.submit_commitment(&session_id, &bidder, &commitment);
+
+    env.ledger().with_mut(|l| l.timestamp = 210);
+    client.reveal_pre_image(&session_id, &bidder, &pre_image);
+
+    let result = client.try_reveal_pre_image(&session_id, &bidder, &pre_image);
+    assert!(result.is_err(), "a bidder may only reveal once");
+}
+
+#[test]
+fn test_non_admin_cannot_create_session() {
+    let (env, contract_id, _admin) = setup();
+    let client = TokenFactoryClient::new(&env, &contract_id);
+
+    let attacker = Address::generate(&env);
+    env.ledger().with_mut(|l| l.timestamp = COMMIT_START);
+    let result = client.try_create_commit_reveal_session(
+        &attacker,
+        &1u64,
+        &COMMIT_START,
+        &COMMIT_END,
+        &REVEAL_END,
+    );
+    assert!(
+        result.is_err(),
+        "only the factory admin may create a commit-reveal session"
+    );
+}
+
+#[test]
+fn test_session_window_too_short_rejected() {
+    let (env, contract_id, admin) = setup();
+    let client = TokenFactoryClient::new(&env, &contract_id);
+
+    env.ledger().with_mut(|l| l.timestamp = COMMIT_START);
+    // Commit window of 1 second is below MIN_COMMIT_WINDOW.
+    let result = client.try_create_commit_reveal_session(
+        &admin,
+        &1u64,
+        &COMMIT_START,
+        &(COMMIT_START + 1),
+        &(COMMIT_START + 1 + 3_600),
+    );
+    assert!(
+        result.is_err(),
+        "a commit window shorter than MIN_COMMIT_WINDOW must be rejected"
+    );
+}
+
+#[test]
+fn test_finalise_before_reveal_window_closes_rejected() {
+    let (env, contract_id, admin) = setup();
+    let client = TokenFactoryClient::new(&env, &contract_id);
+
+    let session_id = open_session(&env, &client, &admin, 1);
+    let bidder = Address::generate(&env);
+    let (pre_image, commitment) = commitment_pair(&env, 0x88);
+
+    env.ledger().with_mut(|l| l.timestamp = 150);
+    client.submit_commitment(&session_id, &bidder, &commitment);
+
+    env.ledger().with_mut(|l| l.timestamp = 210);
+    client.reveal_pre_image(&session_id, &bidder, &pre_image);
+
+    // Reveal window is still open.
+    let result = client.try_finalise_commit_reveal_session(&session_id);
+    assert!(
+        result.is_err(),
+        "finalise must fail while the reveal window is still open"
+    );
+}
+
+#[test]
+fn test_unknown_session_queries_return_none() {
+    let (env, contract_id, _admin) = setup();
+    let client = TokenFactoryClient::new(&env, &contract_id);
+
+    assert!(client.get_commit_reveal_session(&999_u64).is_none());
+    let someone = Address::generate(&env);
+    assert!(client.get_commitment(&999_u64, &someone).is_none());
+}

--- a/contracts/token-factory/src/events.rs
+++ b/contracts/token-factory/src/events.rs
@@ -1894,3 +1894,114 @@ pub fn emit_settlement_timeout_cleanup(env: &Env, reservation_id: u64, proposal_
     env.events()
         .publish((symbol_short!("stl_tmo1"), reservation_id), (proposal_id,));
 }
+
+// ── Commit-reveal auction tie-breaking events (#1626) ────────────────────────
+
+/// Emitted when a commit-reveal session is created via
+/// `create_commit_reveal_session`.
+///
+/// **Schema Version**: 1
+/// **Event Name**: cr_open1
+///
+/// **Topics** (indexed):
+/// - Event name: "cr_open1"
+/// - session_id: u64 - The newly created session id
+///
+/// **Payload** (non-indexed):
+/// - creator: Address - The admin that created the session
+/// - auction_id: u64 - Opaque id of the auction/mechanism this session ties into
+/// - commit_start: u64 - Timestamp the commit window opens
+/// - commit_end: u64 - Timestamp the commit window closes / reveal window opens
+/// - reveal_end: u64 - Timestamp the reveal window closes
+///
+/// **Schema Stability**: This schema is immutable. Any changes require a new version.
+pub fn emit_commit_reveal_session_created(
+    env: &Env,
+    session_id: u64,
+    creator: &Address,
+    auction_id: u64,
+    commit_start: u64,
+    commit_end: u64,
+    reveal_end: u64,
+) {
+    env.events().publish(
+        (symbol_short!("cr_open1"), session_id),
+        (
+            creator.clone(),
+            auction_id,
+            commit_start,
+            commit_end,
+            reveal_end,
+        ),
+    );
+}
+
+/// Emitted when a bidder submits a commitment via `submit_commitment`.
+///
+/// **Schema Version**: 1
+/// **Event Name**: cr_cmit1
+///
+/// **Topics** (indexed):
+/// - Event name: "cr_cmit1"
+/// - session_id: u64 - The session the commitment was submitted to
+///
+/// **Payload** (non-indexed):
+/// - bidder: Address - The address that committed
+/// - index: u32 - The bidder's commitment index (used for hash-chain ordering)
+///
+/// **Schema Stability**: This schema is immutable. Any changes require a new version.
+pub fn emit_commitment_submitted(env: &Env, session_id: u64, bidder: &Address, index: u32) {
+    env.events().publish(
+        (symbol_short!("cr_cmit1"), session_id),
+        (bidder.clone(), index),
+    );
+}
+
+/// Emitted when a bidder successfully reveals a pre-image via `reveal_pre_image`.
+///
+/// **Schema Version**: 1
+/// **Event Name**: cr_rvl1
+///
+/// **Topics** (indexed):
+/// - Event name: "cr_rvl1"
+/// - session_id: u64 - The session the reveal was submitted to
+///
+/// **Payload** (non-indexed):
+/// - bidder: Address - The address that revealed
+/// - index: u32 - The bidder's commitment index
+///
+/// **Schema Stability**: This schema is immutable. Any changes require a new version.
+pub fn emit_pre_image_revealed(env: &Env, session_id: u64, bidder: &Address, index: u32) {
+    env.events().publish(
+        (symbol_short!("cr_rvl1"), session_id),
+        (bidder.clone(), index),
+    );
+}
+
+/// Emitted when a session is finalised via `finalise_commit_reveal_session`.
+///
+/// **Schema Version**: 1
+/// **Event Name**: cr_fin1
+///
+/// **Topics** (indexed):
+/// - Event name: "cr_fin1"
+/// - session_id: u64 - The finalised session id
+///
+/// **Payload** (non-indexed):
+/// - auction_id: u64 - Opaque id of the auction/mechanism this session ties into
+/// - seed: BytesN<32> - The derived tie-break seed
+/// - reveal_count: u32 - Number of valid (non-forfeited) reveals folded into the seed
+///
+/// **Schema Stability**: This schema is immutable. Any changes require a new version.
+pub fn emit_commit_reveal_finalised(
+    env: &Env,
+    session_id: u64,
+    auction_id: u64,
+    seed: &BytesN<32>,
+    reveal_count: u32,
+) {
+    env.events().publish(
+        (symbol_short!("cr_fin1"), session_id),
+        (auction_id, seed.clone(), reveal_count),
+    );
+}

--- a/contracts/token-factory/src/lib.rs
+++ b/contracts/token-factory/src/lib.rs
@@ -16,6 +16,9 @@ mod ipfs_pinning;
 mod batch_operations;
 mod batch_scheduler;
 mod burn;
+mod commit_reveal;
+#[cfg(test)]
+mod commit_reveal_test;
 mod settlement;
 mod clawback;
 mod invariants;
@@ -4147,6 +4150,73 @@ impl TokenFactory {
         Ok(())
     }
 
+    // ── Commit-reveal auction tie-breaking (#1626) ───────────────────────
+
+    /// Create a commit-reveal session for front-running-resistant tie-breaking
+    /// (admin only). Emits `cr_open1`. See `commit_reveal.rs` for full docs.
+    pub fn create_commit_reveal_session(
+        env: Env,
+        admin: Address,
+        auction_id: u64,
+        commit_start: u64,
+        commit_end: u64,
+        reveal_end: u64,
+    ) -> Result<u64, Error> {
+        commit_reveal::create_commit_reveal_session(
+            &env,
+            &admin,
+            auction_id,
+            commit_start,
+            commit_end,
+            reveal_end,
+        )
+    }
+
+    /// Submit a hashed commitment (`SHA256(pre_image)`) during the commit
+    /// window. Emits `cr_cmit1`. Returns the bidder's commitment index.
+    pub fn submit_commitment(
+        env: Env,
+        session_id: u64,
+        bidder: Address,
+        commitment: BytesN<32>,
+    ) -> Result<u32, Error> {
+        commit_reveal::submit_commitment(&env, session_id, &bidder, commitment)
+    }
+
+    /// Reveal the pre-image committed to earlier, during the reveal window.
+    /// Emits `cr_rvl1`.
+    pub fn reveal_pre_image(
+        env: Env,
+        session_id: u64,
+        bidder: Address,
+        pre_image: BytesN<32>,
+    ) -> Result<(), Error> {
+        commit_reveal::reveal_pre_image(&env, session_id, &bidder, pre_image)
+    }
+
+    /// Finalise a commit-reveal session, deriving the tie-break seed from the
+    /// hash-chain of all valid reveals in submission order. Callable by
+    /// anyone once the reveal window has closed. Emits `cr_fin1`.
+    pub fn finalise_commit_reveal_session(env: Env, session_id: u64) -> Result<BytesN<32>, Error> {
+        commit_reveal::finalise_session(&env, session_id)
+    }
+
+    /// Look up a commit-reveal session by id.
+    pub fn get_commit_reveal_session(
+        env: Env,
+        session_id: u64,
+    ) -> Option<commit_reveal::CommitRevealSession> {
+        commit_reveal::get_session(&env, session_id)
+    }
+
+    /// Look up a bidder's commitment record within a session.
+    pub fn get_commitment(
+        env: Env,
+        session_id: u64,
+        bidder: Address,
+    ) -> Option<commit_reveal::CommitRecord> {
+        commit_reveal::get_commitment(&env, session_id, &bidder)
+    }
 }
 
 // Temporarily disabled - requires create_token implementation

--- a/contracts/token-factory/src/storage.rs
+++ b/contracts/token-factory/src/storage.rs
@@ -1,5 +1,6 @@
 use soroban_sdk::{Address, Env, Vec};
 
+use crate::commit_reveal::{CommitRecord, CommitRevealSession};
 use crate::types::{
     BuybackCampaign, DataKey, Error, FactoryState, Reservation, RevealBatchContinuation,
     SettleBatchContinuation, StreamCursor, TokenInfo,
@@ -2208,6 +2209,78 @@ pub fn set_reservation_timeout_ledgers(env: &Env, ledgers: u32) {
     env.storage()
         .instance()
         .set(&DataKey::ReservationTimeoutLedgers, &ledgers);
+}
+
+// ── Commit-reveal session storage (#1626) ────────────────────────────────────
+
+/// Assign and return the next commit-reveal session id, advancing the counter.
+pub fn get_next_commit_reveal_session_id(env: &Env) -> Result<u64, Error> {
+    let count: u64 = env
+        .storage()
+        .instance()
+        .get(&DataKey::CommitRevealSessionCount)
+        .unwrap_or(0_u64);
+    let next = count.checked_add(1).ok_or(Error::ArithmeticError)?;
+    env.storage()
+        .instance()
+        .set(&DataKey::CommitRevealSessionCount, &next);
+    Ok(next)
+}
+
+/// Get a commit-reveal session by id.
+pub fn get_commit_reveal_session(env: &Env, session_id: u64) -> Option<CommitRevealSession> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::CommitRevealSession(session_id))
+}
+
+/// Persist a commit-reveal session, keyed by its own id.
+pub fn set_commit_reveal_session(env: &Env, session: &CommitRevealSession) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::CommitRevealSession(session.id), session);
+}
+
+/// Get a bidder's commitment record by (session, commitment index).
+pub fn get_commit_record(env: &Env, session_id: u64, index: u32) -> Option<CommitRecord> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::CommitRecord(session_id, index))
+}
+
+/// Persist a bidder's commitment record at (session, commitment index).
+pub fn set_commit_record(env: &Env, session_id: u64, index: u32, record: &CommitRecord) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::CommitRecord(session_id, index), record);
+}
+
+/// Whether `bidder` already has a commitment recorded in `session_id`.
+pub fn has_commit_reveal_bidder(env: &Env, session_id: u64, bidder: &Address) -> bool {
+    env.storage()
+        .persistent()
+        .has(&DataKey::CommitRevealBidderIndex(
+            session_id,
+            bidder.clone(),
+        ))
+}
+
+/// Get the commitment index assigned to `bidder` within `session_id`.
+pub fn get_commit_reveal_bidder_index(env: &Env, session_id: u64, bidder: &Address) -> Option<u32> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::CommitRevealBidderIndex(
+            session_id,
+            bidder.clone(),
+        ))
+}
+
+/// Record the commitment index assigned to `bidder` within `session_id`.
+pub fn set_commit_reveal_bidder_index(env: &Env, session_id: u64, bidder: &Address, index: u32) {
+    env.storage().persistent().set(
+        &DataKey::CommitRevealBidderIndex(session_id, bidder.clone()),
+        &index,
+    );
 }
 
 // ── Tests — Issue #1681: panic-free core storage getters ─────────────────────


### PR DESCRIPTION
## Summary

Closes #1766

Implements a commit-reveal randomness primitive for front-running-resistant auction tie-breaking, as a standalone contract module (no auction/backend/frontend wiring, per the issue's scope note):

```
0 ──── commit_start ──── commit_end / reveal_start ──── reveal_end
         [commit window]                [reveal window]
```

- **`create_commit_reveal_session(admin, auction_id, commit_start, commit_end, reveal_end) -> u64`** — admin-gated, opens a new session. `reveal_start` is always pinned to `commit_end`. Enforces `MIN_COMMIT_WINDOW`/`MIN_REVEAL_WINDOW` floors (60s) and `MAX_*` ceilings (7 days) so an admin can't grief bidders with a window too short to realistically act in.
- **`submit_commitment(session_id, bidder, commitment) -> u32`** — bidder-authorized, accepts `SHA256(pre_image)` during `[commit_start, commit_end)`. Returns the assigned commitment index — this index, not reveal-arrival order, is what fixes the hash-chain ordering later.
- **`reveal_pre_image(session_id, bidder, pre_image)`** — bidder-authorized, accepted during `[commit_end, reveal_end)`. Verifies `SHA256(pre_image) == commitment` before recording the reveal.
- **`finalise_commit_reveal_session(session_id) -> BytesN<32>`** — callable by anyone once the reveal window has closed. Walks every commitment in ascending index order and hash-chains only the revealed pre-images (`state_i = SHA256(state_{i-1} || pre_image_i)`, seeded from 32 zero bytes). Bidders who never revealed are silently skipped — forfeited, no refund advantage, and critically they don't get to pick *where* in the chain they'd land by timing a late reveal, since the order is fixed at commit time.
- **Query entry points**: `get_commit_reveal_session(session_id)`, `get_commitment(session_id, bidder)`.

## Changes

Following the issue's integration-points checklist:

- **`contracts/token-factory/src/commit_reveal.rs`** (new) — all logic above, wired via `mod commit_reveal;` in `lib.rs`
- **`lib.rs`** — thin `#[contractimpl]` wrappers for the six suggested entry points
- **`types.rs`** — **no changes needed.** The `DataKey` variants (`CommitRevealSession`, `CommitRevealSessionCount`, `CommitRecord`, `CommitRevealBidderIndex`) and `Error` variants (106–116: `CommitRevealSessionNotFound`, `CommitWindowClosed`, `RevealWindowClosed`, `RevealWindowOpen`, `AlreadyCommitted`, `AlreadyRevealed`, `CommitmentMismatch`, `NoBidderCommitment`, `NoValidReveals`, `AlreadyFinalised`, `TooManyBidders`) already exist on `main` — left over from an earlier commit-reveal implementation (#1739) that was later trimmed as "unused" along with a large batch of other modules. This PR re-adds the module that actually uses them.
- **`storage.rs`** — getters/setters for session/commitment/bidder-index state, following the existing pattern
- **`events.rs`** — `cr_open1` / `cr_cmit1` / `cr_rvl1` / `cr_fin1`, short `symbol_short!` topics per Soroban's 9-character limit, with the same versioned-schema doc-comment format as the rest of the file
- **`commit_reveal_test.rs`** (new) — 15 tests: happy path (3-bidder tiebreak + double-finalise rejection), hash-chain determinism (identical inputs → identical seed across different sessions), non-revealer forfeiture, all-forfeit rejection, reveal before/after window, commit before/after window, commitment mismatch, duplicate commit, double reveal, non-admin session creation, sub-minimum window rejection, premature finalise, and unknown-session queries

## Test plan / screenshots

```
$ cargo check --lib
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.25s

$ cargo build --release
   Compiling token-factory v0.1.0 (/workspaces/Nova-launch/contracts/token-factory)
    Finished `release` profile [optimized] target(s) in 38.14s

$ cargo build --target wasm32v1-none --release --lib
    Finished `release` profile [optimized] target(s) in 0.14s
$ ls contracts/target/wasm32v1-none/release/token_factory.wasm
-rwxrwxrwx 1 codespace codespace 334585 ... token_factory.wasm
```

**On `cargo test` — flagging a pre-existing, unrelated blocker rather than a fabricated pass:**

`cargo test --lib` (and `cargo test --lib commit_reveal`, and even a from-scratch integration test target) currently fail to *compile* on this repo, with an error that traces back to `soroban-sdk-macros` under the `testutils` feature (required for any test build) rejecting `Option<StreamCursor>` in `types.rs`:

```
error[E0277]: the trait bound `ScVal: TryFrom<&core::option::Option<StreamCursor>>` is not satisfied
   --> token-factory/src/types.rs:1559:1
    |
1559 | #[contracttype]
    | ^^^^^^^^^^^^^^^ the trait `From<StreamCursor>` is not implemented for `ScVal`
```

I verified this is **not caused by this PR** and is not a soroban-sdk version-drift fluke:
- It reproduces identically, byte-for-byte, on a clean checkout of `origin/main` (`89ac7bcc`), before any of my changes.
- It reproduces on a from-scratch integration test target that only depends on the compiled lib + `soroban-sdk` `testutils` — no dev-dependency and no test module of mine is involved.
- I bisected it across `soroban-sdk` `27.0.4` / `27.0.5` / `27.0.6` (the whole range `contracts/token-factory/Cargo.toml`'s `"27.0.3"` requirement currently resolves to, since `Cargo.lock` is gitignored) — identical failure on all three, so it isn't a recent upstream regression either.
- The real cause: `types.rs`'s `PaginatedStreamsResponse.next_cursor: Option<StreamCursor>` is the *only* place in the whole crate where a custom (non-SDK) struct is wrapped in `Option<...>`. Every other `Option<T>` in the file uses an SDK type (`Address`, `String`, `i128`, `BytesN`, ...). `#[contracttype]`'s generated `ScVal` conversions apparently don't chain through `Option<CustomStruct>` in this soroban-sdk series — but only under the `testutils`-enabled build (`cargo check`/`cargo build` without dev-dependencies never hit this path, which is why it stayed invisible). This is a pre-existing, narrowly-scoped bug in the stream-pagination feature, unrelated to any file this PR touches.
- Net effect: `cargo test` is currently unable to compile *at all* on this crate, for anyone, regardless of branch — not specific to commit-reveal. Once fixed, `cargo test --lib commit_reveal` is the right command to reproduce the 15 tests above.
- For confidence in the meantime: I ran the near-identical original commit-reveal implementation this PR is adapted from (git history `c299d459`, merged via #1739) and it exercised the same scenarios successfully before the module was later removed as "unused" in #1767 — the module here is that same logic, ported onto the current `storage.rs`/`events.rs` conventions (bridge.rs pattern) instead of raw `env.storage()`/`env.events()` calls.

I didn't touch `types.rs`/`StreamCursor` in this PR since it's unrelated to commit-reveal and outside this issue's scope — flagging it here so it isn't lost, and happy to open a separate fix if that's wanted.

## Acceptance checklist

- [x] `commit_reveal.rs` implemented under `contracts/token-factory/src/`, wired into `lib.rs`
- [x] Session creation, commit, reveal, finalise, and query entry points implemented
- [x] `DataKey`/`Error` additions follow the checklist (already present on `main`, confirmed unchanged/unused before this PR)
- [x] Storage and events wired following existing patterns
- [x] Unit tests in `commit_reveal_test.rs` covering all six required scenarios plus extra edge cases
- [x] `cargo check --lib` clean in `contracts/token-factory`
- [ ] `cargo test --lib` clean — blocked by the pre-existing, unrelated `soroban-sdk`/testutils regression documented above (reproduces on `main`)
- [x] `cargo build --target wasm32v1-none --release --lib` succeeds
