### PR TITLE
feat(contracts): add multi-pool staking with precision-scaled reward accrual

### DIFF
--- a/contracts/token-factory/src/events.rs
+++ b/contracts/token-factory/src/events.rs
@@ -1894,3 +1894,49 @@ pub fn emit_settlement_timeout_cleanup(env: &Env, reservation_id: u64, proposal_
     env.events()
         .publish((symbol_short!("stl_tmo1"), reservation_id), (proposal_id,));
 }
+
+// ── Staking (#1757) ──────────────────────────────────────────────────────
+
+/// Emitted when a new staking pool is created.
+///
+/// **Schema Version**: 1
+/// **Event Name**: stk_crt1
+pub fn emit_staking_pool_created(
+    env: &Env,
+    pool_id: u64,
+    token_index: u32,
+    reward_token_index: u32,
+    reward_rate: i128,
+) {
+    env.events().publish(
+        (symbol_short!("stk_crt1"), pool_id),
+        (token_index, reward_token_index, reward_rate),
+    );
+}
+
+/// Emitted when a user stakes into a pool.
+///
+/// **Schema Version**: 1
+/// **Event Name**: stk_dep1
+pub fn emit_staked(env: &Env, pool_id: u64, user: &Address, amount: i128) {
+    env.events()
+        .publish((symbol_short!("stk_dep1"), pool_id), (user.clone(), amount));
+}
+
+/// Emitted when a user unstakes from a pool.
+///
+/// **Schema Version**: 1
+/// **Event Name**: stk_wd1
+pub fn emit_unstaked(env: &Env, pool_id: u64, user: &Address, amount: i128) {
+    env.events()
+        .publish((symbol_short!("stk_wd1"), pool_id), (user.clone(), amount));
+}
+
+/// Emitted when a user claims accrued staking rewards.
+///
+/// **Schema Version**: 1
+/// **Event Name**: stk_clm1
+pub fn emit_reward_claimed(env: &Env, pool_id: u64, user: &Address, amount: i128) {
+    env.events()
+        .publish((symbol_short!("stk_clm1"), pool_id), (user.clone(), amount));
+}

--- a/contracts/token-factory/src/lib.rs
+++ b/contracts/token-factory/src/lib.rs
@@ -36,6 +36,7 @@ mod proposal_type_queue;
 #[cfg(test)]
 mod proposal_execution_queue_fifo_test;
 mod proposal_state_machine;
+mod staking;
 mod storage;
 mod storage_migration;
 #[cfg(test)]
@@ -48,6 +49,8 @@ mod game_history_test;
 mod proposal_queue_test;
 #[cfg(test)]
 mod event_versions_test;
+#[cfg(test)]
+mod staking_integration_test;
 mod timelock;
 mod token_creation;
 mod treasury;
@@ -163,8 +166,8 @@ use soroban_sdk::{contract, contractimpl, symbol_short, Address, Bytes, BytesN, 
 use types::{
     AuctionStatus, BatchScheduleResult, BurnAuction, BuybackCampaign, CampaignStatus,
     ContractMetadata, DynamicQuorumConfig, Error, FactoryState, PaginationCursor,
-    PreflightItemResult, Reservation, StreamInfo, StreamPage, StreamParams, TokenCreationParams,
-    TokenInfo, TokenStats, Vault, VaultStatus,
+    PreflightItemResult, Reservation, StakeInfo, StakingPool, StreamInfo, StreamPage,
+    StreamParams, TokenCreationParams, TokenInfo, TokenStats, Vault, VaultStatus,
 };
 use crate::milestone_verification::MilestoneVerifier;
 
@@ -4145,6 +4148,57 @@ impl TokenFactory {
         events::emit_multisig_executed(env, proposal.id, executor);
 
         Ok(())
+    }
+
+    // ── Staking (#1757) ─────────────────────────────────────────────────
+
+    /// Create a staking pool paying `reward_rate` units of the reward token
+    /// per second to stakers, proportional to their share of the pool.
+    /// Caller must be the factory admin or the creator of `token_index`.
+    pub fn create_staking_pool(
+        env: Env,
+        creator: Address,
+        token_index: u32,
+        reward_token_index: u32,
+        reward_rate: i128,
+    ) -> Result<u64, Error> {
+        staking::create_staking_pool(&env, creator, token_index, reward_token_index, reward_rate)
+    }
+
+    /// Stake `amount` of a pool's staking token, settling any pending
+    /// reward first.
+    pub fn stake(env: Env, caller: Address, pool_id: u64, amount: i128) -> Result<(), Error> {
+        staking::stake(&env, caller, pool_id, amount)
+    }
+
+    /// Unstake `amount` of a pool's staking token, settling any pending
+    /// reward first.
+    pub fn unstake(env: Env, caller: Address, pool_id: u64, amount: i128) -> Result<(), Error> {
+        staking::unstake(&env, caller, pool_id, amount)
+    }
+
+    /// Pay out a staker's currently accrued reward without unstaking.
+    pub fn claim_rewards(env: Env, caller: Address, pool_id: u64) -> Result<(), Error> {
+        staking::claim_rewards(&env, caller, pool_id)
+    }
+
+    /// Query a staking pool's current state.
+    pub fn get_staking_pool(env: Env, pool_id: u64) -> Result<StakingPool, Error> {
+        storage::get_staking_pool(&env, pool_id).ok_or(Error::StakingPoolNotFound)
+    }
+
+    /// Query a user's stake within a pool (zeroed if the user never staked).
+    pub fn get_user_stake(env: Env, pool_id: u64, user: Address) -> StakeInfo {
+        storage::get_user_stake(&env, pool_id, &user).unwrap_or(StakeInfo {
+            amount: 0,
+            reward_debt: 0,
+        })
+    }
+
+    /// Preview a staker's currently accrued (unclaimed) reward without
+    /// mutating any state.
+    pub fn pending_rewards(env: Env, caller: Address, pool_id: u64) -> Result<i128, Error> {
+        staking::pending_rewards(&env, caller, pool_id)
     }
 
 }

--- a/contracts/token-factory/src/staking.rs
+++ b/contracts/token-factory/src/staking.rs
@@ -1,0 +1,306 @@
+//! Multi-pool staking (#1757).
+//!
+//! Users create staking pools for a given token and stake into them to earn
+//! rewards in a (possibly different) reward token, accrued over time via a
+//! precision-scaled reward-per-share accumulator — the standard "MasterChef"
+//! checkpoint pattern.
+//!
+//! `stake` / `unstake` / `claim_rewards` all call [`update_pool`] first, which
+//! rolls the pool's `acc_reward_per_share` forward to the current ledger
+//! timestamp before touching the caller's position. This guarantees every
+//! mutation is checkpointed against a consistent accumulator value:
+//! - Rewards that accrue while a pool has zero stakers are simply not
+//!   accrued (no elapsed-time reward is materialized into
+//!   `acc_reward_per_share`), so they are never later attributed to a
+//!   staker who wasn't there to earn them.
+//! - A staker's `reward_debt` is always re-anchored to the accumulator value
+//!   at the moment their `amount` changes, so reward accrued before they
+//!   entered (or after they fully exited) is neither double-counted nor lost.
+
+use crate::events;
+use crate::storage;
+use crate::types::{Error, StakeInfo, StakingPool};
+use soroban_sdk::{Address, Env};
+
+/// Fixed-point scaling factor for the reward-per-share accumulator.
+const PRECISION: i128 = 1_000_000_000_000;
+
+/// Create a new staking pool paying `reward_rate` units of the reward token
+/// per second to stakers, proportional to their share of the pool.
+///
+/// Caller must be either the factory admin or the creator of `token_index`.
+pub fn create_staking_pool(
+    env: &Env,
+    creator: Address,
+    token_index: u32,
+    reward_token_index: u32,
+    reward_rate: i128,
+) -> Result<u64, Error> {
+    creator.require_auth();
+
+    if reward_rate < 0 {
+        return Err(Error::InvalidRewardRate);
+    }
+
+    let admin = storage::get_admin(env).ok_or(Error::MissingAdmin)?;
+    let token = storage::get_token_info(env, token_index).ok_or(Error::TokenNotFound)?;
+    storage::get_token_info(env, reward_token_index).ok_or(Error::TokenNotFound)?;
+
+    if creator != admin && creator != token.creator {
+        return Err(Error::Unauthorized);
+    }
+
+    let pool_id = storage::increment_next_staking_pool_id(env);
+    let pool = StakingPool {
+        id: pool_id,
+        token_index,
+        reward_token_index,
+        reward_rate,
+        total_staked: 0,
+        acc_reward_per_share: 0,
+        last_reward_time: env.ledger().timestamp(),
+        active: true,
+        creator: creator.clone(),
+    };
+
+    storage::set_staking_pool(env, pool_id, &pool);
+    storage::increment_staking_pool_count(env)?;
+
+    events::emit_staking_pool_created(env, pool_id, token_index, reward_token_index, reward_rate);
+
+    Ok(pool_id)
+}
+
+/// Roll a pool's `acc_reward_per_share` forward to the current ledger
+/// timestamp. Must be called before reading or mutating any staker's
+/// position so accrual is always computed against a consistent checkpoint.
+fn update_pool(env: &Env, pool: &mut StakingPool) -> Result<(), Error> {
+    let current_time = env.ledger().timestamp();
+    if current_time <= pool.last_reward_time {
+        return Ok(());
+    }
+
+    if pool.total_staked == 0 {
+        // No stakers to attribute rewards to; skip accrual for this
+        // interval entirely rather than letting it land on whoever stakes
+        // next.
+        pool.last_reward_time = current_time;
+        return Ok(());
+    }
+
+    let time_delta = (current_time - pool.last_reward_time) as i128;
+    let reward = time_delta
+        .checked_mul(pool.reward_rate)
+        .ok_or(Error::ArithmeticError)?;
+
+    let reward_per_share_delta = reward
+        .checked_mul(PRECISION)
+        .ok_or(Error::ArithmeticError)?
+        .checked_div(pool.total_staked)
+        .ok_or(Error::ArithmeticError)?;
+
+    pool.acc_reward_per_share = pool
+        .acc_reward_per_share
+        .checked_add(reward_per_share_delta)
+        .ok_or(Error::ArithmeticError)?;
+
+    pool.last_reward_time = current_time;
+    Ok(())
+}
+
+/// Compute a staker's currently accrued (unclaimed) reward against `pool`'s
+/// up-to-date `acc_reward_per_share`, without mutating anything.
+fn accrued_reward(pool: &StakingPool, user_stake: &StakeInfo) -> Result<i128, Error> {
+    user_stake
+        .amount
+        .checked_mul(pool.acc_reward_per_share)
+        .ok_or(Error::ArithmeticError)?
+        .checked_div(PRECISION)
+        .ok_or(Error::ArithmeticError)?
+        .checked_sub(user_stake.reward_debt)
+        .ok_or(Error::ArithmeticError)
+}
+
+/// Re-anchor `user_stake.reward_debt` to `pool`'s current
+/// `acc_reward_per_share`, marking all currently-accrued reward as settled.
+fn checkpoint_debt(pool: &StakingPool, user_stake: &mut StakeInfo) -> Result<(), Error> {
+    user_stake.reward_debt = user_stake
+        .amount
+        .checked_mul(pool.acc_reward_per_share)
+        .ok_or(Error::ArithmeticError)?
+        .checked_div(PRECISION)
+        .ok_or(Error::ArithmeticError)?;
+    Ok(())
+}
+
+/// Pay out `amount` of `pool.reward_token_index` to `user`, if positive, and
+/// emit `stk_clm1`.
+fn payout_reward(env: &Env, pool: &StakingPool, user: &Address, amount: i128) -> Result<(), Error> {
+    if amount <= 0 {
+        return Ok(());
+    }
+    let reward_balance = storage::get_balance(env, pool.reward_token_index, user);
+    let new_reward_balance = reward_balance
+        .checked_add(amount)
+        .ok_or(Error::ArithmeticError)?;
+    storage::set_balance(env, pool.reward_token_index, user, new_reward_balance);
+    events::emit_reward_claimed(env, pool.id, user, amount);
+    Ok(())
+}
+
+/// Stake `amount` of a pool's staking token. Settles any pending reward for
+/// the caller first, against the checkpoint immediately before `amount` is
+/// applied.
+pub fn stake(env: &Env, caller: Address, pool_id: u64, amount: i128) -> Result<(), Error> {
+    caller.require_auth();
+
+    if amount <= 0 {
+        return Err(Error::InvalidParameters);
+    }
+
+    let mut pool = storage::get_staking_pool(env, pool_id).ok_or(Error::StakingPoolNotFound)?;
+    if !pool.active {
+        return Err(Error::StakingNotActive);
+    }
+
+    update_pool(env, &mut pool)?;
+
+    let mut user_stake = storage::get_user_stake(env, pool_id, &caller).unwrap_or(StakeInfo {
+        amount: 0,
+        reward_debt: 0,
+    });
+
+    let pending = if user_stake.amount > 0 {
+        accrued_reward(&pool, &user_stake)?
+    } else {
+        0
+    };
+
+    let balance = storage::get_balance(env, pool.token_index, &caller);
+    if balance < amount {
+        return Err(Error::InsufficientBalance);
+    }
+    let new_balance = balance.checked_sub(amount).ok_or(Error::ArithmeticError)?;
+    storage::set_balance(env, pool.token_index, &caller, new_balance);
+
+    user_stake.amount = user_stake
+        .amount
+        .checked_add(amount)
+        .ok_or(Error::ArithmeticError)?;
+    checkpoint_debt(&pool, &mut user_stake)?;
+
+    pool.total_staked = pool
+        .total_staked
+        .checked_add(amount)
+        .ok_or(Error::ArithmeticError)?;
+
+    storage::set_staking_pool(env, pool_id, &pool);
+    storage::set_user_stake(env, pool_id, &caller, &user_stake);
+
+    events::emit_staked(env, pool_id, &caller, amount);
+    payout_reward(env, &pool, &caller, pending)?;
+
+    Ok(())
+}
+
+/// Unstake `amount` of a pool's staking token. Settles any pending reward
+/// for the caller first, against the checkpoint immediately before `amount`
+/// is applied.
+pub fn unstake(env: &Env, caller: Address, pool_id: u64, amount: i128) -> Result<(), Error> {
+    caller.require_auth();
+
+    if amount <= 0 {
+        return Err(Error::InvalidParameters);
+    }
+
+    let mut pool = storage::get_staking_pool(env, pool_id).ok_or(Error::StakingPoolNotFound)?;
+    update_pool(env, &mut pool)?;
+
+    let mut user_stake =
+        storage::get_user_stake(env, pool_id, &caller).ok_or(Error::InsufficientStake)?;
+    if user_stake.amount < amount {
+        return Err(Error::InsufficientStake);
+    }
+
+    let pending = accrued_reward(&pool, &user_stake)?;
+
+    user_stake.amount = user_stake
+        .amount
+        .checked_sub(amount)
+        .ok_or(Error::ArithmeticError)?;
+    checkpoint_debt(&pool, &mut user_stake)?;
+
+    pool.total_staked = pool
+        .total_staked
+        .checked_sub(amount)
+        .ok_or(Error::ArithmeticError)?;
+
+    let balance = storage::get_balance(env, pool.token_index, &caller);
+    let new_balance = balance.checked_add(amount).ok_or(Error::ArithmeticError)?;
+    storage::set_balance(env, pool.token_index, &caller, new_balance);
+
+    storage::set_staking_pool(env, pool_id, &pool);
+    storage::set_user_stake(env, pool_id, &caller, &user_stake);
+
+    events::emit_unstaked(env, pool_id, &caller, amount);
+    payout_reward(env, &pool, &caller, pending)?;
+
+    Ok(())
+}
+
+/// Pay out a staker's currently accrued reward without unstaking.
+pub fn claim_rewards(env: &Env, caller: Address, pool_id: u64) -> Result<(), Error> {
+    caller.require_auth();
+
+    let mut pool = storage::get_staking_pool(env, pool_id).ok_or(Error::StakingPoolNotFound)?;
+    update_pool(env, &mut pool)?;
+
+    let mut user_stake =
+        storage::get_user_stake(env, pool_id, &caller).ok_or(Error::InsufficientStake)?;
+
+    let pending = accrued_reward(&pool, &user_stake)?;
+    if pending <= 0 {
+        return Err(Error::NothingToClaim);
+    }
+
+    checkpoint_debt(&pool, &mut user_stake)?;
+    storage::set_staking_pool(env, pool_id, &pool);
+    storage::set_user_stake(env, pool_id, &caller, &user_stake);
+
+    payout_reward(env, &pool, &caller, pending)?;
+
+    Ok(())
+}
+
+/// Preview a staker's currently accrued (unclaimed) reward without
+/// mutating any state.
+pub fn pending_rewards(env: &Env, caller: Address, pool_id: u64) -> Result<i128, Error> {
+    let pool = storage::get_staking_pool(env, pool_id).ok_or(Error::StakingPoolNotFound)?;
+    let user_stake = match storage::get_user_stake(env, pool_id, &caller) {
+        Some(s) if s.amount > 0 => s,
+        _ => return Ok(0),
+    };
+
+    let mut acc_reward_per_share = pool.acc_reward_per_share;
+    let current_time = env.ledger().timestamp();
+    if current_time > pool.last_reward_time && pool.total_staked != 0 {
+        let time_delta = (current_time - pool.last_reward_time) as i128;
+        let reward = time_delta
+            .checked_mul(pool.reward_rate)
+            .ok_or(Error::ArithmeticError)?;
+        let reward_per_share_delta = reward
+            .checked_mul(PRECISION)
+            .ok_or(Error::ArithmeticError)?
+            .checked_div(pool.total_staked)
+            .ok_or(Error::ArithmeticError)?;
+        acc_reward_per_share = acc_reward_per_share
+            .checked_add(reward_per_share_delta)
+            .ok_or(Error::ArithmeticError)?;
+    }
+
+    let projected_pool = StakingPool {
+        acc_reward_per_share,
+        ..pool
+    };
+    accrued_reward(&projected_pool, &user_stake)
+}

--- a/contracts/token-factory/src/staking_integration_test.rs
+++ b/contracts/token-factory/src/staking_integration_test.rs
@@ -1,0 +1,414 @@
+#[cfg(test)]
+mod staking_integration_tests {
+    use crate::staking;
+    use crate::storage;
+    use crate::types::Error;
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger},
+        Address, Env,
+    };
+
+    const PRECISION: i128 = 1_000_000_000_000;
+
+    fn make_token_info(env: &Env, creator: &Address, symbol: &str) -> crate::types::TokenInfo {
+        crate::types::TokenInfo {
+            address: Address::generate(env),
+            creator: creator.clone(),
+            name: soroban_sdk::String::from_str(env, symbol),
+            symbol: soroban_sdk::String::from_str(env, symbol),
+            decimals: 7,
+            total_supply: 1_000_000_0000000,
+            initial_supply: 1_000_000_0000000,
+            max_supply: None,
+            total_burned: 0,
+            burn_count: 0,
+            metadata_uri: None,
+            metadata_version: 0,
+            created_at: env.ledger().timestamp(),
+            is_paused: false,
+            clawback_enabled: false,
+            freeze_enabled: false,
+        }
+    }
+
+    fn setup() -> (Env, Address, Address, Address) {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let creator = Address::generate(&env);
+        let user1 = Address::generate(&env);
+
+        storage::set_admin(&env, &admin);
+        storage::set_paused(&env, false);
+
+        storage::set_token_info(&env, 0, &make_token_info(&env, &creator, "STK"));
+        storage::set_token_info(&env, 1, &make_token_info(&env, &creator, "RWD"));
+
+        storage::set_balance(&env, 0, &user1, 1000);
+        storage::set_balance(&env, 1, &creator, 10000);
+
+        (env, admin, creator, user1)
+    }
+
+    #[test]
+    fn test_create_staking_pool() {
+        let (env, admin, _creator, _user1) = setup();
+
+        let reward_rate = 10;
+        let pool_id =
+            staking::create_staking_pool(&env, admin.clone(), 0, 1, reward_rate).unwrap();
+
+        assert_eq!(pool_id, 0);
+
+        let pool = storage::get_staking_pool(&env, pool_id).unwrap();
+        assert_eq!(pool.token_index, 0);
+        assert_eq!(pool.reward_token_index, 1);
+        assert_eq!(pool.reward_rate, 10);
+        assert_eq!(pool.total_staked, 0);
+        assert_eq!(pool.creator, admin);
+        assert!(pool.active);
+    }
+
+    #[test]
+    fn test_create_staking_pool_by_token_creator() {
+        let (env, _admin, creator, _user1) = setup();
+
+        // The token's creator (not the factory admin) may also create a pool.
+        let pool_id = staking::create_staking_pool(&env, creator.clone(), 0, 1, 5).unwrap();
+        let pool = storage::get_staking_pool(&env, pool_id).unwrap();
+        assert_eq!(pool.creator, creator);
+    }
+
+    #[test]
+    fn test_create_staking_pool_unauthorized() {
+        let (env, _admin, _creator, user1) = setup();
+
+        // user1 is neither the factory admin nor token 0's creator.
+        let result = staking::create_staking_pool(&env, user1, 0, 1, 10);
+        assert_eq!(result, Err(Error::Unauthorized));
+    }
+
+    #[test]
+    fn test_create_staking_pool_negative_rate_rejected() {
+        let (env, admin, _creator, _user1) = setup();
+        let result = staking::create_staking_pool(&env, admin, 0, 1, -1);
+        assert_eq!(result, Err(Error::InvalidRewardRate));
+    }
+
+    #[test]
+    fn test_stake_success() {
+        let (env, admin, _creator, user1) = setup();
+
+        let pool_id = staking::create_staking_pool(&env, admin, 0, 1, 10).unwrap();
+
+        staking::stake(&env, user1.clone(), pool_id, 500).unwrap();
+
+        let pool = storage::get_staking_pool(&env, pool_id).unwrap();
+        assert_eq!(pool.total_staked, 500);
+
+        let user_stake = storage::get_user_stake(&env, pool_id, &user1).unwrap();
+        assert_eq!(user_stake.amount, 500);
+
+        let balance = storage::get_balance(&env, 0, &user1);
+        assert_eq!(balance, 500); // 1000 - 500
+    }
+
+    #[test]
+    fn test_stake_zero_amount_rejected() {
+        let (env, admin, _creator, user1) = setup();
+        let pool_id = staking::create_staking_pool(&env, admin, 0, 1, 10).unwrap();
+
+        let result = staking::stake(&env, user1, pool_id, 0);
+        assert_eq!(result, Err(Error::InvalidParameters));
+    }
+
+    #[test]
+    fn test_stake_insufficient_balance() {
+        let (env, admin, _creator, user1) = setup();
+        let pool_id = staking::create_staking_pool(&env, admin, 0, 1, 10).unwrap();
+
+        // user1 has 1000 tokens
+        let result = staking::stake(&env, user1, pool_id, 1500);
+        assert_eq!(result, Err(Error::InsufficientBalance));
+    }
+
+    #[test]
+    fn test_stake_nonexistent_pool() {
+        let (env, _admin, _creator, user1) = setup();
+        let result = staking::stake(&env, user1, 999, 100);
+        assert_eq!(result, Err(Error::StakingPoolNotFound));
+    }
+
+    #[test]
+    fn test_unstake_success() {
+        let (env, admin, _creator, user1) = setup();
+        let pool_id = staking::create_staking_pool(&env, admin, 0, 1, 10).unwrap();
+
+        staking::stake(&env, user1.clone(), pool_id, 500).unwrap();
+
+        env.ledger().with_mut(|li| {
+            li.timestamp += 100;
+        });
+
+        staking::unstake(&env, user1.clone(), pool_id, 200).unwrap();
+
+        let pool = storage::get_staking_pool(&env, pool_id).unwrap();
+        assert_eq!(pool.total_staked, 300); // 500 - 200
+
+        let user_stake = storage::get_user_stake(&env, pool_id, &user1).unwrap();
+        assert_eq!(user_stake.amount, 300);
+
+        let balance = storage::get_balance(&env, 0, &user1);
+        assert_eq!(balance, 700); // 1000 - 500 + 200
+
+        // 100s * 10 reward_rate, 100% of pool -> 1000 reward.
+        let reward_balance = storage::get_balance(&env, 1, &user1);
+        assert_eq!(reward_balance, 1000);
+    }
+
+    #[test]
+    fn test_unstake_without_ever_staking() {
+        let (env, admin, _creator, user1) = setup();
+        let pool_id = staking::create_staking_pool(&env, admin, 0, 1, 10).unwrap();
+
+        let result = staking::unstake(&env, user1, pool_id, 100);
+        assert_eq!(result, Err(Error::InsufficientStake));
+    }
+
+    #[test]
+    fn test_unstake_more_than_staked() {
+        let (env, admin, _creator, user1) = setup();
+        let pool_id = staking::create_staking_pool(&env, admin, 0, 1, 10).unwrap();
+
+        staking::stake(&env, user1.clone(), pool_id, 500).unwrap();
+
+        let result = staking::unstake(&env, user1, pool_id, 501);
+        assert_eq!(result, Err(Error::InsufficientStake));
+    }
+
+    #[test]
+    fn test_claim_rewards() {
+        let (env, admin, _creator, user1) = setup();
+        let pool_id = staking::create_staking_pool(&env, admin, 0, 1, 10).unwrap();
+
+        staking::stake(&env, user1.clone(), pool_id, 500).unwrap();
+
+        env.ledger().with_mut(|li| {
+            li.timestamp += 10;
+        });
+
+        staking::claim_rewards(&env, user1.clone(), pool_id).unwrap();
+
+        // 10 seconds * 10 reward rate = 100 total rewards.
+        // Since user1 has 100% of the pool, they get 100 rewards.
+        let reward_balance = storage::get_balance(&env, 1, &user1);
+        assert_eq!(reward_balance, 100);
+
+        // Reward debt is re-anchored so the same period isn't paid twice.
+        let result = staking::claim_rewards(&env, user1, pool_id);
+        assert_eq!(result, Err(Error::NothingToClaim));
+    }
+
+    #[test]
+    fn test_pending_rewards() {
+        let (env, admin, _creator, user1) = setup();
+        let pool_id = staking::create_staking_pool(&env, admin, 0, 1, 10).unwrap();
+
+        staking::stake(&env, user1.clone(), pool_id, 500).unwrap();
+
+        env.ledger().with_mut(|li| {
+            li.timestamp += 10;
+        });
+
+        let pending = staking::pending_rewards(&env, user1.clone(), pool_id).unwrap();
+        assert_eq!(pending, 100);
+
+        // pending_rewards must not mutate state.
+        let pool = storage::get_staking_pool(&env, pool_id).unwrap();
+        assert_eq!(pool.last_reward_time, env.ledger().timestamp() - 10);
+    }
+
+    #[test]
+    fn test_pending_rewards_zero_stake() {
+        let (env, admin, _creator, user1) = setup();
+        let pool_id = staking::create_staking_pool(&env, admin, 0, 1, 10).unwrap();
+
+        // user1 never staked into this pool.
+        let pending = staking::pending_rewards(&env, user1, pool_id).unwrap();
+        assert_eq!(pending, 0);
+    }
+
+    #[test]
+    fn test_claim_nothing() {
+        let (env, admin, _creator, user1) = setup();
+        let pool_id = staking::create_staking_pool(&env, admin, 0, 1, 10).unwrap();
+
+        staking::stake(&env, user1.clone(), pool_id, 500).unwrap();
+
+        // 0 time passed
+        let result = staking::claim_rewards(&env, user1.clone(), pool_id);
+        assert_eq!(result, Err(Error::NothingToClaim));
+    }
+
+    #[test]
+    fn test_claim_rewards_without_stake() {
+        let (env, admin, _creator, user1) = setup();
+        let pool_id = staking::create_staking_pool(&env, admin, 0, 1, 10).unwrap();
+
+        let result = staking::claim_rewards(&env, user1, pool_id);
+        assert_eq!(result, Err(Error::InsufficientStake));
+    }
+
+    #[test]
+    fn test_reward_accrual_over_multiple_periods() {
+        let (env, admin, _creator, user1) = setup();
+        let pool_id = staking::create_staking_pool(&env, admin, 0, 1, 10).unwrap();
+
+        staking::stake(&env, user1.clone(), pool_id, 500).unwrap();
+
+        env.ledger().with_mut(|li| li.timestamp += 5);
+        let pending_1 = staking::pending_rewards(&env, user1.clone(), pool_id).unwrap();
+        assert_eq!(pending_1, 50); // 5s * 10
+
+        env.ledger().with_mut(|li| li.timestamp += 5);
+        let pending_2 = staking::pending_rewards(&env, user1.clone(), pool_id).unwrap();
+        assert_eq!(pending_2, 100); // 10s * 10, still unclaimed
+
+        staking::claim_rewards(&env, user1.clone(), pool_id).unwrap();
+        assert_eq!(storage::get_balance(&env, 1, &user1), 100);
+
+        // A further period accrues independently of what was already claimed.
+        env.ledger().with_mut(|li| li.timestamp += 3);
+        let pending_3 = staking::pending_rewards(&env, user1, pool_id).unwrap();
+        assert_eq!(pending_3, 30); // 3s * 10
+    }
+
+    #[test]
+    fn test_zero_staker_period_is_not_double_counted() {
+        let (env, admin, _creator, user1) = setup();
+        let pool_id = staking::create_staking_pool(&env, admin, 0, 1, 10).unwrap();
+
+        // Pool sits empty for a while before anyone stakes.
+        env.ledger().with_mut(|li| li.timestamp += 1000);
+
+        staking::stake(&env, user1.clone(), pool_id, 500).unwrap();
+
+        // The empty period must not be attributed to user1 once they join.
+        let pending_immediately = staking::pending_rewards(&env, user1.clone(), pool_id).unwrap();
+        assert_eq!(pending_immediately, 0);
+
+        env.ledger().with_mut(|li| li.timestamp += 10);
+        let pending_after = staking::pending_rewards(&env, user1, pool_id).unwrap();
+        assert_eq!(pending_after, 100); // only the post-stake 10s * 10
+    }
+
+    #[test]
+    fn test_multiple_stakers_share_proportionally() {
+        let (env, admin, _creator, user1) = setup();
+        let user2 = Address::generate(&env);
+        storage::set_balance(&env, 0, &user2, 1000);
+
+        let pool_id = staking::create_staking_pool(&env, admin, 0, 1, 100).unwrap();
+
+        // user1 stakes 300, user2 stakes 700 -> 30% / 70% split.
+        staking::stake(&env, user1.clone(), pool_id, 300).unwrap();
+        staking::stake(&env, user2.clone(), pool_id, 700).unwrap();
+
+        env.ledger().with_mut(|li| li.timestamp += 10);
+
+        // 10s * 100 reward_rate = 1000 total reward, split 300:700.
+        let pending_1 = staking::pending_rewards(&env, user1.clone(), pool_id).unwrap();
+        let pending_2 = staking::pending_rewards(&env, user2.clone(), pool_id).unwrap();
+        assert_eq!(pending_1, 300);
+        assert_eq!(pending_2, 700);
+        assert_eq!(pending_1 + pending_2, 1000);
+
+        staking::claim_rewards(&env, user1.clone(), pool_id).unwrap();
+        staking::claim_rewards(&env, user2.clone(), pool_id).unwrap();
+        assert_eq!(storage::get_balance(&env, 1, &user1), 300);
+        assert_eq!(storage::get_balance(&env, 1, &user2), 700);
+    }
+
+    #[test]
+    fn test_late_staker_does_not_earn_pre_entry_rewards() {
+        let (env, admin, _creator, user1) = setup();
+        let user2 = Address::generate(&env);
+        storage::set_balance(&env, 0, &user2, 1000);
+
+        let pool_id = staking::create_staking_pool(&env, admin, 0, 1, 100).unwrap();
+
+        staking::stake(&env, user1.clone(), pool_id, 500).unwrap();
+
+        // user1 alone earns 10s * 100 = 1000 before user2 joins.
+        env.ledger().with_mut(|li| li.timestamp += 10);
+        staking::claim_rewards(&env, user1.clone(), pool_id).unwrap();
+        assert_eq!(storage::get_balance(&env, 1, &user1), 1000);
+
+        // user2 joins with an equal stake; the pre-entry rewards must not
+        // leak to them.
+        staking::stake(&env, user2.clone(), pool_id, 500).unwrap();
+        assert_eq!(
+            staking::pending_rewards(&env, user2.clone(), pool_id).unwrap(),
+            0
+        );
+
+        env.ledger().with_mut(|li| li.timestamp += 10);
+        // Now evenly split: 10s * 100 = 1000, 500 each.
+        assert_eq!(
+            staking::pending_rewards(&env, user1, pool_id).unwrap(),
+            500
+        );
+        assert_eq!(
+            staking::pending_rewards(&env, user2, pool_id).unwrap(),
+            500
+        );
+    }
+
+    #[test]
+    fn test_reward_rate_precision_rounding() {
+        let (env, admin, _creator, user1) = setup();
+        let user2 = Address::generate(&env);
+        storage::set_balance(&env, 0, &user2, 1000);
+
+        // reward_rate and total_staked chosen so per-share division isn't exact,
+        // exercising the PRECISION-scaled floor-division rounding behavior.
+        let pool_id = staking::create_staking_pool(&env, admin, 0, 1, 7).unwrap();
+
+        staking::stake(&env, user1.clone(), pool_id, 1).unwrap();
+        staking::stake(&env, user2.clone(), pool_id, 2).unwrap();
+
+        env.ledger().with_mut(|li| li.timestamp += 1);
+
+        // total reward for the tick = 1 * 7 = 7, split 1:2 across 3 staked.
+        // acc_reward_per_share = 7 * PRECISION / 3 (floors).
+        let expected_acc = 7i128
+            .checked_mul(PRECISION)
+            .unwrap()
+            .checked_div(3)
+            .unwrap();
+        staking::claim_rewards(&env, user1.clone(), pool_id).unwrap();
+        let pool_after = storage::get_staking_pool(&env, pool_id).unwrap();
+        assert_eq!(pool_after.acc_reward_per_share, expected_acc);
+
+        // user1 (1 share) gets floor(1 * expected_acc / PRECISION) = 2.
+        // user2 (2 shares) gets floor(2 * expected_acc / PRECISION) = 4.
+        let user1_reward = storage::get_balance(&env, 1, &user1);
+        assert_eq!(user1_reward, 2);
+
+        staking::claim_rewards(&env, user2.clone(), pool_id).unwrap();
+        let user2_reward = storage::get_balance(&env, 1, &user2);
+        assert_eq!(user2_reward, 4);
+
+        // Rounding dust (7 - 2 - 4 = 1) is neither over- nor under-paid twice;
+        // it simply isn't attributable at this precision and stays unclaimed.
+        assert_eq!(
+            staking::pending_rewards(&env, user1, pool_id).unwrap(),
+            0
+        );
+        assert_eq!(
+            staking::pending_rewards(&env, user2, pool_id).unwrap(),
+            0
+        );
+    }
+}

--- a/contracts/token-factory/src/storage.rs
+++ b/contracts/token-factory/src/storage.rs
@@ -2210,6 +2210,77 @@ pub fn set_reservation_timeout_ledgers(env: &Env, ledgers: u32) {
         .set(&DataKey::ReservationTimeoutLedgers, &ledgers);
 }
 
+// ═══════════════════════════════════════════════════════════════════════
+// Staking storage (#1757)
+// ═══════════════════════════════════════════════════════════════════════
+
+/// Get a staking pool by ID.
+pub fn get_staking_pool(env: &Env, pool_id: u64) -> Option<crate::types::StakingPool> {
+    env.storage().persistent().get(&DataKey::StakingPool(pool_id))
+}
+
+/// Save a staking pool.
+pub fn set_staking_pool(env: &Env, pool_id: u64, pool: &crate::types::StakingPool) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::StakingPool(pool_id), pool);
+}
+
+/// Allocate and return the next staking pool ID.
+pub fn increment_next_staking_pool_id(env: &Env) -> u64 {
+    let current = env
+        .storage()
+        .instance()
+        .get(&DataKey::NextStakingPoolId)
+        .unwrap_or(0u64);
+    env.storage()
+        .instance()
+        .set(&DataKey::NextStakingPoolId, &(current + 1));
+    current
+}
+
+/// Get the total number of staking pools created.
+pub fn get_staking_pool_count(env: &Env) -> u64 {
+    env.storage()
+        .instance()
+        .get(&DataKey::StakingPoolCount)
+        .unwrap_or(0)
+}
+
+/// Increment and persist the staking pool counter.
+pub fn increment_staking_pool_count(env: &Env) -> Result<u64, Error> {
+    let count = get_staking_pool_count(env)
+        .checked_add(1)
+        .ok_or(Error::ArithmeticError)?;
+    env.storage()
+        .instance()
+        .set(&DataKey::StakingPoolCount, &count);
+    Ok(count)
+}
+
+/// Get a user's stake within a pool.
+pub fn get_user_stake(
+    env: &Env,
+    pool_id: u64,
+    user: &Address,
+) -> Option<crate::types::StakeInfo> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::UserStake(pool_id, user.clone()))
+}
+
+/// Save a user's stake within a pool.
+pub fn set_user_stake(
+    env: &Env,
+    pool_id: u64,
+    user: &Address,
+    stake: &crate::types::StakeInfo,
+) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::UserStake(pool_id, user.clone()), stake);
+}
+
 // ── Tests — Issue #1681: panic-free core storage getters ─────────────────────
 //
 // Each test calls a getter *before* `initialize()` has been invoked and

--- a/contracts/token-factory/src/types.rs
+++ b/contracts/token-factory/src/types.rs
@@ -962,6 +962,15 @@ pub enum DataKey {
     Reservation(u64),
     /// Ledgers a reservation may sit `Prepared` before it can be force-released
     ReservationTimeoutLedgers,
+    // ── Staking (#1757) ──
+    /// Staking pool configuration and state, keyed by pool_id
+    StakingPool(u64),
+    /// Total number of staking pools created
+    StakingPoolCount,
+    /// Next available staking pool ID
+    NextStakingPoolId,
+    /// A user's stake within a pool: (pool_id, staker) → StakeInfo
+    UserStake(u64, Address),
 }
 
 /// A point-in-time record of a token holder's balance.
@@ -1310,6 +1319,11 @@ impl Error {
     pub const MetadataImmutable: Self = Self(131);
     // Multisig admin-change errors
     pub const DuplicateSigners: Self = Self(132);
+    // Staking errors (#1757)
+    pub const StakingPoolNotFound: Self = Self(133);
+    pub const StakingNotActive: Self = Self(134);
+    pub const InvalidRewardRate: Self = Self(135);
+    pub const InsufficientStake: Self = Self(136);
 
     /// Stable string name for this error code, for off-chain event payloads
     /// (see `emit_operation_failed`). Covers the vault entry-point error
@@ -1333,6 +1347,10 @@ impl Error {
             98 => "VaultOwnerChangeNotFound",
             99 => "VaultOwnerChangeAlreadyApproved",
             130 => "VaultCircuitBreakerActive",
+            133 => "StakingPoolNotFound",
+            134 => "StakingNotActive",
+            135 => "InvalidRewardRate",
+            136 => "InsufficientStake",
             _ => "UnknownError",
         }
     }


### PR DESCRIPTION
## Summary

Closes #1757

Adds a staking module to `token-factory`: users create staking pools for a
given token and earn rewards in a (possibly different) reward token,
accrued over time via a `PRECISION = 1_000_000_000_000`-scaled
reward-per-share accumulator.

- `create_staking_pool(creator, token_index, reward_token_index, reward_rate)`
  — admin- or token-creator-authorized (whichever the caller is), sets up a
  pool paying `reward_rate` of the reward token per second, proportional to
  stake share.
- `stake` / `unstake` roll the pool's accumulator forward and settle the
  caller's pending reward *before* their `amount` changes, so accrual is
  always checkpointed consistently — a pool with zero stakers simply skips
  accrual for that interval (never later attributed to whoever stakes
  next), and a staker's `reward_debt` is re-anchored on every change so
  pre-entry accrual can't leak to a later entrant.
- `claim_rewards` pays out accrued reward without unstaking.
- `get_staking_pool` / `get_user_stake` / `pending_rewards` for queries.

### Integration points (per the issue checklist)
- `contracts/token-factory/src/staking.rs`, wired via `mod staking;` in `lib.rs`
- `#[contractimpl]` entry points added to `TokenFactory` in `lib.rs`
- New `DataKey` variants (`StakingPool`, `StakingPoolCount`, `NextStakingPoolId`, `UserStake`) — `StakingPool`/`StakeInfo` struct definitions already existed in `types.rs` from an earlier attempt that was later reverted in the "trim unused contract modules" refactor; only the `DataKey`/`Error`/storage/events/lib wiring needed to be re-added.
- New `Error` variants 133-136 (current highest in-use was 132), with `Error::name()` entries
- Storage getters/setters in `storage.rs`, using persistent storage for per-pool/per-stake records and instance storage for the counters (matching the existing proposal/vault convention)
- Events via `events.rs`: `stk_crt1` / `stk_dep1` / `stk_wd1` / `stk_clm1`, versioned per the existing schema convention

### Tests
`staking_integration_test.rs` covers stake/unstake, reward accrual over
time (advancing the ledger timestamp), reward-rate precision/rounding,
multiple stakers sharing a pool proportionally, a late staker not earning
pre-entry rewards, a zero-staker accrual period not being double-counted,
and zero-stake edge cases (staking/unstaking zero, unstaking/claiming
without ever staking, claiming with nothing accrued).

## Test plan

- [x] `cargo check --lib` - clean
- [x] `cargo build --target wasm32v1-none --release --lib` - clean
- [x] `cargo test --lib` - **currently fails to compile on `main` itself**,
      independent of this change. I verified this by `git stash`-ing this
      PR's diff entirely and re-running against a pristine `main` checkout:
      it already fails with ~156 compile errors across ~20 unrelated
      legacy test modules (stale API usage predating the "trim unused
      contract modules" refactor - missing `Address::generate` imports,
      outdated `create_vault`/`TokenCreationParams` signatures, a
      `legacy-tests`-feature-gated module referenced outside its feature
      gate, etc.), plus a `#[contracttype]` trait-resolution issue on
      `PaginatedStreamsResponse`/`StreamCursor` that only surfaces once the
      `testutils` dev-dependency feature is active. None of this is
      touched by this PR (`git diff` against `types.rs` is purely
      additive). I confirmed this PR's own tests are unaffected by
      temporarily neutralizing all of that pre-existing breakage in a
      scratch copy: with it neutralized, the new staking tests compile and
      pass. I also cross-checked the accrual arithmetic (multi-staker
      proportionality, late-staker non-leakage, zero-staker periods,
      precision rounding) against a standalone reimplementation of the
      same accumulator logic outside the soroban macro system, and all
      values matched. Fixing the broader pre-existing test-suite breakage
      is out of scope for this issue.
- [x] `cargo fmt --all -- --check` - no diff in any file this PR touches
      (pre-existing diffs elsewhere in the repo, e.g.
      `contracts/governance`, unrelated to this change)
- [x] `cargo clippy --lib -- -D warnings` - no warnings in any file this PR
      touches (pre-existing warnings elsewhere, e.g. `create_token`/
      `create_vault` argument counts, unrelated to this change)