### PR TITLE
Implement asset fractionalization (contract-only)

### DIFF
--- a/contracts/token-factory/src/fractionalization.rs
+++ b/contracts/token-factory/src/fractionalization.rs
@@ -1,0 +1,183 @@
+//! Asset Fractionalization Module
+//!
+//! Locks a unique external asset (identified by its `asset_contract` SAC
+//! address plus a caller-supplied `asset_id`) in this contract and mints
+//! fractional ownership shares. Locking is performed via the standard
+//! `soroban_sdk::token` client against the external asset contract, mirroring
+//! the pattern already used by `vault.rs` / `create_vault` for real token
+//! custody.
+//!
+//! Fractional shares are tracked in dedicated storage (`FractionalShareBalance`)
+//! rather than through the factory's own token registry, since shares aren't
+//! one of this factory's deployed tokens.
+//!
+//! The asset can only be redeemed once a single holder has accumulated and
+//! burned 100% of the outstanding shares for that vault.
+
+use crate::storage;
+use crate::types::{Error, FractionalStatus, FractionalVault, FractionalizationParams};
+use soroban_sdk::{token, Address, Env};
+
+/// Amount of the underlying asset locked to represent one unique, indivisible unit.
+const UNIQUE_ASSET_AMOUNT: i128 = 1;
+
+fn validate_params(params: &FractionalizationParams) -> Result<(), Error> {
+    if params.token_name.is_empty() || params.token_name.len() > 32 {
+        return Err(Error::InvalidTokenParams);
+    }
+    if params.token_symbol.is_empty() || params.token_symbol.len() > 12 {
+        return Err(Error::InvalidTokenParams);
+    }
+    if params.total_supply <= 0 {
+        return Err(Error::InvalidAmount);
+    }
+    Ok(())
+}
+
+/// Lock a unique asset and mint `params.total_supply` fractional ownership shares.
+///
+/// `owner` must hold and authorize the transfer of `UNIQUE_ASSET_AMOUNT` of
+/// `params.asset_contract` to this contract. The pair
+/// `(params.asset_contract, params.asset_id)` identifies this specific
+/// unique asset and cannot have another active fractionalization vault.
+///
+/// # Returns
+/// The id of the newly created fractionalization vault.
+///
+/// # Errors
+/// * `Error::ContractPaused` - Contract is paused
+/// * `Error::InvalidTokenParams` - Shares token name/symbol are invalid
+/// * `Error::InvalidAmount` - `total_supply` is zero or negative
+/// * `Error::AssetAlreadyFractionalized` - This asset already has an active vault
+/// * `Error::ArithmeticError` - Overflow incrementing the vault id counter
+pub fn fractionalize(
+    env: &Env,
+    owner: Address,
+    params: FractionalizationParams,
+) -> Result<u64, Error> {
+    owner.require_auth();
+
+    if storage::is_paused(env) {
+        return Err(Error::ContractPaused);
+    }
+
+    validate_params(&params)?;
+
+    // Reject double-fractionalization / enforce asset uniqueness: this exact
+    // (asset_contract, asset_id) pair may not have another active vault.
+    if let Some(existing_id) =
+        storage::get_asset_fractionalization_index(env, &params.asset_contract, &params.asset_id)
+    {
+        if let Some(existing) = storage::get_fractional_vault(env, existing_id) {
+            if existing.status == FractionalStatus::Active {
+                return Err(Error::AssetAlreadyFractionalized);
+            }
+        }
+    }
+
+    // Lock the asset: transfer the single unique unit from the owner into
+    // this contract's custody via the external asset's standard token interface.
+    let asset_client = token::Client::new(env, &params.asset_contract);
+    asset_client.transfer(&owner, env.current_contract_address(), &UNIQUE_ASSET_AMOUNT);
+
+    let vault_id = storage::increment_fractional_vault_count(env)?;
+
+    // The shares "token" isn't a separately deployed contract — the factory
+    // itself is the fractional token's issuer/ledger of record, matching how
+    // this factory's own registered tokens report their own contract address
+    // (see `token_creation::create_token_internal`).
+    let fractional_token = env.current_contract_address();
+
+    let vault = FractionalVault {
+        id: vault_id,
+        asset_id: params.asset_id.clone(),
+        asset_contract: params.asset_contract.clone(),
+        owner: owner.clone(),
+        fractional_token: fractional_token.clone(),
+        total_supply: params.total_supply,
+        created_at: env.ledger().timestamp(),
+        status: FractionalStatus::Active,
+    };
+    storage::set_fractional_vault(env, &vault);
+    storage::set_asset_fractionalization_index(
+        env,
+        &params.asset_contract,
+        &params.asset_id,
+        vault_id,
+    );
+    storage::set_fractional_share_balance(env, vault_id, &owner, params.total_supply);
+
+    crate::events::emit_asset_fractionalized(
+        env,
+        vault_id,
+        &params.asset_id,
+        &params.asset_contract,
+        &owner,
+        &fractional_token,
+        params.total_supply,
+    );
+
+    Ok(vault_id)
+}
+
+/// Redeem (unlock) a fractionalized asset.
+///
+/// `caller` must hold and authorize the burn of 100% of the vault's
+/// outstanding shares; the locked asset is then released back to `caller`.
+///
+/// # Errors
+/// * `Error::ContractPaused` - Contract is paused
+/// * `Error::FractionalVaultNotFound` - No active vault exists for `vault_id`
+/// * `Error::InsufficientShares` - Caller does not hold 100% of the outstanding shares
+pub fn redeem(env: &Env, caller: Address, vault_id: u64) -> Result<(), Error> {
+    caller.require_auth();
+
+    if storage::is_paused(env) {
+        return Err(Error::ContractPaused);
+    }
+
+    let mut vault =
+        storage::get_fractional_vault(env, vault_id).ok_or(Error::FractionalVaultNotFound)?;
+
+    if vault.status != FractionalStatus::Active {
+        return Err(Error::FractionalVaultNotFound);
+    }
+
+    let caller_shares = storage::get_fractional_share_balance(env, vault_id, &caller);
+    if caller_shares <= 0 || caller_shares != vault.total_supply {
+        return Err(Error::InsufficientShares);
+    }
+
+    // Burn 100% of the outstanding shares held by the caller.
+    storage::set_fractional_share_balance(env, vault_id, &caller, 0);
+
+    // Release the locked asset back to the caller.
+    let asset_client = token::Client::new(env, &vault.asset_contract);
+    asset_client.transfer(
+        &env.current_contract_address(),
+        &caller,
+        &UNIQUE_ASSET_AMOUNT,
+    );
+
+    vault.status = FractionalStatus::Redeemed;
+    storage::set_fractional_vault(env, &vault);
+
+    crate::events::emit_asset_redeemed(
+        env,
+        vault_id,
+        &vault.asset_id,
+        &vault.asset_contract,
+        &caller,
+        caller_shares,
+    );
+
+    Ok(())
+}
+
+/// Returns `true` if `vault_id` currently has an active fractionalization vault.
+pub fn is_fractionalized(env: &Env, vault_id: u64) -> bool {
+    match storage::get_fractional_vault(env, vault_id) {
+        Some(vault) => vault.status == FractionalStatus::Active,
+        None => false,
+    }
+}

--- a/contracts/token-factory/src/fractionalization_test.rs
+++ b/contracts/token-factory/src/fractionalization_test.rs
@@ -1,0 +1,270 @@
+//! Fractionalization Entry Point Tests
+//!
+//! Covers `fractionalize` / `redeem_fractional_asset` / status queries at
+//! the contract entry-point level (via `TokenFactoryClient`), matching the
+//! acceptance criteria: fractionalize/redeem happy path, double
+//! fractionalization rejection, unauthorized redemption, asset-uniqueness
+//! enforcement, and partial-shares redemption rejection.
+//!
+//! The locked "unique asset" is a real Stellar Asset Contract instance
+//! registered via `Env::register_stellar_asset_contract_v2`, exercised
+//! through the standard `soroban_sdk::token` client — the same mechanism
+//! this crate already uses for real token custody in `vault.rs`.
+
+#![cfg(test)]
+
+use crate::types::{Error, FractionalStatus, FractionalizationParams};
+use crate::{TokenFactory, TokenFactoryClient};
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{token, Address, BytesN, Env, String};
+
+const BASE_FEE: i128 = 70_000_000;
+const METADATA_FEE: i128 = 30_000_000;
+
+struct TestCtx {
+    env: Env,
+    contract_id: Address,
+    owner: Address,
+    asset_contract: Address,
+    asset_id: BytesN<32>,
+}
+
+impl TestCtx {
+    fn client(&self) -> TokenFactoryClient<'_> {
+        TokenFactoryClient::new(&self.env, &self.contract_id)
+    }
+
+    fn params(&self, total_supply: i128) -> FractionalizationParams {
+        FractionalizationParams {
+            asset_id: self.asset_id.clone(),
+            asset_contract: self.asset_contract.clone(),
+            total_supply,
+            token_name: String::from_str(&self.env, "Fractional Shares"),
+            token_symbol: String::from_str(&self.env, "FRAC"),
+        }
+    }
+}
+
+/// Deploys and initializes the factory, registers a real Stellar Asset
+/// Contract to stand in for the unique external asset, and mints exactly
+/// one unit of it to a fresh `owner`.
+fn setup() -> TestCtx {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, TokenFactory);
+    let client = TokenFactoryClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    client.initialize(&admin, &treasury, &BASE_FEE, &METADATA_FEE);
+
+    let asset_admin = Address::generate(&env);
+    let asset = env.register_stellar_asset_contract_v2(asset_admin.clone());
+    let asset_contract = asset.address();
+
+    let owner = Address::generate(&env);
+    token::StellarAssetClient::new(&env, &asset_contract).mint(&owner, &1);
+
+    let asset_id = BytesN::from_array(&env, &[7u8; 32]);
+
+    TestCtx {
+        env,
+        contract_id,
+        owner,
+        asset_contract,
+        asset_id,
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// Happy path
+// ════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_fractionalize_and_redeem_happy_path() {
+    let ctx = setup();
+    let client = ctx.client();
+    let asset_token = token::Client::new(&ctx.env, &ctx.asset_contract);
+
+    let vault_id = client.fractionalize(&ctx.owner, &ctx.params(1_000));
+
+    // Asset locked away from the owner into the contract's custody.
+    assert_eq!(asset_token.balance(&ctx.owner), 0);
+    assert_eq!(asset_token.balance(&ctx.contract_id), 1);
+
+    // Shares minted entirely to owner.
+    assert_eq!(
+        client.get_fractional_share_balance(&vault_id, &ctx.owner),
+        1_000
+    );
+    assert!(client.is_asset_fractionalized(&vault_id));
+
+    let vault = client.get_fractional_vault(&vault_id).unwrap();
+    assert_eq!(vault.id, vault_id);
+    assert_eq!(vault.asset_contract, ctx.asset_contract);
+    assert_eq!(vault.asset_id, ctx.asset_id);
+    assert_eq!(vault.owner, ctx.owner);
+    assert_eq!(vault.total_supply, 1_000);
+    assert_eq!(vault.status, FractionalStatus::Active);
+
+    // Redeem: owner holds 100% of shares.
+    client.redeem_fractional_asset(&ctx.owner, &vault_id);
+
+    assert_eq!(asset_token.balance(&ctx.owner), 1);
+    assert_eq!(asset_token.balance(&ctx.contract_id), 0);
+    assert_eq!(
+        client.get_fractional_share_balance(&vault_id, &ctx.owner),
+        0
+    );
+    assert!(!client.is_asset_fractionalized(&vault_id));
+
+    let vault = client.get_fractional_vault(&vault_id).unwrap();
+    assert_eq!(vault.status, FractionalStatus::Redeemed);
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// Double-fractionalization rejection
+// ════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_double_fractionalization_rejected() {
+    let ctx = setup();
+    let client = ctx.client();
+
+    client.fractionalize(&ctx.owner, &ctx.params(1_000));
+
+    // Same (asset_contract, asset_id) pair, still active — must be rejected
+    // even though the owner no longer holds a spendable unit of the asset.
+    let result = client.try_fractionalize(&ctx.owner, &ctx.params(500));
+    assert_eq!(result, Err(Ok(Error::AssetAlreadyFractionalized)));
+}
+
+#[test]
+fn test_refractionalize_after_redeem_succeeds() {
+    let ctx = setup();
+    let client = ctx.client();
+
+    let vault_id = client.fractionalize(&ctx.owner, &ctx.params(1_000));
+    client.redeem_fractional_asset(&ctx.owner, &vault_id);
+
+    // Asset is back with owner as a whole unit; fractionalizing again must succeed.
+    let result = client.try_fractionalize(&ctx.owner, &ctx.params(250));
+    assert!(result.is_ok());
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// Unauthorized redemption
+// ════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_unauthorized_redemption_rejected() {
+    let ctx = setup();
+    let client = ctx.client();
+
+    let vault_id = client.fractionalize(&ctx.owner, &ctx.params(1_000));
+
+    // Attacker holds zero shares and never locked the asset.
+    let attacker = Address::generate(&ctx.env);
+    let result = client.try_redeem_fractional_asset(&attacker, &vault_id);
+    assert_eq!(result, Err(Ok(Error::InsufficientShares)));
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// Asset-uniqueness enforcement
+// ════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_asset_uniqueness_enforced_across_owners() {
+    let ctx = setup();
+    let client = ctx.client();
+
+    client.fractionalize(&ctx.owner, &ctx.params(1_000));
+
+    // A different address cannot fractionalize the same (asset_contract,
+    // asset_id) identity while it is actively locked, even with a fresh
+    // FractionalizationParams — uniqueness of the underlying asset is
+    // enforced regardless of who calls.
+    let second_owner = Address::generate(&ctx.env);
+    let mut params = ctx.params(1_000);
+    params.total_supply = 42;
+    let result = client.try_fractionalize(&second_owner, &params);
+    assert_eq!(result, Err(Ok(Error::AssetAlreadyFractionalized)));
+}
+
+#[test]
+fn test_fractionalize_zero_or_negative_supply_rejected() {
+    let ctx = setup();
+    let client = ctx.client();
+
+    let result = client.try_fractionalize(&ctx.owner, &ctx.params(0));
+    assert_eq!(result, Err(Ok(Error::InvalidAmount)));
+
+    let result = client.try_fractionalize(&ctx.owner, &ctx.params(-1));
+    assert_eq!(result, Err(Ok(Error::InvalidAmount)));
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// Partial-shares redemption rejection
+// ════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_partial_shares_redemption_rejected() {
+    let ctx = setup();
+    let client = ctx.client();
+
+    let vault_id = client.fractionalize(&ctx.owner, &ctx.params(1_000));
+
+    // Simulate some shares moving to another holder. There is no public
+    // transfer entry point for fractional shares (mirroring how this
+    // crate's other test suites, e.g. burn/vault tests, adjust balances
+    // directly in storage rather than via a transfer entry point), so the
+    // split is applied directly in storage here.
+    let other_holder = Address::generate(&ctx.env);
+    ctx.env.as_contract(&ctx.contract_id, || {
+        crate::storage::set_fractional_share_balance(&ctx.env, vault_id, &ctx.owner, 600);
+        crate::storage::set_fractional_share_balance(&ctx.env, vault_id, &other_holder, 400);
+    });
+
+    let result = client.try_redeem_fractional_asset(&ctx.owner, &vault_id);
+    assert_eq!(result, Err(Ok(Error::InsufficientShares)));
+
+    // The other holder alone doesn't have 100% either.
+    let result = client.try_redeem_fractional_asset(&other_holder, &vault_id);
+    assert_eq!(result, Err(Ok(Error::InsufficientShares)));
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// Misc coverage
+// ════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_redeem_nonexistent_vault_rejected() {
+    let ctx = setup();
+    let client = ctx.client();
+    let caller = Address::generate(&ctx.env);
+
+    let result = client.try_redeem_fractional_asset(&caller, &9999_u64);
+    assert_eq!(result, Err(Ok(Error::FractionalVaultNotFound)));
+}
+
+#[test]
+fn test_redeem_already_redeemed_vault_rejected() {
+    let ctx = setup();
+    let client = ctx.client();
+
+    let vault_id = client.fractionalize(&ctx.owner, &ctx.params(1_000));
+    client.redeem_fractional_asset(&ctx.owner, &vault_id);
+
+    let result = client.try_redeem_fractional_asset(&ctx.owner, &vault_id);
+    assert_eq!(result, Err(Ok(Error::FractionalVaultNotFound)));
+}
+
+#[test]
+fn test_get_fractional_vault_none_for_unknown_id() {
+    let ctx = setup();
+    let client = ctx.client();
+
+    assert!(client.get_fractional_vault(&9999_u64).is_none());
+    assert!(!client.is_asset_fractionalized(&9999_u64));
+}

--- a/contracts/token-factory/src/lib.rs
+++ b/contracts/token-factory/src/lib.rs
@@ -9,6 +9,9 @@ extern crate std;
 
 mod compliance_reporting;
 mod freeze_functions;
+mod fractionalization;
+#[cfg(test)]
+mod fractionalization_test;
 mod governance;
 mod game_history;
 mod ipfs_pinning;
@@ -162,9 +165,9 @@ mod vault_balance_invariant_proptest;
 use soroban_sdk::{contract, contractimpl, symbol_short, Address, Bytes, BytesN, Env, String, Symbol, Vec};
 use types::{
     AuctionStatus, BatchScheduleResult, BurnAuction, BuybackCampaign, CampaignStatus,
-    ContractMetadata, DynamicQuorumConfig, Error, FactoryState, PaginationCursor,
-    PreflightItemResult, Reservation, StreamInfo, StreamPage, StreamParams, TokenCreationParams,
-    TokenInfo, TokenStats, Vault, VaultStatus,
+    ContractMetadata, DynamicQuorumConfig, Error, FactoryState, FractionalVault,
+    FractionalizationParams, PaginationCursor, PreflightItemResult, Reservation, StreamInfo,
+    StreamPage, StreamParams, TokenCreationParams, TokenInfo, TokenStats, Vault, VaultStatus,
 };
 use crate::milestone_verification::MilestoneVerifier;
 
@@ -4147,6 +4150,52 @@ impl TokenFactory {
         Ok(())
     }
 
+    // ── Fractionalization entry points ──────────────────────────────────
+
+    /// Lock a unique asset (identified by `params.asset_contract` +
+    /// `params.asset_id`) and mint `params.total_supply` fractional
+    /// ownership shares. `owner` must hold and authorize transfer of the
+    /// asset. Returns the id of the newly created fractionalization vault.
+    ///
+    /// # Errors
+    /// * `Error::ContractPaused` - Contract is paused
+    /// * `Error::InvalidTokenParams` - Shares token name/symbol are invalid
+    /// * `Error::InvalidAmount` - `total_supply` is zero or negative
+    /// * `Error::AssetAlreadyFractionalized` - This asset already has an active vault
+    pub fn fractionalize(
+        env: Env,
+        owner: Address,
+        params: FractionalizationParams,
+    ) -> Result<u64, Error> {
+        fractionalization::fractionalize(&env, owner, params)
+    }
+
+    /// Redeem (unlock) a fractionalized asset. `caller` must hold and burn
+    /// 100% of the vault's outstanding shares; the locked asset is then
+    /// released back to `caller`.
+    ///
+    /// # Errors
+    /// * `Error::ContractPaused` - Contract is paused
+    /// * `Error::FractionalVaultNotFound` - No active fractional vault exists for `vault_id`
+    /// * `Error::InsufficientShares` - Caller does not hold 100% of the outstanding shares
+    pub fn redeem_fractional_asset(env: Env, caller: Address, vault_id: u64) -> Result<(), Error> {
+        fractionalization::redeem(&env, caller, vault_id)
+    }
+
+    /// Return the fractionalization vault record for `vault_id`, if any.
+    pub fn get_fractional_vault(env: Env, vault_id: u64) -> Option<FractionalVault> {
+        storage::get_fractional_vault(&env, vault_id)
+    }
+
+    /// Returns `true` if `vault_id` is currently locked in an active fractionalization vault.
+    pub fn is_asset_fractionalized(env: Env, vault_id: u64) -> bool {
+        fractionalization::is_fractionalized(&env, vault_id)
+    }
+
+    /// Return a holder's outstanding fractional share balance for `vault_id`.
+    pub fn get_fractional_share_balance(env: Env, vault_id: u64, holder: Address) -> i128 {
+        storage::get_fractional_share_balance(&env, vault_id, &holder)
+    }
 }
 
 // Temporarily disabled - requires create_token implementation

--- a/contracts/token-factory/src/storage.rs
+++ b/contracts/token-factory/src/storage.rs
@@ -2210,6 +2210,77 @@ pub fn set_reservation_timeout_ledgers(env: &Env, ledgers: u32) {
         .set(&DataKey::ReservationTimeoutLedgers, &ledgers);
 }
 
+// ── Fractionalization storage functions ─────────────────────────────
+
+/// Get a fractionalization vault record by its vault id.
+pub fn get_fractional_vault(env: &Env, vault_id: u64) -> Option<crate::types::FractionalVault> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::FractionalVault(vault_id))
+}
+
+/// Persist a fractionalization vault record, keyed by its vault id.
+pub fn set_fractional_vault(env: &Env, vault: &crate::types::FractionalVault) {
+    let key = DataKey::FractionalVault(vault.id);
+    env.storage().persistent().set(&key, vault);
+    bump_persistent(env, &key);
+}
+
+/// Increment and return the next fractionalization vault id (starts at 1).
+pub fn increment_fractional_vault_count(env: &Env) -> Result<u64, Error> {
+    let count = env
+        .storage()
+        .instance()
+        .get(&DataKey::FractionalVaultCount)
+        .unwrap_or(0_u64);
+    let next = count.checked_add(1).ok_or(Error::ArithmeticError)?;
+    env.storage()
+        .instance()
+        .set(&DataKey::FractionalVaultCount, &next);
+    Ok(next)
+}
+
+/// Look up the vault id for a locked asset's identity, if it has ever been fractionalized.
+pub fn get_asset_fractionalization_index(
+    env: &Env,
+    asset_contract: &Address,
+    asset_id: &soroban_sdk::BytesN<32>,
+) -> Option<u64> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::AssetFractionalizationIndex(
+            asset_contract.clone(),
+            asset_id.clone(),
+        ))
+}
+
+/// Record which vault id a locked asset's identity maps to.
+pub fn set_asset_fractionalization_index(
+    env: &Env,
+    asset_contract: &Address,
+    asset_id: &soroban_sdk::BytesN<32>,
+    vault_id: u64,
+) {
+    let key = DataKey::AssetFractionalizationIndex(asset_contract.clone(), asset_id.clone());
+    env.storage().persistent().set(&key, &vault_id);
+    bump_persistent(env, &key);
+}
+
+/// Get a holder's outstanding fractional share balance for a vault.
+pub fn get_fractional_share_balance(env: &Env, vault_id: u64, holder: &Address) -> i128 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::FractionalShareBalance(vault_id, holder.clone()))
+        .unwrap_or(0)
+}
+
+/// Set a holder's outstanding fractional share balance for a vault.
+pub fn set_fractional_share_balance(env: &Env, vault_id: u64, holder: &Address, balance: i128) {
+    let key = DataKey::FractionalShareBalance(vault_id, holder.clone());
+    env.storage().persistent().set(&key, &balance);
+    bump_persistent(env, &key);
+}
+
 // ── Tests — Issue #1681: panic-free core storage getters ─────────────────────
 //
 // Each test calls a getter *before* `initialize()` has been invoked and

--- a/contracts/token-factory/src/types.rs
+++ b/contracts/token-factory/src/types.rs
@@ -962,6 +962,16 @@ pub enum DataKey {
     Reservation(u64),
     /// Ledgers a reservation may sit `Prepared` before it can be force-released
     ReservationTimeoutLedgers,
+    /// Fractionalization vault record, keyed by vault id
+    FractionalVault(u64),
+    /// Running counter used to assign new fractionalization vault ids
+    FractionalVaultCount,
+    /// Secondary index from a locked asset's identity to its vault id, used
+    /// to reject double-fractionalization / enforce asset uniqueness:
+    /// (asset_contract, asset_id) -> vault_id
+    AssetFractionalizationIndex(Address, BytesN<32>),
+    /// Outstanding fractional share balance: (vault_id, holder) -> amount
+    FractionalShareBalance(u64, Address),
 }
 
 /// A point-in-time record of a token holder's balance.
@@ -1310,6 +1320,13 @@ impl Error {
     pub const MetadataImmutable: Self = Self(131);
     // Multisig admin-change errors
     pub const DuplicateSigners: Self = Self(132);
+    // Fractionalization errors
+    /// The (asset_contract, asset_id) pair already has an active fractionalization vault.
+    pub const AssetAlreadyFractionalized: Self = Self(133);
+    /// No active fractionalization vault exists for the given identifier.
+    pub const FractionalVaultNotFound: Self = Self(134);
+    /// Caller does not hold 100% of the outstanding shares supply.
+    pub const InsufficientShares: Self = Self(135);
 
     /// Stable string name for this error code, for off-chain event payloads
     /// (see `emit_operation_failed`). Covers the vault entry-point error
@@ -1333,6 +1350,9 @@ impl Error {
             98 => "VaultOwnerChangeNotFound",
             99 => "VaultOwnerChangeAlreadyApproved",
             130 => "VaultCircuitBreakerActive",
+            133 => "AssetAlreadyFractionalized",
+            134 => "FractionalVaultNotFound",
+            135 => "InsufficientShares",
             _ => "UnknownError",
         }
     }


### PR DESCRIPTION
## Summary
- Adds `fractionalize` / `redeem_fractional_asset` entry points to the token-factory contract: lock a unique external asset (identified by `asset_contract` + `asset_id`, via the standard `soroban_sdk::token` client — mirroring how `vault.rs`/`create_vault` already custodies real tokens) and mint fractional ownership shares.
- Redemption requires the caller to hold and burn 100% of a vault's *current outstanding* shares supply before the locked asset is released back to them.
- A `FractionalStatus`-gated uniqueness index (`(asset_contract, asset_id) -> vault_id`) makes it impossible to fractionalize the same asset twice while a vault is `Active`; once `Redeemed`, the same asset can be fractionalized again.
- New module `contracts/token-factory/src/fractionalization.rs`, wired into `lib.rs` via `mod fractionalization;` and new `#[contractimpl]` entry points (`fractionalize`, `redeem_fractional_asset`, `get_fractional_vault`, `is_asset_fractionalized`, `get_fractional_share_balance`).
- New `DataKey` variants (`FractionalVault`, `FractionalVaultCount`, `AssetFractionalizationIndex`, `FractionalShareBalance`) and `Error` variants `133`–`135` (`AssetAlreadyFractionalized`, `FractionalVaultNotFound`, `InsufficientShares`), with matching `Error::name()` entries.
- Fresh storage getters/setters in `storage.rs` for vault records, the vault-id counter, the asset-identity uniqueness index, and per-holder share balances — no reuse of existing storage.
- Reuses the `FractionalVault` / `FractionalStatus` / `FractionalizationParams` types and the `emit_asset_fractionalized` / `emit_asset_redeemed` event functions that were already declared (but unused/unwired) in `types.rs` / `events.rs`.

## Design notes
The locked asset is represented via a real `soroban_sdk::token` client against an external SAC (`asset_contract`), with a caller-supplied `asset_id: BytesN<32>` disambiguating which specific unit of that contract is being locked — this is the interpretation that matches the pre-existing `FractionalVault { asset_id, asset_contract, ... }` scaffold already in `types.rs`. The minted shares are **not** one of the factory's own registered tokens (no new `Token(u32)` entry) — they're tracked in dedicated `FractionalShareBalance(vault_id, holder)` storage, since the issue explicitly calls for "a fresh addition, not an extension of existing code."

## Test plan
- [x] `fractionalization_test.rs` — 10 tests via `TokenFactoryClient` against a real `register_stellar_asset_contract_v2` instance: fractionalize/redeem happy path, double-fractionalization rejection, re-fractionalization after redeem, unauthorized redemption, partial-shares redemption rejection (both parties), asset-uniqueness enforcement across different callers, zero/negative supply rejection, vault-not-found paths.
- [x] `cargo check --lib` — clean.
- [x] `cargo fmt --check` / `cargo clippy --lib` — clean on the new/changed files.
- [x] `cargo build --target wasm32v1-none --release --lib` — succeeds.
- [x] `cargo test --lib` for just this feature — verified by temporarily stripping this crate's ~23 already-broken, unrelated pre-existing test modules from a scratch copy (they fail to compile against the resolved `soroban-sdk 27.0.6` independent of this branch — reproduces identically on a clean `main` checkout) and confirming all 10 new tests pass. **A plain `cargo test --lib` on `main` today does not compile**, for reasons unrelated to this change (stale APIs — `Ledger::with_mut`, removed macros, mismatched struct fields — across many long-disabled test files, plus one `#[contracttype]`/`Option<T>` macro limitation in `pagination.rs`'s `PaginatedStreamsResponse`). Flagging this here since it also blocks the CI "Build & Lint Gate" `clippy --all-targets` step and the later `cargo test --lib <name>` stages regardless of this PR; happy to open a separate issue/PR to unblock it if useful.

Closes #1760