### PR TITLE
feat(contracts): add liquidity mining incentive program

### DIFF
--- a/contracts/token-factory/src/events.rs
+++ b/contracts/token-factory/src/events.rs
@@ -1894,3 +1894,115 @@ pub fn emit_settlement_timeout_cleanup(env: &Env, reservation_id: u64, proposal_
     env.events()
         .publish((symbol_short!("stl_tmo1"), reservation_id), (proposal_id,));
 }
+
+// ═══════════════════════════════════════════════════════════════════════
+// Liquidity Mining Events (v1)
+// ═══════════════════════════════════════════════════════════════════════
+
+/// Emitted when a new liquidity mining pool is created.
+///
+/// **Event Name**: lm_crt_v1
+pub fn emit_mining_pool_created(
+    env: &Env,
+    pool_id: u64,
+    admin: &Address,
+    reward_token_index: u32,
+    stake_token_index: u32,
+    reward_rate: i128,
+    start_time: u64,
+    end_time: u64,
+) {
+    env.events().publish(
+        (symbol_short!("lm_crt_v1"), pool_id),
+        (
+            admin.clone(),
+            reward_token_index,
+            stake_token_index,
+            reward_rate,
+            start_time,
+            end_time,
+        ),
+    );
+}
+
+/// Emitted when a provider deposits (stakes) tokens into a pool.
+///
+/// **Event Name**: lm_dep_v1
+pub fn emit_liquidity_deposited(
+    env: &Env,
+    pool_id: u64,
+    provider: &Address,
+    amount: i128,
+    new_total: i128,
+) {
+    env.events().publish(
+        (symbol_short!("lm_dep_v1"), pool_id),
+        (provider.clone(), amount, new_total),
+    );
+}
+
+/// Emitted when a provider withdraws staked tokens from a pool.
+///
+/// **Event Name**: lm_wdr_v1
+pub fn emit_liquidity_withdrawn(
+    env: &Env,
+    pool_id: u64,
+    provider: &Address,
+    amount: i128,
+    remaining: i128,
+) {
+    env.events().publish(
+        (symbol_short!("lm_wdr_v1"), pool_id),
+        (provider.clone(), amount, remaining),
+    );
+}
+
+/// Emitted when a provider claims their accumulated rewards.
+///
+/// **Event Name**: lm_clm_v1
+pub fn emit_mining_rewards_claimed(env: &Env, pool_id: u64, provider: &Address, amount: i128) {
+    env.events().publish(
+        (symbol_short!("lm_clm_v1"), pool_id),
+        (provider.clone(), amount),
+    );
+}
+
+/// Emitted when an admin pauses a mining pool.
+///
+/// **Event Name**: lm_pse_v1
+pub fn emit_mining_pool_paused(env: &Env, pool_id: u64, admin: &Address) {
+    env.events()
+        .publish((symbol_short!("lm_pse_v1"), pool_id), (admin.clone(),));
+}
+
+/// Emitted when an admin resumes a paused mining pool.
+///
+/// **Event Name**: lm_rsm_v1
+pub fn emit_mining_pool_resumed(env: &Env, pool_id: u64, admin: &Address) {
+    env.events()
+        .publish((symbol_short!("lm_rsm_v1"), pool_id), (admin.clone(),));
+}
+
+/// Emitted when an admin ends a mining pool.
+///
+/// **Event Name**: lm_end_v1
+pub fn emit_mining_pool_ended(env: &Env, pool_id: u64, admin: &Address) {
+    env.events()
+        .publish((symbol_short!("lm_end_v1"), pool_id), (admin.clone(),));
+}
+
+/// Emitted when an admin updates the reward rate for a pool.
+///
+/// **Event Name**: lm_rru_v1
+pub fn emit_mining_reward_rate_updated(
+    env: &Env,
+    pool_id: u64,
+    admin: &Address,
+    old_rate: i128,
+    new_rate: i128,
+) {
+    env.events().publish(
+        (symbol_short!("lm_rru_v1"), pool_id),
+        (admin.clone(), old_rate, new_rate),
+    );
+}

--- a/contracts/token-factory/src/lib.rs
+++ b/contracts/token-factory/src/lib.rs
@@ -22,6 +22,7 @@ mod invariants;
 mod differential_engine;
 mod event_versions;
 mod events;
+mod liquidity_mining;
 mod milestone_verification;
 #[cfg(all(test, feature = "legacy-tests"))]
 const _ISOLATED_DISABLED_milestone_verification_test: () = ();
@@ -42,6 +43,8 @@ mod storage_migration;
 mod test_helpers;
 #[cfg(test)]
 mod freeze_functions_test;
+#[cfg(test)]
+mod liquidity_mining_test;
 #[cfg(test)]
 mod game_history_test;
 #[cfg(test)]
@@ -162,9 +165,9 @@ mod vault_balance_invariant_proptest;
 use soroban_sdk::{contract, contractimpl, symbol_short, Address, Bytes, BytesN, Env, String, Symbol, Vec};
 use types::{
     AuctionStatus, BatchScheduleResult, BurnAuction, BuybackCampaign, CampaignStatus,
-    ContractMetadata, DynamicQuorumConfig, Error, FactoryState, PaginationCursor,
-    PreflightItemResult, Reservation, StreamInfo, StreamPage, StreamParams, TokenCreationParams,
-    TokenInfo, TokenStats, Vault, VaultStatus,
+    ContractMetadata, DynamicQuorumConfig, Error, FactoryState, LiquidityMiningPool,
+    PaginationCursor, PreflightItemResult, ProviderStake, Reservation, StreamInfo, StreamPage,
+    StreamParams, TokenCreationParams, TokenInfo, TokenStats, Vault, VaultStatus,
 };
 use crate::milestone_verification::MilestoneVerifier;
 
@@ -4145,6 +4148,152 @@ impl TokenFactory {
         events::emit_multisig_executed(env, proposal.id, executor);
 
         Ok(())
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Liquidity Mining Program
+    // ─────────────────────────────────────────────────────────────────────
+
+    /// Create a new liquidity mining pool (admin only)
+    ///
+    /// Initializes a pool that distributes `reward_token_index` tokens to
+    /// providers who deposit `stake_token_index` tokens, proportional to
+    /// their share of the pool. The pool starts `Active` immediately.
+    ///
+    /// # Arguments
+    /// * `admin` - Admin address (must authorize)
+    /// * `reward_token_index` - Token index for reward distribution
+    /// * `stake_token_index` - Token index that providers deposit
+    /// * `reward_rate` - Rewards distributed per second across the pool (in stroops)
+    /// * `start_time` - Unix timestamp when the pool opens for deposits
+    /// * `end_time` - Unix timestamp when reward accrual stops
+    ///
+    /// # Returns
+    /// The new pool's id.
+    pub fn create_mining_pool(
+        env: Env,
+        admin: Address,
+        reward_token_index: u32,
+        stake_token_index: u32,
+        reward_rate: i128,
+        start_time: u64,
+        end_time: u64,
+    ) -> Result<u64, Error> {
+        liquidity_mining::create_mining_pool(
+            &env,
+            &admin,
+            reward_token_index,
+            stake_token_index,
+            reward_rate,
+            start_time,
+            end_time,
+        )
+    }
+
+    /// Deposit stake tokens into a liquidity mining pool
+    ///
+    /// Updates the caller's position and begins accruing rewards
+    /// proportional to their share of the pool's total deposits.
+    ///
+    /// # Arguments
+    /// * `provider` - Address depositing tokens (must authorize)
+    /// * `pool_id` - Pool to deposit into
+    /// * `amount` - Amount of stake tokens to deposit
+    pub fn deposit_liquidity(
+        env: Env,
+        provider: Address,
+        pool_id: u64,
+        amount: i128,
+    ) -> Result<(), Error> {
+        liquidity_mining::deposit(&env, &provider, pool_id, amount)
+    }
+
+    /// Withdraw staked tokens from a liquidity mining pool
+    ///
+    /// Pending rewards are preserved but not automatically claimed; call
+    /// `claim_mining_rewards` to collect them.
+    ///
+    /// # Arguments
+    /// * `provider` - Address withdrawing tokens (must authorize)
+    /// * `pool_id` - Pool to withdraw from
+    /// * `amount` - Amount of stake tokens to withdraw
+    pub fn withdraw_liquidity(
+        env: Env,
+        provider: Address,
+        pool_id: u64,
+        amount: i128,
+    ) -> Result<(), Error> {
+        liquidity_mining::withdraw(&env, &provider, pool_id, amount)
+    }
+
+    /// Claim accumulated rewards from a liquidity mining pool
+    ///
+    /// # Arguments
+    /// * `provider` - Address claiming rewards (must authorize)
+    /// * `pool_id` - Pool to claim from
+    ///
+    /// # Returns
+    /// The amount of reward tokens claimed.
+    pub fn claim_mining_rewards(env: Env, provider: Address, pool_id: u64) -> Result<i128, Error> {
+        liquidity_mining::claim_rewards(&env, &provider, pool_id)
+    }
+
+    /// Pause an active liquidity mining pool (admin only)
+    pub fn pause_mining_pool(env: Env, admin: Address, pool_id: u64) -> Result<(), Error> {
+        liquidity_mining::pause_mining_pool(&env, &admin, pool_id)
+    }
+
+    /// Resume a paused liquidity mining pool (admin only)
+    pub fn resume_mining_pool(env: Env, admin: Address, pool_id: u64) -> Result<(), Error> {
+        liquidity_mining::resume_mining_pool(&env, &admin, pool_id)
+    }
+
+    /// End a liquidity mining pool, permanently stopping reward accrual (admin only)
+    pub fn end_mining_pool(env: Env, admin: Address, pool_id: u64) -> Result<(), Error> {
+        liquidity_mining::end_mining_pool(&env, &admin, pool_id)
+    }
+
+    /// Update the reward rate for an active liquidity mining pool (admin only)
+    ///
+    /// # Arguments
+    /// * `admin` - Admin address (must authorize)
+    /// * `pool_id` - Pool to update
+    /// * `new_reward_rate` - New reward rate distributed per second across the pool
+    pub fn update_mining_reward_rate(
+        env: Env,
+        admin: Address,
+        pool_id: u64,
+        new_reward_rate: i128,
+    ) -> Result<(), Error> {
+        liquidity_mining::update_reward_rate(&env, &admin, pool_id, new_reward_rate)
+    }
+
+    /// Get a liquidity mining pool by id
+    pub fn get_mining_pool(env: Env, pool_id: u64) -> Option<LiquidityMiningPool> {
+        liquidity_mining::get_mining_pool(&env, pool_id)
+    }
+
+    /// Get a provider's position (stake + reward checkpoint) in a pool
+    pub fn get_mining_position(
+        env: Env,
+        pool_id: u64,
+        provider: Address,
+    ) -> Option<ProviderStake> {
+        liquidity_mining::get_provider_position(&env, pool_id, &provider)
+    }
+
+    /// Get the current claimable reward amount for a provider in a pool
+    pub fn get_claimable_mining_rewards(
+        env: Env,
+        pool_id: u64,
+        provider: Address,
+    ) -> Result<i128, Error> {
+        liquidity_mining::get_claimable_rewards(&env, pool_id, &provider)
+    }
+
+    /// Get the total number of liquidity mining pools created
+    pub fn get_mining_pool_count(env: Env) -> u64 {
+        liquidity_mining::get_mining_pool_count(&env)
     }
 
 }

--- a/contracts/token-factory/src/liquidity_mining.rs
+++ b/contracts/token-factory/src/liquidity_mining.rs
@@ -1,0 +1,546 @@
+//! Liquidity Mining Program
+//!
+//! Liquidity providers deposit a stake token into an admin-created mining
+//! pool and earn a reward token over time, distributed proportionally to
+//! their share of the pool's total deposits.
+//!
+//! ## Pool lifecycle
+//!
+//! Pools are an explicit state machine (see [`MiningPoolStatus`]):
+//!
+//! ```text
+//! Active <──────> Paused
+//!   │                │
+//!   └──────┬─────────┘
+//!          v
+//!        Ended
+//! ```
+//!
+//! * `Active -> Paused` via [`pause_mining_pool`]
+//! * `Paused -> Active` via [`resume_mining_pool`]
+//! * `Active -> Ended` or `Paused -> Ended` via [`end_mining_pool`] (terminal)
+//!
+//! Any other transition (e.g. pausing an already-paused pool, resuming an
+//! `Ended` pool) is rejected with a dedicated error rather than silently
+//! no-op'ing.
+//!
+//! ## Reward accrual
+//!
+//! Rewards use the standard reward-per-token accumulator pattern (as seen
+//! in Synthetix-style staking rewards contracts), giving O(1) reward
+//! calculation regardless of provider count:
+//!
+//! * `reward_per_token_stored` accumulates `elapsed * reward_rate * PRECISION / total_staked`
+//!   every time the pool is checkpointed (on deposit, withdraw, claim, or an
+//!   admin lifecycle/rate change).
+//! * Accrual is capped at `pool.end_time` and freezes entirely while the
+//!   pool is `Paused` — resuming resets the checkpoint clock to "now" so the
+//!   paused interval is never rewarded.
+//! * A provider's claimable amount is derived from the delta between the
+//!   pool's current accumulator and the value it had at the provider's last
+//!   checkpoint (`reward_per_token_paid`), scaled by their staked amount.
+//!
+//! ## Security
+//!
+//! * All arithmetic uses checked operations.
+//! * State-changing entry points require the caller's `require_auth`.
+//! * Admin-only operations additionally verify the caller against the
+//!   contract's stored admin.
+//! * Pool/position state is written before events are emitted.
+
+use crate::events;
+use crate::storage;
+use crate::types::{Error, LiquidityMiningPool, MiningPoolStatus, ProviderStake};
+use soroban_sdk::{Address, Env};
+
+/// Fixed-point precision used for the reward-per-token accumulator.
+const REWARD_PRECISION: i128 = 10_000_000;
+
+/// Upper bound on the number of pools that may be created, to keep
+/// pool-count storage bounded.
+const MAX_POOLS: u64 = 1_000;
+
+/// Upper bound on `reward_rate` (reward tokens per second, in stroops)
+/// accepted for a pool, as a basic sanity guard against fat-fingered input.
+const MAX_REWARD_RATE: i128 = 1_000_000_000;
+
+// ─────────────────────────────────────────────────────────────────────────
+// Pool management
+// ─────────────────────────────────────────────────────────────────────────
+
+/// Create a new liquidity mining pool.
+///
+/// Only the contract admin may create pools. The pool starts in the
+/// `Active` state immediately.
+///
+/// # Errors
+/// * [`Error::Unauthorized`] - caller is not the admin
+/// * [`Error::ContractPaused`] - contract is globally paused
+/// * [`Error::TokenNotFound`] - reward or stake token index does not exist
+/// * [`Error::InvalidPoolTimeWindow`] - `start_time >= end_time`, or `end_time` already elapsed
+/// * [`Error::InvalidRewardRate`] - `reward_rate <= 0` or exceeds the maximum
+/// * [`Error::TooManyMiningPools`] - the pool cap has been reached
+pub fn create_mining_pool(
+    env: &Env,
+    admin: &Address,
+    reward_token_index: u32,
+    stake_token_index: u32,
+    reward_rate: i128,
+    start_time: u64,
+    end_time: u64,
+) -> Result<u64, Error> {
+    admin.require_auth();
+
+    let stored_admin = storage::get_admin(env).ok_or(Error::MissingAdmin)?;
+    if *admin != stored_admin {
+        return Err(Error::Unauthorized);
+    }
+
+    if storage::is_paused(env) {
+        return Err(Error::ContractPaused);
+    }
+
+    storage::get_token_info(env, reward_token_index).ok_or(Error::TokenNotFound)?;
+    storage::get_token_info(env, stake_token_index).ok_or(Error::TokenNotFound)?;
+
+    let now = env.ledger().timestamp();
+    if start_time >= end_time || end_time <= now {
+        return Err(Error::InvalidPoolTimeWindow);
+    }
+
+    if reward_rate <= 0 || reward_rate > MAX_REWARD_RATE {
+        return Err(Error::InvalidRewardRate);
+    }
+
+    if storage::get_mining_pool_count(env) >= MAX_POOLS {
+        return Err(Error::TooManyMiningPools);
+    }
+
+    let pool_id = storage::next_mining_pool_id(env)?;
+
+    let pool = LiquidityMiningPool {
+        id: pool_id,
+        reward_token_index,
+        stake_token_index,
+        reward_rate,
+        start_time,
+        end_time,
+        total_staked: 0,
+        reward_per_token_stored: 0,
+        last_update_time: start_time,
+        status: MiningPoolStatus::Active,
+        created_at: now,
+    };
+
+    storage::set_mining_pool(env, pool_id, &pool);
+
+    events::emit_mining_pool_created(
+        env,
+        pool_id,
+        admin,
+        reward_token_index,
+        stake_token_index,
+        reward_rate,
+        start_time,
+        end_time,
+    );
+
+    Ok(pool_id)
+}
+
+/// Deposit stake tokens into a pool, updating the caller's position.
+///
+/// Pending rewards are checkpointed before the new deposit is applied so
+/// that reward accrual is always attributed fairly across depositors.
+///
+/// # Errors
+/// * [`Error::InvalidAmount`] - `amount <= 0`
+/// * [`Error::MiningPoolNotFound`] - pool does not exist
+/// * [`Error::MiningPoolNotActive`] - pool is not `Active`
+/// * [`Error::InvalidPoolTimeWindow`] - pool has not started, or has already ended
+/// * [`Error::ArithmeticError`] - overflow updating staked totals
+pub fn deposit(env: &Env, provider: &Address, pool_id: u64, amount: i128) -> Result<(), Error> {
+    provider.require_auth();
+
+    if amount <= 0 {
+        return Err(Error::InvalidAmount);
+    }
+
+    let mut pool = storage::get_mining_pool(env, pool_id).ok_or(Error::MiningPoolNotFound)?;
+
+    if pool.status != MiningPoolStatus::Active {
+        return Err(Error::MiningPoolNotActive);
+    }
+
+    let now = env.ledger().timestamp();
+    if now < pool.start_time || now >= pool.end_time {
+        return Err(Error::InvalidPoolTimeWindow);
+    }
+
+    update_reward_per_token(env, &mut pool)?;
+
+    let mut position =
+        storage::get_mining_position(env, pool_id, provider).unwrap_or(ProviderStake {
+            provider: provider.clone(),
+            pool_id,
+            staked_amount: 0,
+            reward_per_token_paid: pool.reward_per_token_stored,
+            pending_rewards: 0,
+        });
+
+    position.pending_rewards = calculate_earned(&pool, &position)?;
+    position.reward_per_token_paid = pool.reward_per_token_stored;
+    position.staked_amount = position
+        .staked_amount
+        .checked_add(amount)
+        .ok_or(Error::ArithmeticError)?;
+
+    pool.total_staked = pool
+        .total_staked
+        .checked_add(amount)
+        .ok_or(Error::ArithmeticError)?;
+
+    storage::set_mining_pool(env, pool_id, &pool);
+    storage::set_mining_position(env, pool_id, provider, &position);
+
+    events::emit_liquidity_deposited(env, pool_id, provider, amount, position.staked_amount);
+
+    Ok(())
+}
+
+/// Withdraw staked tokens from a pool, updating the caller's position.
+///
+/// Pending rewards are checkpointed but *not* automatically claimed — call
+/// [`claim_rewards`] separately to collect them. Withdrawal is allowed
+/// regardless of pool status (including `Ended`) so providers can always
+/// retrieve their principal.
+///
+/// # Errors
+/// * [`Error::InvalidAmount`] - `amount <= 0`
+/// * [`Error::MiningPoolNotFound`] - pool does not exist
+/// * [`Error::NoMiningPosition`] - caller has no position in the pool
+/// * [`Error::InsufficientStakedAmount`] - `amount` exceeds the caller's staked balance
+/// * [`Error::ArithmeticError`] - overflow updating staked totals
+pub fn withdraw(env: &Env, provider: &Address, pool_id: u64, amount: i128) -> Result<(), Error> {
+    provider.require_auth();
+
+    if amount <= 0 {
+        return Err(Error::InvalidAmount);
+    }
+
+    let mut pool = storage::get_mining_pool(env, pool_id).ok_or(Error::MiningPoolNotFound)?;
+    let mut position =
+        storage::get_mining_position(env, pool_id, provider).ok_or(Error::NoMiningPosition)?;
+
+    if position.staked_amount < amount {
+        return Err(Error::InsufficientStakedAmount);
+    }
+
+    update_reward_per_token(env, &mut pool)?;
+
+    position.pending_rewards = calculate_earned(&pool, &position)?;
+    position.reward_per_token_paid = pool.reward_per_token_stored;
+    position.staked_amount = position
+        .staked_amount
+        .checked_sub(amount)
+        .ok_or(Error::ArithmeticError)?;
+
+    pool.total_staked = pool
+        .total_staked
+        .checked_sub(amount)
+        .ok_or(Error::ArithmeticError)?;
+
+    storage::set_mining_pool(env, pool_id, &pool);
+    storage::set_mining_position(env, pool_id, provider, &position);
+
+    events::emit_liquidity_withdrawn(env, pool_id, provider, amount, position.staked_amount);
+
+    Ok(())
+}
+
+/// Claim all accumulated rewards for the caller from a pool.
+///
+/// # Errors
+/// * [`Error::MiningPoolNotFound`] - pool does not exist
+/// * [`Error::NoMiningPosition`] - caller has no position in the pool
+/// * [`Error::NothingToClaim`] - claimable amount is zero
+/// * [`Error::ArithmeticError`] - overflow computing the claimable amount
+pub fn claim_rewards(env: &Env, provider: &Address, pool_id: u64) -> Result<i128, Error> {
+    provider.require_auth();
+
+    let mut pool = storage::get_mining_pool(env, pool_id).ok_or(Error::MiningPoolNotFound)?;
+    let mut position =
+        storage::get_mining_position(env, pool_id, provider).ok_or(Error::NoMiningPosition)?;
+
+    update_reward_per_token(env, &mut pool)?;
+
+    let earned = calculate_earned(&pool, &position)?;
+    let claimable = earned
+        .checked_add(position.pending_rewards)
+        .ok_or(Error::ArithmeticError)?;
+
+    if claimable <= 0 {
+        return Err(Error::NothingToClaim);
+    }
+
+    position.pending_rewards = 0;
+    position.reward_per_token_paid = pool.reward_per_token_stored;
+
+    storage::set_mining_pool(env, pool_id, &pool);
+    storage::set_mining_position(env, pool_id, provider, &position);
+
+    events::emit_mining_rewards_claimed(env, pool_id, provider, claimable);
+
+    Ok(claimable)
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Admin lifecycle controls
+// ─────────────────────────────────────────────────────────────────────────
+
+/// Pause an `Active` pool (admin only): halts new deposits and reward
+/// accrual while preserving existing positions.
+///
+/// # Errors
+/// * [`Error::Unauthorized`] - caller is not the admin
+/// * [`Error::MiningPoolNotFound`] - pool does not exist
+/// * [`Error::MiningPoolInvalidTransition`] - pool is not `Active`
+pub fn pause_mining_pool(env: &Env, admin: &Address, pool_id: u64) -> Result<(), Error> {
+    admin.require_auth();
+
+    let stored_admin = storage::get_admin(env).ok_or(Error::MissingAdmin)?;
+    if *admin != stored_admin {
+        return Err(Error::Unauthorized);
+    }
+
+    let mut pool = storage::get_mining_pool(env, pool_id).ok_or(Error::MiningPoolNotFound)?;
+
+    if pool.status != MiningPoolStatus::Active {
+        return Err(Error::MiningPoolInvalidTransition);
+    }
+
+    update_reward_per_token(env, &mut pool)?;
+    pool.status = MiningPoolStatus::Paused;
+
+    storage::set_mining_pool(env, pool_id, &pool);
+    events::emit_mining_pool_paused(env, pool_id, admin);
+
+    Ok(())
+}
+
+/// Resume a `Paused` pool (admin only). The checkpoint clock resets to
+/// "now" so the paused interval accrues no reward.
+///
+/// # Errors
+/// * [`Error::Unauthorized`] - caller is not the admin
+/// * [`Error::MiningPoolNotFound`] - pool does not exist
+/// * [`Error::MiningPoolInvalidTransition`] - pool is not `Paused`
+pub fn resume_mining_pool(env: &Env, admin: &Address, pool_id: u64) -> Result<(), Error> {
+    admin.require_auth();
+
+    let stored_admin = storage::get_admin(env).ok_or(Error::MissingAdmin)?;
+    if *admin != stored_admin {
+        return Err(Error::Unauthorized);
+    }
+
+    let mut pool = storage::get_mining_pool(env, pool_id).ok_or(Error::MiningPoolNotFound)?;
+
+    if pool.status != MiningPoolStatus::Paused {
+        return Err(Error::MiningPoolInvalidTransition);
+    }
+
+    pool.last_update_time = env.ledger().timestamp();
+    pool.status = MiningPoolStatus::Active;
+
+    storage::set_mining_pool(env, pool_id, &pool);
+    events::emit_mining_pool_resumed(env, pool_id, admin);
+
+    Ok(())
+}
+
+/// End a pool (admin only), permanently stopping reward accrual. Providers
+/// can still withdraw principal and claim previously-earned rewards.
+///
+/// # Errors
+/// * [`Error::Unauthorized`] - caller is not the admin
+/// * [`Error::MiningPoolNotFound`] - pool does not exist
+/// * [`Error::MiningPoolInvalidTransition`] - pool is already `Ended`
+pub fn end_mining_pool(env: &Env, admin: &Address, pool_id: u64) -> Result<(), Error> {
+    admin.require_auth();
+
+    let stored_admin = storage::get_admin(env).ok_or(Error::MissingAdmin)?;
+    if *admin != stored_admin {
+        return Err(Error::Unauthorized);
+    }
+
+    let mut pool = storage::get_mining_pool(env, pool_id).ok_or(Error::MiningPoolNotFound)?;
+
+    if pool.status == MiningPoolStatus::Ended {
+        return Err(Error::MiningPoolInvalidTransition);
+    }
+
+    update_reward_per_token(env, &mut pool)?;
+    pool.status = MiningPoolStatus::Ended;
+
+    storage::set_mining_pool(env, pool_id, &pool);
+    events::emit_mining_pool_ended(env, pool_id, admin);
+
+    Ok(())
+}
+
+/// Update the reward rate for an `Active` pool (admin only). Rewards are
+/// checkpointed at the old rate before the new rate takes effect, so past
+/// accrual is unaffected.
+///
+/// # Errors
+/// * [`Error::Unauthorized`] - caller is not the admin
+/// * [`Error::MiningPoolNotFound`] - pool does not exist
+/// * [`Error::MiningPoolNotActive`] - pool is not `Active`
+/// * [`Error::InvalidRewardRate`] - `new_reward_rate <= 0` or exceeds the maximum
+pub fn update_reward_rate(
+    env: &Env,
+    admin: &Address,
+    pool_id: u64,
+    new_reward_rate: i128,
+) -> Result<(), Error> {
+    admin.require_auth();
+
+    let stored_admin = storage::get_admin(env).ok_or(Error::MissingAdmin)?;
+    if *admin != stored_admin {
+        return Err(Error::Unauthorized);
+    }
+
+    if new_reward_rate <= 0 || new_reward_rate > MAX_REWARD_RATE {
+        return Err(Error::InvalidRewardRate);
+    }
+
+    let mut pool = storage::get_mining_pool(env, pool_id).ok_or(Error::MiningPoolNotFound)?;
+
+    if pool.status != MiningPoolStatus::Active {
+        return Err(Error::MiningPoolNotActive);
+    }
+
+    update_reward_per_token(env, &mut pool)?;
+
+    let old_rate = pool.reward_rate;
+    pool.reward_rate = new_reward_rate;
+
+    storage::set_mining_pool(env, pool_id, &pool);
+    events::emit_mining_reward_rate_updated(env, pool_id, admin, old_rate, new_reward_rate);
+
+    Ok(())
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Queries
+// ─────────────────────────────────────────────────────────────────────────
+
+/// Get a liquidity mining pool by id.
+pub fn get_mining_pool(env: &Env, pool_id: u64) -> Option<LiquidityMiningPool> {
+    storage::get_mining_pool(env, pool_id)
+}
+
+/// Get a provider's position (stake + reward checkpoint) in a pool.
+pub fn get_provider_position(env: &Env, pool_id: u64, provider: &Address) -> Option<ProviderStake> {
+    storage::get_mining_position(env, pool_id, provider)
+}
+
+/// Compute a provider's currently claimable reward amount without mutating
+/// any state.
+///
+/// # Errors
+/// * [`Error::MiningPoolNotFound`] - pool does not exist
+pub fn get_claimable_rewards(env: &Env, pool_id: u64, provider: &Address) -> Result<i128, Error> {
+    let pool = storage::get_mining_pool(env, pool_id).ok_or(Error::MiningPoolNotFound)?;
+
+    let position = match storage::get_mining_position(env, pool_id, provider) {
+        Some(p) => p,
+        None => return Ok(0),
+    };
+
+    let current_rpt = current_reward_per_token(env, &pool)?;
+
+    let newly_earned = position
+        .staked_amount
+        .checked_mul(
+            current_rpt
+                .checked_sub(position.reward_per_token_paid)
+                .ok_or(Error::ArithmeticError)?,
+        )
+        .ok_or(Error::ArithmeticError)?
+        .checked_div(REWARD_PRECISION)
+        .ok_or(Error::ArithmeticError)?;
+
+    position
+        .pending_rewards
+        .checked_add(newly_earned)
+        .ok_or(Error::ArithmeticError)
+}
+
+/// Get the total number of liquidity mining pools created.
+pub fn get_mining_pool_count(env: &Env) -> u64 {
+    storage::get_mining_pool_count(env)
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Internal reward accumulator helpers
+// ─────────────────────────────────────────────────────────────────────────
+
+/// Compute the pool's up-to-date `reward_per_token_stored` without mutating
+/// it. Accrual is capped at `end_time` and frozen while `Paused` or `Ended`.
+fn current_reward_per_token(env: &Env, pool: &LiquidityMiningPool) -> Result<i128, Error> {
+    if pool.total_staked == 0 || pool.status != MiningPoolStatus::Active {
+        return Ok(pool.reward_per_token_stored);
+    }
+
+    let now = env.ledger().timestamp();
+    let effective_time = if now > pool.end_time { pool.end_time } else { now };
+
+    if effective_time <= pool.last_update_time {
+        return Ok(pool.reward_per_token_stored);
+    }
+
+    let elapsed = effective_time
+        .checked_sub(pool.last_update_time)
+        .ok_or(Error::ArithmeticError)? as i128;
+
+    let delta = elapsed
+        .checked_mul(pool.reward_rate)
+        .ok_or(Error::ArithmeticError)?
+        .checked_mul(REWARD_PRECISION)
+        .ok_or(Error::ArithmeticError)?
+        .checked_div(pool.total_staked)
+        .ok_or(Error::ArithmeticError)?;
+
+    pool.reward_per_token_stored
+        .checked_add(delta)
+        .ok_or(Error::ArithmeticError)
+}
+
+/// Checkpoint `pool.reward_per_token_stored` and `pool.last_update_time` in place.
+fn update_reward_per_token(env: &Env, pool: &mut LiquidityMiningPool) -> Result<(), Error> {
+    pool.reward_per_token_stored = current_reward_per_token(env, pool)?;
+
+    let now = env.ledger().timestamp();
+    pool.last_update_time = if now > pool.end_time { pool.end_time } else { now };
+
+    Ok(())
+}
+
+/// Compute rewards newly earned by a position since its last checkpoint,
+/// against the pool's *current* `reward_per_token_stored` (caller is
+/// expected to have already checkpointed the pool via
+/// [`update_reward_per_token`]).
+fn calculate_earned(pool: &LiquidityMiningPool, position: &ProviderStake) -> Result<i128, Error> {
+    let rpt_delta = pool
+        .reward_per_token_stored
+        .checked_sub(position.reward_per_token_paid)
+        .ok_or(Error::ArithmeticError)?;
+
+    position
+        .staked_amount
+        .checked_mul(rpt_delta)
+        .ok_or(Error::ArithmeticError)?
+        .checked_div(REWARD_PRECISION)
+        .ok_or(Error::ArithmeticError)
+}

--- a/contracts/token-factory/src/liquidity_mining_test.rs
+++ b/contracts/token-factory/src/liquidity_mining_test.rs
@@ -1,0 +1,784 @@
+//! Liquidity Mining Program test suite
+//!
+//! Covers: full pool lifecycle state transitions (including rejecting
+//! invalid transitions), reward accrual across pause/resume, proportional
+//! distribution among multiple providers, and admin-only reward-rate
+//! updates.
+//!
+//! Each mutating call runs inside its own `env.as_contract(...)` frame
+//! (see the `call_*` helpers below) so that `mock_all_auths()` sees a
+//! fresh top-level invocation per `require_auth()` call — batching two
+//! auth-requiring calls into a single `as_contract` closure trips the
+//! host's "frame is already authorized" guard.
+
+#[cfg(test)]
+mod liquidity_mining_test {
+    use crate::liquidity_mining;
+    use crate::storage;
+    use crate::types::{Error, LiquidityMiningPool, MiningPoolStatus, ProviderStake, TokenInfo};
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger},
+        Address, Env, String,
+    };
+
+    // ─────────────────────────────────────────────────────────────────
+    // Per-call helpers — each opens its own `as_contract` frame
+    // ─────────────────────────────────────────────────────────────────
+
+    fn call_create_pool(
+        env: &Env,
+        contract_id: &Address,
+        admin: &Address,
+        reward_token_index: u32,
+        stake_token_index: u32,
+        reward_rate: i128,
+        start_time: u64,
+        end_time: u64,
+    ) -> Result<u64, Error> {
+        env.as_contract(contract_id, || {
+            liquidity_mining::create_mining_pool(
+                env,
+                admin,
+                reward_token_index,
+                stake_token_index,
+                reward_rate,
+                start_time,
+                end_time,
+            )
+        })
+    }
+
+    fn call_deposit(
+        env: &Env,
+        contract_id: &Address,
+        provider: &Address,
+        pool_id: u64,
+        amount: i128,
+    ) -> Result<(), Error> {
+        env.as_contract(contract_id, || {
+            liquidity_mining::deposit(env, provider, pool_id, amount)
+        })
+    }
+
+    fn call_withdraw(
+        env: &Env,
+        contract_id: &Address,
+        provider: &Address,
+        pool_id: u64,
+        amount: i128,
+    ) -> Result<(), Error> {
+        env.as_contract(contract_id, || {
+            liquidity_mining::withdraw(env, provider, pool_id, amount)
+        })
+    }
+
+    fn call_claim_rewards(
+        env: &Env,
+        contract_id: &Address,
+        provider: &Address,
+        pool_id: u64,
+    ) -> Result<i128, Error> {
+        env.as_contract(contract_id, || {
+            liquidity_mining::claim_rewards(env, provider, pool_id)
+        })
+    }
+
+    fn call_pause(env: &Env, contract_id: &Address, admin: &Address, pool_id: u64) -> Result<(), Error> {
+        env.as_contract(contract_id, || {
+            liquidity_mining::pause_mining_pool(env, admin, pool_id)
+        })
+    }
+
+    fn call_resume(env: &Env, contract_id: &Address, admin: &Address, pool_id: u64) -> Result<(), Error> {
+        env.as_contract(contract_id, || {
+            liquidity_mining::resume_mining_pool(env, admin, pool_id)
+        })
+    }
+
+    fn call_end(env: &Env, contract_id: &Address, admin: &Address, pool_id: u64) -> Result<(), Error> {
+        env.as_contract(contract_id, || {
+            liquidity_mining::end_mining_pool(env, admin, pool_id)
+        })
+    }
+
+    fn call_update_reward_rate(
+        env: &Env,
+        contract_id: &Address,
+        admin: &Address,
+        pool_id: u64,
+        new_rate: i128,
+    ) -> Result<(), Error> {
+        env.as_contract(contract_id, || {
+            liquidity_mining::update_reward_rate(env, admin, pool_id, new_rate)
+        })
+    }
+
+    fn query_pool(env: &Env, contract_id: &Address, pool_id: u64) -> Option<LiquidityMiningPool> {
+        env.as_contract(contract_id, || liquidity_mining::get_mining_pool(env, pool_id))
+    }
+
+    fn query_position(
+        env: &Env,
+        contract_id: &Address,
+        pool_id: u64,
+        provider: &Address,
+    ) -> Option<ProviderStake> {
+        env.as_contract(contract_id, || {
+            liquidity_mining::get_provider_position(env, pool_id, provider)
+        })
+    }
+
+    fn query_claimable(
+        env: &Env,
+        contract_id: &Address,
+        pool_id: u64,
+        provider: &Address,
+    ) -> Result<i128, Error> {
+        env.as_contract(contract_id, || {
+            liquidity_mining::get_claimable_rewards(env, pool_id, provider)
+        })
+    }
+
+    fn advance_time(env: &Env, seconds: u64) {
+        env.ledger().with_mut(|l| l.timestamp += seconds);
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Test setup
+    // ─────────────────────────────────────────────────────────────────
+
+    /// Registers a fresh `TokenFactory` contract, bootstraps admin/pause
+    /// state, and creates a reward + stake token pair (indices 0 and 1).
+    fn setup() -> (Env, Address, Address, Address) {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, crate::TokenFactory);
+        let admin = Address::generate(&env);
+        let provider = Address::generate(&env);
+
+        env.as_contract(&contract_id, || {
+            storage::set_admin(&env, &admin);
+            storage::set_paused(&env, false);
+            storage::set_token_info(&env, 0, &make_token(&env, &admin));
+            storage::set_token_info(&env, 1, &make_token(&env, &admin));
+        });
+
+        (env, contract_id, admin, provider)
+    }
+
+    fn make_token(env: &Env, creator: &Address) -> TokenInfo {
+        TokenInfo {
+            address: Address::generate(env),
+            creator: creator.clone(),
+            name: String::from_str(env, "Token"),
+            symbol: String::from_str(env, "TKN"),
+            decimals: 7,
+            total_supply: 1_000_000_0000000,
+            initial_supply: 1_000_000_0000000,
+            max_supply: None,
+            total_burned: 0,
+            burn_count: 0,
+            metadata_uri: None,
+            metadata_version: 0,
+            created_at: env.ledger().timestamp(),
+            is_paused: false,
+            clawback_enabled: false,
+            freeze_enabled: false,
+        }
+    }
+
+    /// Creates an `Active` pool: reward token 0, stake token 1, rate 10,
+    /// running from `now` to `now + 1_000`.
+    fn create_pool(env: &Env, contract_id: &Address, admin: &Address) -> u64 {
+        let now = env.ledger().timestamp();
+        call_create_pool(env, contract_id, admin, 0, 1, 10, now, now + 1_000).unwrap()
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Pool creation
+    // ─────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_create_pool_success() {
+        let (env, contract_id, admin, _provider) = setup();
+        let pool_id = create_pool(&env, &contract_id, &admin);
+
+        let pool = query_pool(&env, &contract_id, pool_id).unwrap();
+        assert_eq!(pool.id, pool_id);
+        assert_eq!(pool.reward_rate, 10);
+        assert_eq!(pool.status, MiningPoolStatus::Active);
+        assert_eq!(pool.total_staked, 0);
+    }
+
+    #[test]
+    fn test_create_pool_increments_count() {
+        let (env, contract_id, admin, _provider) = setup();
+        create_pool(&env, &contract_id, &admin);
+        let count = env.as_contract(&contract_id, || liquidity_mining::get_mining_pool_count(&env));
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn test_create_pool_invalid_time_window() {
+        let (env, contract_id, admin, _provider) = setup();
+        let now = env.ledger().timestamp();
+        let result = call_create_pool(&env, &contract_id, &admin, 0, 1, 10, now + 100, now + 50);
+        assert_eq!(result, Err(Error::InvalidPoolTimeWindow));
+    }
+
+    #[test]
+    fn test_create_pool_end_in_past() {
+        let (env, contract_id, admin, _provider) = setup();
+        env.ledger().with_mut(|l| l.timestamp = 5_000);
+        let result = call_create_pool(&env, &contract_id, &admin, 0, 1, 10, 1_000, 2_000);
+        assert_eq!(result, Err(Error::InvalidPoolTimeWindow));
+    }
+
+    #[test]
+    fn test_create_pool_invalid_reward_rate() {
+        let (env, contract_id, admin, _provider) = setup();
+        let now = env.ledger().timestamp();
+        let result = call_create_pool(&env, &contract_id, &admin, 0, 1, 0, now, now + 1_000);
+        assert_eq!(result, Err(Error::InvalidRewardRate));
+    }
+
+    #[test]
+    fn test_create_pool_unauthorized() {
+        let (env, contract_id, _admin, provider) = setup();
+        let now = env.ledger().timestamp();
+        let result = call_create_pool(&env, &contract_id, &provider, 0, 1, 10, now, now + 1_000);
+        assert_eq!(result, Err(Error::Unauthorized));
+    }
+
+    #[test]
+    fn test_create_pool_invalid_token() {
+        let (env, contract_id, admin, _provider) = setup();
+        let now = env.ledger().timestamp();
+        let result = call_create_pool(&env, &contract_id, &admin, 99, 1, 10, now, now + 1_000);
+        assert_eq!(result, Err(Error::TokenNotFound));
+    }
+
+    #[test]
+    fn test_create_pool_contract_paused() {
+        let (env, contract_id, admin, _provider) = setup();
+        env.as_contract(&contract_id, || storage::set_paused(&env, true));
+        let now = env.ledger().timestamp();
+        let result = call_create_pool(&env, &contract_id, &admin, 0, 1, 10, now, now + 1_000);
+        assert_eq!(result, Err(Error::ContractPaused));
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Deposit
+    // ─────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_deposit_success() {
+        let (env, contract_id, admin, provider) = setup();
+        let pool_id = create_pool(&env, &contract_id, &admin);
+
+        call_deposit(&env, &contract_id, &provider, pool_id, 1_000).unwrap();
+
+        let position = query_position(&env, &contract_id, pool_id, &provider).unwrap();
+        assert_eq!(position.staked_amount, 1_000);
+
+        let pool = query_pool(&env, &contract_id, pool_id).unwrap();
+        assert_eq!(pool.total_staked, 1_000);
+    }
+
+    #[test]
+    fn test_deposit_zero_amount_rejected() {
+        let (env, contract_id, admin, provider) = setup();
+        let pool_id = create_pool(&env, &contract_id, &admin);
+        let result = call_deposit(&env, &contract_id, &provider, pool_id, 0);
+        assert_eq!(result, Err(Error::InvalidAmount));
+    }
+
+    #[test]
+    fn test_deposit_negative_amount_rejected() {
+        let (env, contract_id, admin, provider) = setup();
+        let pool_id = create_pool(&env, &contract_id, &admin);
+        let result = call_deposit(&env, &contract_id, &provider, pool_id, -1);
+        assert_eq!(result, Err(Error::InvalidAmount));
+    }
+
+    #[test]
+    fn test_deposit_pool_not_found() {
+        let (env, contract_id, _admin, provider) = setup();
+        let result = call_deposit(&env, &contract_id, &provider, 999, 1_000);
+        assert_eq!(result, Err(Error::MiningPoolNotFound));
+    }
+
+    #[test]
+    fn test_deposit_before_pool_start_rejected() {
+        let (env, contract_id, admin, provider) = setup();
+        let now = env.ledger().timestamp();
+        let pool_id =
+            call_create_pool(&env, &contract_id, &admin, 0, 1, 10, now + 500, now + 2_000).unwrap();
+
+        let result = call_deposit(&env, &contract_id, &provider, pool_id, 1_000);
+        assert_eq!(result, Err(Error::InvalidPoolTimeWindow));
+    }
+
+    #[test]
+    fn test_deposit_after_pool_end_rejected() {
+        let (env, contract_id, admin, provider) = setup();
+        let pool_id = create_pool(&env, &contract_id, &admin);
+
+        advance_time(&env, 2_000);
+        let result = call_deposit(&env, &contract_id, &provider, pool_id, 1_000);
+        assert_eq!(result, Err(Error::InvalidPoolTimeWindow));
+    }
+
+    #[test]
+    fn test_deposit_paused_pool_rejected() {
+        let (env, contract_id, admin, provider) = setup();
+        let pool_id = create_pool(&env, &contract_id, &admin);
+
+        call_pause(&env, &contract_id, &admin, pool_id).unwrap();
+        let result = call_deposit(&env, &contract_id, &provider, pool_id, 1_000);
+        assert_eq!(result, Err(Error::MiningPoolNotActive));
+    }
+
+    #[test]
+    fn test_multiple_deposits_accumulate() {
+        let (env, contract_id, admin, provider) = setup();
+        let pool_id = create_pool(&env, &contract_id, &admin);
+
+        call_deposit(&env, &contract_id, &provider, pool_id, 500).unwrap();
+        call_deposit(&env, &contract_id, &provider, pool_id, 300).unwrap();
+
+        let position = query_position(&env, &contract_id, pool_id, &provider).unwrap();
+        assert_eq!(position.staked_amount, 800);
+
+        let pool = query_pool(&env, &contract_id, pool_id).unwrap();
+        assert_eq!(pool.total_staked, 800);
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Withdraw
+    // ─────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_withdraw_success() {
+        let (env, contract_id, admin, provider) = setup();
+        let pool_id = create_pool(&env, &contract_id, &admin);
+
+        call_deposit(&env, &contract_id, &provider, pool_id, 1_000).unwrap();
+        call_withdraw(&env, &contract_id, &provider, pool_id, 400).unwrap();
+
+        let position = query_position(&env, &contract_id, pool_id, &provider).unwrap();
+        assert_eq!(position.staked_amount, 600);
+
+        let pool = query_pool(&env, &contract_id, pool_id).unwrap();
+        assert_eq!(pool.total_staked, 600);
+    }
+
+    #[test]
+    fn test_withdraw_full_amount() {
+        let (env, contract_id, admin, provider) = setup();
+        let pool_id = create_pool(&env, &contract_id, &admin);
+
+        call_deposit(&env, &contract_id, &provider, pool_id, 1_000).unwrap();
+        call_withdraw(&env, &contract_id, &provider, pool_id, 1_000).unwrap();
+
+        let position = query_position(&env, &contract_id, pool_id, &provider).unwrap();
+        assert_eq!(position.staked_amount, 0);
+    }
+
+    #[test]
+    fn test_withdraw_exceeds_balance_rejected() {
+        let (env, contract_id, admin, provider) = setup();
+        let pool_id = create_pool(&env, &contract_id, &admin);
+
+        call_deposit(&env, &contract_id, &provider, pool_id, 500).unwrap();
+        let result = call_withdraw(&env, &contract_id, &provider, pool_id, 600);
+        assert_eq!(result, Err(Error::InsufficientStakedAmount));
+    }
+
+    #[test]
+    fn test_withdraw_zero_amount_rejected() {
+        let (env, contract_id, admin, provider) = setup();
+        let pool_id = create_pool(&env, &contract_id, &admin);
+
+        call_deposit(&env, &contract_id, &provider, pool_id, 500).unwrap();
+        let result = call_withdraw(&env, &contract_id, &provider, pool_id, 0);
+        assert_eq!(result, Err(Error::InvalidAmount));
+    }
+
+    #[test]
+    fn test_withdraw_no_position_rejected() {
+        let (env, contract_id, admin, provider) = setup();
+        let pool_id = create_pool(&env, &contract_id, &admin);
+        let result = call_withdraw(&env, &contract_id, &provider, pool_id, 100);
+        assert_eq!(result, Err(Error::NoMiningPosition));
+    }
+
+    #[test]
+    fn test_withdraw_allowed_after_pool_ended() {
+        let (env, contract_id, admin, provider) = setup();
+        let pool_id = create_pool(&env, &contract_id, &admin);
+
+        call_deposit(&env, &contract_id, &provider, pool_id, 1_000).unwrap();
+        call_end(&env, &contract_id, &admin, pool_id).unwrap();
+        let result = call_withdraw(&env, &contract_id, &provider, pool_id, 1_000);
+        assert!(result.is_ok(), "withdrawal must remain possible after pool ends");
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Reward accrual and claiming
+    // ─────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_rewards_accrue_over_time() {
+        let (env, contract_id, admin, provider) = setup();
+        let pool_id = create_pool(&env, &contract_id, &admin);
+
+        call_deposit(&env, &contract_id, &provider, pool_id, 1_000).unwrap();
+        advance_time(&env, 100);
+
+        let claimable = query_claimable(&env, &contract_id, pool_id, &provider).unwrap();
+        assert!(claimable > 0, "rewards should have accrued");
+    }
+
+    #[test]
+    fn test_claim_rewards_success() {
+        let (env, contract_id, admin, provider) = setup();
+        let pool_id = create_pool(&env, &contract_id, &admin);
+
+        call_deposit(&env, &contract_id, &provider, pool_id, 1_000).unwrap();
+        advance_time(&env, 100);
+
+        let claimed = call_claim_rewards(&env, &contract_id, &provider, pool_id).unwrap();
+        assert!(claimed > 0, "should have claimed rewards");
+
+        let claimable = query_claimable(&env, &contract_id, pool_id, &provider).unwrap();
+        assert_eq!(claimable, 0, "pending rewards reset after claim");
+    }
+
+    #[test]
+    fn test_claim_nothing_to_claim() {
+        let (env, contract_id, admin, provider) = setup();
+        let pool_id = create_pool(&env, &contract_id, &admin);
+        let result = call_claim_rewards(&env, &contract_id, &provider, pool_id);
+        assert_eq!(result, Err(Error::NoMiningPosition));
+    }
+
+    #[test]
+    fn test_claim_immediately_after_deposit_is_zero() {
+        let (env, contract_id, admin, provider) = setup();
+        let pool_id = create_pool(&env, &contract_id, &admin);
+
+        call_deposit(&env, &contract_id, &provider, pool_id, 1_000).unwrap();
+        let result = call_claim_rewards(&env, &contract_id, &provider, pool_id);
+        assert_eq!(result, Err(Error::NothingToClaim));
+    }
+
+    #[test]
+    fn test_rewards_stop_at_end_time() {
+        let (env, contract_id, admin, provider) = setup();
+        let pool_id = create_pool(&env, &contract_id, &admin);
+
+        call_deposit(&env, &contract_id, &provider, pool_id, 1_000).unwrap();
+        advance_time(&env, 5_000);
+        let claimable_past = query_claimable(&env, &contract_id, pool_id, &provider).unwrap();
+
+        advance_time(&env, 5_000);
+        let claimable_further = query_claimable(&env, &contract_id, pool_id, &provider).unwrap();
+
+        assert_eq!(
+            claimable_past, claimable_further,
+            "rewards must not accrue past end_time"
+        );
+    }
+
+    #[test]
+    fn test_proportional_rewards_two_providers() {
+        let (env, contract_id, admin, provider) = setup();
+        let pool_id = create_pool(&env, &contract_id, &admin);
+        let provider2 = Address::generate(&env);
+
+        // 3000/1000 = 75/25 split
+        call_deposit(&env, &contract_id, &provider, pool_id, 3_000).unwrap();
+        call_deposit(&env, &contract_id, &provider2, pool_id, 1_000).unwrap();
+
+        advance_time(&env, 100);
+
+        let r1 = query_claimable(&env, &contract_id, pool_id, &provider).unwrap();
+        let r2 = query_claimable(&env, &contract_id, pool_id, &provider2).unwrap();
+
+        assert!(r1 > r2, "larger depositor should earn more");
+        let ratio = r1 / r2.max(1);
+        assert!((2..=4).contains(&ratio), "ratio should be ~3x, got {}", ratio);
+    }
+
+    #[test]
+    fn test_rewards_preserved_after_withdraw() {
+        let (env, contract_id, admin, provider) = setup();
+        let pool_id = create_pool(&env, &contract_id, &admin);
+
+        call_deposit(&env, &contract_id, &provider, pool_id, 1_000).unwrap();
+        advance_time(&env, 100);
+        call_withdraw(&env, &contract_id, &provider, pool_id, 1_000).unwrap();
+
+        let position = query_position(&env, &contract_id, pool_id, &provider).unwrap();
+        assert!(
+            position.pending_rewards > 0,
+            "pending rewards must be preserved after withdraw"
+        );
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Pool lifecycle: pause / resume / end (state machine)
+    // ─────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_pause_resume_pause_cycle() {
+        let (env, contract_id, admin, _provider) = setup();
+        let pool_id = create_pool(&env, &contract_id, &admin);
+
+        call_pause(&env, &contract_id, &admin, pool_id).unwrap();
+        assert_eq!(
+            query_pool(&env, &contract_id, pool_id).unwrap().status,
+            MiningPoolStatus::Paused
+        );
+
+        call_resume(&env, &contract_id, &admin, pool_id).unwrap();
+        assert_eq!(
+            query_pool(&env, &contract_id, pool_id).unwrap().status,
+            MiningPoolStatus::Active
+        );
+
+        call_pause(&env, &contract_id, &admin, pool_id).unwrap();
+        assert_eq!(
+            query_pool(&env, &contract_id, pool_id).unwrap().status,
+            MiningPoolStatus::Paused
+        );
+    }
+
+    #[test]
+    fn test_pause_already_paused_rejected() {
+        let (env, contract_id, admin, _provider) = setup();
+        let pool_id = create_pool(&env, &contract_id, &admin);
+
+        call_pause(&env, &contract_id, &admin, pool_id).unwrap();
+        let result = call_pause(&env, &contract_id, &admin, pool_id);
+        assert_eq!(result, Err(Error::MiningPoolInvalidTransition));
+    }
+
+    #[test]
+    fn test_resume_active_pool_rejected() {
+        let (env, contract_id, admin, _provider) = setup();
+        let pool_id = create_pool(&env, &contract_id, &admin);
+        let result = call_resume(&env, &contract_id, &admin, pool_id);
+        assert_eq!(result, Err(Error::MiningPoolInvalidTransition));
+    }
+
+    #[test]
+    fn test_end_pool_success() {
+        let (env, contract_id, admin, _provider) = setup();
+        let pool_id = create_pool(&env, &contract_id, &admin);
+
+        call_end(&env, &contract_id, &admin, pool_id).unwrap();
+        assert_eq!(
+            query_pool(&env, &contract_id, pool_id).unwrap().status,
+            MiningPoolStatus::Ended
+        );
+    }
+
+    #[test]
+    fn test_end_already_ended_rejected() {
+        let (env, contract_id, admin, _provider) = setup();
+        let pool_id = create_pool(&env, &contract_id, &admin);
+
+        call_end(&env, &contract_id, &admin, pool_id).unwrap();
+        let result = call_end(&env, &contract_id, &admin, pool_id);
+        assert_eq!(result, Err(Error::MiningPoolInvalidTransition));
+    }
+
+    #[test]
+    fn test_pause_ended_pool_rejected() {
+        let (env, contract_id, admin, _provider) = setup();
+        let pool_id = create_pool(&env, &contract_id, &admin);
+
+        call_end(&env, &contract_id, &admin, pool_id).unwrap();
+        let result = call_pause(&env, &contract_id, &admin, pool_id);
+        assert_eq!(result, Err(Error::MiningPoolInvalidTransition));
+    }
+
+    #[test]
+    fn test_resume_ended_pool_rejected() {
+        let (env, contract_id, admin, _provider) = setup();
+        let pool_id = create_pool(&env, &contract_id, &admin);
+
+        call_end(&env, &contract_id, &admin, pool_id).unwrap();
+        let result = call_resume(&env, &contract_id, &admin, pool_id);
+        assert_eq!(result, Err(Error::MiningPoolInvalidTransition));
+    }
+
+    #[test]
+    fn test_pause_unauthorized() {
+        let (env, contract_id, admin, provider) = setup();
+        let pool_id = create_pool(&env, &contract_id, &admin);
+        let result = call_pause(&env, &contract_id, &provider, pool_id);
+        assert_eq!(result, Err(Error::Unauthorized));
+    }
+
+    #[test]
+    fn test_end_unauthorized() {
+        let (env, contract_id, admin, provider) = setup();
+        let pool_id = create_pool(&env, &contract_id, &admin);
+        let result = call_end(&env, &contract_id, &provider, pool_id);
+        assert_eq!(result, Err(Error::Unauthorized));
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Reward rate update (admin only)
+    // ─────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_update_reward_rate_success() {
+        let (env, contract_id, admin, _provider) = setup();
+        let pool_id = create_pool(&env, &contract_id, &admin);
+
+        call_update_reward_rate(&env, &contract_id, &admin, pool_id, 50).unwrap();
+        let pool = query_pool(&env, &contract_id, pool_id).unwrap();
+        assert_eq!(pool.reward_rate, 50);
+    }
+
+    #[test]
+    fn test_update_reward_rate_zero_rejected() {
+        let (env, contract_id, admin, _provider) = setup();
+        let pool_id = create_pool(&env, &contract_id, &admin);
+        let result = call_update_reward_rate(&env, &contract_id, &admin, pool_id, 0);
+        assert_eq!(result, Err(Error::InvalidRewardRate));
+    }
+
+    #[test]
+    fn test_update_reward_rate_paused_pool_rejected() {
+        let (env, contract_id, admin, _provider) = setup();
+        let pool_id = create_pool(&env, &contract_id, &admin);
+
+        call_pause(&env, &contract_id, &admin, pool_id).unwrap();
+        let result = call_update_reward_rate(&env, &contract_id, &admin, pool_id, 20);
+        assert_eq!(result, Err(Error::MiningPoolNotActive));
+    }
+
+    #[test]
+    fn test_update_reward_rate_unauthorized() {
+        let (env, contract_id, admin, provider) = setup();
+        let pool_id = create_pool(&env, &contract_id, &admin);
+        let result = call_update_reward_rate(&env, &contract_id, &provider, pool_id, 20);
+        assert_eq!(result, Err(Error::Unauthorized));
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Reward accrual pauses while the pool is paused
+    // ─────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_no_rewards_during_pause() {
+        let (env, contract_id, admin, provider) = setup();
+        let pool_id = create_pool(&env, &contract_id, &admin);
+
+        call_deposit(&env, &contract_id, &provider, pool_id, 1_000).unwrap();
+
+        advance_time(&env, 50);
+        call_pause(&env, &contract_id, &admin, pool_id).unwrap();
+
+        let claimable_at_pause = query_claimable(&env, &contract_id, pool_id, &provider).unwrap();
+
+        advance_time(&env, 100);
+        let claimable_while_paused = query_claimable(&env, &contract_id, pool_id, &provider).unwrap();
+
+        assert_eq!(
+            claimable_at_pause, claimable_while_paused,
+            "rewards must not accrue while the pool is paused"
+        );
+    }
+
+    #[test]
+    fn test_rewards_resume_after_unpause() {
+        let (env, contract_id, admin, provider) = setup();
+        let pool_id = create_pool(&env, &contract_id, &admin);
+
+        call_deposit(&env, &contract_id, &provider, pool_id, 1_000).unwrap();
+
+        advance_time(&env, 50);
+        call_pause(&env, &contract_id, &admin, pool_id).unwrap();
+
+        let claimable_at_pause = query_claimable(&env, &contract_id, pool_id, &provider).unwrap();
+
+        advance_time(&env, 100);
+        call_resume(&env, &contract_id, &admin, pool_id).unwrap();
+
+        advance_time(&env, 50);
+        let claimable_after_resume = query_claimable(&env, &contract_id, pool_id, &provider).unwrap();
+
+        assert!(
+            claimable_after_resume > claimable_at_pause,
+            "rewards should accrue again after resume"
+        );
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Arithmetic safety
+    // ─────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_deposit_i128_max_rejected() {
+        let (env, contract_id, admin, provider) = setup();
+        let pool_id = create_pool(&env, &contract_id, &admin);
+
+        call_deposit(&env, &contract_id, &provider, pool_id, 1_000).unwrap();
+        let result = call_deposit(&env, &contract_id, &provider, pool_id, i128::MAX);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_claimable_rewards_no_position_returns_zero() {
+        let (env, contract_id, admin, provider) = setup();
+        let pool_id = create_pool(&env, &contract_id, &admin);
+        let claimable = query_claimable(&env, &contract_id, pool_id, &provider).unwrap();
+        assert_eq!(claimable, 0);
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Integration: full lifecycle
+    // ─────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_full_lifecycle() {
+        let (env, contract_id, admin, provider) = setup();
+        let pool_id = create_pool(&env, &contract_id, &admin);
+
+        // Deposit
+        call_deposit(&env, &contract_id, &provider, pool_id, 2_000).unwrap();
+
+        // Accrue
+        advance_time(&env, 200);
+
+        // Claim
+        let claimed = call_claim_rewards(&env, &contract_id, &provider, pool_id).unwrap();
+        assert!(claimed > 0);
+
+        // Accrue more
+        advance_time(&env, 200);
+
+        // Withdraw everything
+        call_withdraw(&env, &contract_id, &provider, pool_id, 2_000).unwrap();
+        let position = query_position(&env, &contract_id, pool_id, &provider).unwrap();
+        assert!(position.pending_rewards > 0);
+
+        // Admin ends the pool
+        call_end(&env, &contract_id, &admin, pool_id).unwrap();
+        assert_eq!(
+            query_pool(&env, &contract_id, pool_id).unwrap().status,
+            MiningPoolStatus::Ended
+        );
+
+        // Remaining rewards still claimable after the pool ends
+        let final_claim = call_claim_rewards(&env, &contract_id, &provider, pool_id).unwrap();
+        assert!(final_claim > 0);
+    }
+}

--- a/contracts/token-factory/src/storage.rs
+++ b/contracts/token-factory/src/storage.rs
@@ -2210,6 +2210,63 @@ pub fn set_reservation_timeout_ledgers(env: &Env, ledgers: u32) {
         .set(&DataKey::ReservationTimeoutLedgers, &ledgers);
 }
 
+// ============================================================
+// Storage Functions - Liquidity Mining
+// ============================================================
+
+/// Get a liquidity mining pool by id
+pub fn get_mining_pool(env: &Env, pool_id: u64) -> Option<crate::types::LiquidityMiningPool> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::MiningPool(pool_id))
+}
+
+/// Store a liquidity mining pool
+pub fn set_mining_pool(env: &Env, pool_id: u64, pool: &crate::types::LiquidityMiningPool) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::MiningPool(pool_id), pool);
+}
+
+/// Get the total number of liquidity mining pools created
+pub fn get_mining_pool_count(env: &Env) -> u64 {
+    env.storage()
+        .instance()
+        .get(&DataKey::MiningPoolCount)
+        .unwrap_or(0)
+}
+
+/// Allocate and return the next liquidity mining pool id, bumping the counter
+pub fn next_mining_pool_id(env: &Env) -> Result<u64, Error> {
+    let id = get_mining_pool_count(env);
+    let next = id.checked_add(1).ok_or(Error::ArithmeticError)?;
+    env.storage().instance().set(&DataKey::MiningPoolCount, &next);
+    Ok(id)
+}
+
+/// Get a provider's position (stake + reward checkpoint) in a pool
+pub fn get_mining_position(
+    env: &Env,
+    pool_id: u64,
+    provider: &Address,
+) -> Option<crate::types::ProviderStake> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::MiningPosition(pool_id, provider.clone()))
+}
+
+/// Store a provider's position in a pool
+pub fn set_mining_position(
+    env: &Env,
+    pool_id: u64,
+    provider: &Address,
+    position: &crate::types::ProviderStake,
+) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::MiningPosition(pool_id, provider.clone()), position);
+}
+
 // ── Tests — Issue #1681: panic-free core storage getters ─────────────────────
 //
 // Each test calls a getter *before* `initialize()` has been invoked and

--- a/contracts/token-factory/src/types.rs
+++ b/contracts/token-factory/src/types.rs
@@ -962,6 +962,14 @@ pub enum DataKey {
     Reservation(u64),
     /// Ledgers a reservation may sit `Prepared` before it can be force-released
     ReservationTimeoutLedgers,
+    // ── Liquidity mining (pools distribute reward tokens to LPs proportional
+    // to their share of total deposits) ──
+    /// Liquidity mining pool record, keyed by pool id
+    MiningPool(u64),
+    /// Total number of liquidity mining pools created
+    MiningPoolCount,
+    /// A provider's position (stake + reward checkpoint) in a pool: (pool_id, provider)
+    MiningPosition(u64, Address),
 }
 
 /// A point-in-time record of a token holder's balance.
@@ -1310,6 +1318,26 @@ impl Error {
     pub const MetadataImmutable: Self = Self(131);
     // Multisig admin-change errors
     pub const DuplicateSigners: Self = Self(132);
+    // Liquidity mining errors
+    /// Pool with the given id does not exist
+    pub const MiningPoolNotFound: Self = Self(133);
+    /// Operation requires the pool to be in the `Active` state
+    pub const MiningPoolNotActive: Self = Self(134);
+    /// `resume_mining_pool` called on a pool that is not `Paused`
+    pub const MiningPoolNotPaused: Self = Self(135);
+    /// `pause_mining_pool`/`resume_mining_pool`/`end_mining_pool` called on an
+    /// already-`Ended` pool, or `pause_mining_pool` called on an already-`Paused` pool
+    pub const MiningPoolInvalidTransition: Self = Self(136);
+    /// `reward_rate` is zero, negative, or exceeds the maximum allowed rate
+    pub const InvalidRewardRate: Self = Self(137);
+    /// Pool `start_time`/`end_time` window is invalid (start >= end, or end already elapsed)
+    pub const InvalidPoolTimeWindow: Self = Self(138);
+    /// Caller has no position (stake) recorded in the pool
+    pub const NoMiningPosition: Self = Self(139);
+    /// Withdrawal amount exceeds the caller's staked balance
+    pub const InsufficientStakedAmount: Self = Self(140);
+    /// The maximum number of liquidity mining pools has been reached
+    pub const TooManyMiningPools: Self = Self(141);
 
     /// Stable string name for this error code, for off-chain event payloads
     /// (see `emit_operation_failed`). Covers the vault entry-point error
@@ -1333,6 +1361,15 @@ impl Error {
             98 => "VaultOwnerChangeNotFound",
             99 => "VaultOwnerChangeAlreadyApproved",
             130 => "VaultCircuitBreakerActive",
+            133 => "MiningPoolNotFound",
+            134 => "MiningPoolNotActive",
+            135 => "MiningPoolNotPaused",
+            136 => "MiningPoolInvalidTransition",
+            137 => "InvalidRewardRate",
+            138 => "InvalidPoolTimeWindow",
+            139 => "NoMiningPosition",
+            140 => "InsufficientStakedAmount",
+            141 => "TooManyMiningPools",
             _ => "UnknownError",
         }
     }


### PR DESCRIPTION
## Summary

Adds a liquidity mining incentive program to the token-factory contract: liquidity providers deposit a stake token into an admin-created mining pool and earn a reward token over time, distributed proportionally to their share of the pool's total deposits.

- Pool lifecycle is an explicit, tested state machine (`Active <-> Paused`, `Active`/`Paused -> Ended`) with invalid transitions rejected via a dedicated `MiningPoolInvalidTransition` error, mirroring the pattern used for buyback campaign state (`CampaignStatus`).
- Reward accrual uses a reward-per-token accumulator (O(1) per provider regardless of pool size), capped at `end_time` and frozen entirely while the pool is paused; resuming resets the checkpoint clock so the paused interval is never rewarded.
- New entry points on `TokenFactory`: `create_mining_pool`, `deposit_liquidity`, `withdraw_liquidity`, `claim_mining_rewards`, `pause_mining_pool`/`resume_mining_pool`/`end_mining_pool`, `update_mining_reward_rate`, and `get_mining_pool`/`get_mining_position`/`get_claimable_mining_rewards`/`get_mining_pool_count` queries.
- New `DataKey::MiningPool(u64)` / `MiningPoolCount` / `MiningPosition(u64, Address)` variants (appended at the end of the enum — no existing discriminants reused).
- New `Error` variants `133`–`141` (`MiningPoolNotFound`, `MiningPoolNotActive`, `MiningPoolNotPaused`, `MiningPoolInvalidTransition`, `InvalidRewardRate`, `InvalidPoolTimeWindow`, `NoMiningPosition`, `InsufficientStakedAmount`, `TooManyMiningPools`), with matching entries in `Error::name()`.
- Storage getters/setters added in `storage.rs` following the existing `persistent()`/`instance()` pattern; events emitted via `events.rs` using versioned `lm_*_v1` topics (all ≤ 9 chars for `symbol_short!`).

### On the shared reward-accumulator question

The issue suggests considering a shared reward-accumulator helper with the Staking issue (#1757), since both have a similar reward-accrual shape. I checked: neither `staking.rs` nor `amm.rs` exist in this codebase currently — both were removed in a prior "trim unused contract modules" pass, along with liquidity mining's own original implementation (all three had been built and merged once already, then swept out together). Since there's no live staking code to share against, I kept the accumulator logic self-contained in `liquidity_mining.rs`. If/when the Staking issue is picked up, its reward math is a natural candidate to extract into a shared helper alongside this module's.

## Test plan

- [x] `cargo check --lib` — clean
- [x] `cargo build --target wasm32v1-none --release --lib` — clean
- [x] 47 new unit tests in `liquidity_mining_test.rs` covering: full pool lifecycle transitions including rejected invalid transitions, reward accrual across pause/resume, proportional distribution across multiple providers, and admin-only reward-rate updates — all pass
- [x] `cargo test --lib` — **cannot currently run clean on this crate.** `contracts/token-factory`'s test build fails to compile on `main` itself (156 pre-existing errors spread across ~18 unrelated files: stale struct-literal fields against current `TokenInfo`/`Vault` shapes, missing `soroban_sdk::testutils::{Ledger, Events}` imports, a `prop_assert_eq!` capture-syntax issue, an `Option<T>` XDR-derive issue in an unrelated dead pagination struct, etc.). I confirmed this is 100% pre-existing and unrelated to this change by running `cargo test --lib --no-run` on a clean `main` checkout (identical 156-error count, none referencing `liquidity_mining`). I verified my 47 new tests actually pass by temporarily isolating them from the unrelated broken files locally (not part of this diff) — all 47 passed cleanly. Fixing the crate-wide pre-existing test breakage is out of scope for this PR; happy to split that into a separate cleanup PR if useful.

Closes #1758