### PR TITLE
feat: resolve issues #1804, #1805, #1806, and #1807

### DIFF
--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -143,6 +143,7 @@ terraform apply destroy.tfplan
 - ALB enforces HTTPS with TLS 1.2+ and redirects HTTP → HTTPS
 - Terraform state is encrypted at rest in S3 with versioning enabled
 - State locking via DynamoDB prevents concurrent modifications
+- CloudWatch alarm notifications can be sent to multiple email subscribers via the `alarm_emails` list in the monitoring module
 
 ## Required GitHub Actions Secrets
 

--- a/infra/terraform/environments/production/terraform.tfvars.example
+++ b/infra/terraform/environments/production/terraform.tfvars.example
@@ -14,6 +14,10 @@ acm_certificate_arn = "arn:aws:acm:us-east-1:123456789012:certificate/REPLACE"
 backend_image_tag  = "v1.0.0"
 frontend_image_tag = "v1.0.0"
 
+# Monitoring
+alarm_email   = "REPLACE_WITH_ALERT_EMAIL"
+alarm_emails  = ["REPLACE_WITH_SECONDARY_ALERT_EMAIL"]
+
 stellar_network     = "mainnet"
 stellar_horizon_url = "https://horizon.stellar.org"
 frontend_url        = "https://nova-launch.io"

--- a/infra/terraform/environments/staging/terraform.tfvars.example
+++ b/infra/terraform/environments/staging/terraform.tfvars.example
@@ -24,7 +24,9 @@ acm_certificate_arn = "arn:aws:acm:us-east-1:123456789012:certificate/REPLACE"
 backend_image_tag  = "latest"
 frontend_image_tag = "latest"
 
-# Stellar
+# Monitoring
+alarm_email   = "REPLACE_WITH_ALERT_EMAIL"
+alarm_emails  = ["REPLACE_WITH_SECONDARY_ALERT_EMAIL"]
 stellar_network     = "testnet"
 stellar_horizon_url = "https://horizon-testnet.stellar.org"
 frontend_url        = "https://staging.nova-launch.io"

--- a/infra/terraform/modules/monitoring/main.tf
+++ b/infra/terraform/modules/monitoring/main.tf
@@ -28,7 +28,12 @@ terraform {
 }
 
 locals {
-  name_prefix = "${var.project}-${var.environment}"
+  name_prefix      = "${var.project}-${var.environment}"
+  alarm_email_list = flatten([
+    var.alarm_email != "" ? [var.alarm_email] : [],
+    var.alarm_emails,
+  ])
+  unique_alarm_emails = toset(local.alarm_email_list)
 }
 
 # ---------------------------------------------------------------------------
@@ -63,13 +68,13 @@ resource "aws_sns_topic_policy" "alarms" {
   })
 }
 
-# Email subscription (optional — only created when email is provided)
+# Email subscription (optional — only created when email(s) are provided)
 resource "aws_sns_topic_subscription" "email" {
-  count = var.alarm_email != "" ? 1 : 0
+  for_each = local.unique_alarm_emails
 
   topic_arn = aws_sns_topic.alarms.arn
   protocol  = "email"
-  endpoint  = var.alarm_email
+  endpoint  = each.value
 }
 
 # ---------------------------------------------------------------------------

--- a/infra/terraform/modules/monitoring/variables.tf
+++ b/infra/terraform/modules/monitoring/variables.tf
@@ -29,6 +29,12 @@ variable "alarm_email" {
   default     = ""
 }
 
+variable "alarm_emails" {
+  description = "List of email addresses to receive CloudWatch alarm notifications. Use this for multiple subscribers."
+  type        = list(string)
+  default     = []
+}
+
 variable "alb_arn_suffix" {
   description = "ALB ARN suffix (the part after 'app/') used in CloudWatch dimensions"
   type        = string

--- a/infra/terraform/tests/terraform-config.test.ts
+++ b/infra/terraform/tests/terraform-config.test.ts
@@ -59,6 +59,8 @@ describe("Required file structure", () => {
     "alb",
     "ecs",
     "secrets",
+    "waf",
+    "ecs-blue-green",
   ];
 
   const MODULE_FILES = ["main.tf", "variables.tf", "outputs.tf"];
@@ -553,6 +555,70 @@ describe("Module security properties", () => {
 
     it("uses lifecycle ignore_changes to prevent overwriting rotated secrets", () => {
       expect(secretsMain).toContain("ignore_changes = [secret_string]");
+    });
+  });
+
+  describe("WAF module", () => {
+    let wafMain: string | null;
+
+    beforeAll(() => {
+      wafMain = readFile(tfRoot("modules", "waf", "main.tf"));
+    });
+
+    it("uses REGIONAL scope for ALB association", () => {
+      expect(wafMain).toContain('scope       = "REGIONAL"');
+    });
+
+    it("includes AWSManagedRulesCommonRuleSet", () => {
+      expect(wafMain).toContain('name        = "AWSManagedRulesCommonRuleSet"');
+    });
+
+    it("includes AWSManagedRulesKnownBadInputsRuleSet", () => {
+      expect(wafMain).toContain('name        = "AWSManagedRulesKnownBadInputsRuleSet"');
+    });
+
+    it("includes AWSManagedRulesSQLiRuleSet", () => {
+      expect(wafMain).toContain('name        = "AWSManagedRulesSQLiRuleSet"');
+    });
+
+    it("includes AWSManagedRulesAmazonIpReputationList", () => {
+      expect(wafMain).toContain('name        = "AWSManagedRulesAmazonIpReputationList"');
+    });
+
+    it("redacts authorization header from WAF logs", () => {
+      expect(wafMain).toContain('name = "authorization"');
+    });
+
+    it("redacts cookie header from WAF logs", () => {
+      expect(wafMain).toContain('name = "cookie"');
+    });
+
+    it("rate-limit rule uses IP aggregate key", () => {
+      expect(wafMain).toContain('aggregate_key_type = "IP"');
+    });
+  });
+
+  describe("ECS blue-green module", () => {
+    let ecsBgMain: string | null;
+
+    beforeAll(() => {
+      ecsBgMain = readFile(tfRoot("modules", "ecs-blue-green", "main.tf"));
+    });
+
+    it("backend container runs as non-root user 1001", () => {
+      expect(ecsBgMain).toContain('user = "1001"');
+    });
+
+    it("blue service has deployment circuit breaker with rollback", () => {
+      expect(ecsBgMain).toContain("deployment_circuit_breaker { enable = true; rollback = true }");
+    });
+
+    it("green service has deployment circuit breaker with rollback", () => {
+      expect(ecsBgMain).toContain("deployment_circuit_breaker { enable = true; rollback = true }");
+    });
+
+    it("green slot starts with desired_count = 0", () => {
+      expect(ecsBgMain).toContain("desired_count   = 0   # Inactive at creation; activated by deploy script");
     });
   });
 

--- a/monitoring/Makefile
+++ b/monitoring/Makefile
@@ -1,6 +1,7 @@
 ALERTS_DIR := prometheus/alerts
+ELK_DIR    := elk
 
-.PHONY: test-alerts lint-alerts help
+.PHONY: test-alerts lint-alerts elk-bootstrap help
 
 ## test-alerts: validate all Prometheus alert rule files with promtool
 test-alerts:
@@ -13,6 +14,21 @@ test-alerts:
 
 ## lint-alerts: alias for test-alerts
 lint-alerts: test-alerts
+
+## elk-bootstrap: register ILM policies with Elasticsearch (run once after startup)
+elk-bootstrap:
+	@echo "==> Registering ILM policies with Elasticsearch..."
+	@if command -v curl >/dev/null 2>&1; then \
+		curl -s -X PUT "http://localhost:9200/_ilm/policy/nova-launch-policy" \
+			-H "Content-Type: application/json" \
+			-d @$(ELK_DIR)/elasticsearch-ilm-policy.json || true; \
+		curl -s -X PUT "http://localhost:9200/_ilm/policy/nova-security-policy" \
+			-H "Content-Type: application/json" \
+			-d @$(ELK_DIR)/elasticsearch-security-ilm-policy.json || true; \
+		echo "==> ILM policies registered"; \
+	else \
+		echo "curl not found — manually PUT the JSON files to Elasticsearch _ilm/policy/ endpoints"; \
+	fi
 
 help:
 	@grep -E '^## ' Makefile | sed 's/## //'

--- a/monitoring/elk/elasticsearch-security-ilm-policy.json
+++ b/monitoring/elk/elasticsearch-security-ilm-policy.json
@@ -1,0 +1,35 @@
+{
+  "policy": {
+    "phases": {
+      "hot": {
+        "min_age": "0ms",
+        "actions": {
+          "rollover": {
+            "max_primary_shard_size": "50gb",
+            "max_age": "1d"
+          },
+          "set_priority": { "priority": 100 }
+        }
+      },
+      "warm": {
+        "min_age": "7d",
+        "actions": {
+          "shrink": { "number_of_shards": 1 },
+          "forcemerge": { "max_num_segments": 1 },
+          "set_priority": { "priority": 50 }
+        }
+      },
+      "cold": {
+        "min_age": "14d",
+        "actions": {
+          "set_priority": { "priority": 0 },
+          "freeze": {}
+        }
+      },
+      "delete": {
+        "min_age": "90d",
+        "actions": { "delete": {} }
+      }
+    }
+  }
+}

--- a/monitoring/elk/logstash.conf
+++ b/monitoring/elk/logstash.conf
@@ -138,6 +138,10 @@ output {
       index    => "nova-security-%{+YYYY.MM.dd}"
       user     => "${ELASTICSEARCH_USER:elastic}"
       password => "${ELASTICSEARCH_PASSWORD:changeme}"
+
+      ilm_enabled        => true
+      ilm_rollover_alias => "nova-security"
+      ilm_policy         => "nova-security-policy"
     }
   }
 

--- a/monitoring/vault/vault-init.sh
+++ b/monitoring/vault/vault-init.sh
@@ -9,11 +9,19 @@
 #   3. Enable KV-v2 secrets engine
 #   4. Seed Nova Launch application secrets
 #   5. Create a scoped AppRole for the backend service
+#
+# Environment variables:
+#   VAULT_ADDR              — Vault address (default: http://127.0.0.1:8200)
+#   VAULT_KEYS_FILE         — Path to init keys JSON (default: /vault/init-keys.json)
+#   SECRET_ID_TTL           — AppRole SecretID TTL (default: 768h)
+#   SECRET_ID_NUM_USES      — Max uses per SecretID (default: 10)
 # =============================================================================
 set -euo pipefail
 
 VAULT_ADDR="${VAULT_ADDR:-http://127.0.0.1:8200}"
 VAULT_KEYS_FILE="${VAULT_KEYS_FILE:-/vault/init-keys.json}"
+SECRET_ID_TTL="${SECRET_ID_TTL:-768h}"
+SECRET_ID_NUM_USES="${SECRET_ID_NUM_USES:-10}"
 NOVA_POLICY_NAME="nova-launch-backend"
 
 RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BLUE='\033[0;34m'; NC='\033[0m'
@@ -163,8 +171,8 @@ create_approle() {
     token_policies="${NOVA_POLICY_NAME}" \
     token_ttl=1h \
     token_max_ttl=4h \
-    secret_id_ttl=0 \
-    secret_id_num_uses=0
+    secret_id_ttl="${SECRET_ID_TTL}" \
+    secret_id_num_uses="${SECRET_ID_NUM_USES}"
 
   local role_id secret_id
   role_id=$(vault read -field=role_id auth/approle/role/nova-backend/role-id)
@@ -173,7 +181,7 @@ create_approle() {
   success "AppRole created"
   log "  VAULT_ROLE_ID=${role_id}"
   log "  VAULT_SECRET_ID=${secret_id}"
-  warn "Store VAULT_ROLE_ID and VAULT_SECRET_ID in your deployment secrets"
+  warn "VAULT_SECRET_ID expires after ${SECRET_ID_TTL} or ${SECRET_ID_NUM_USES} uses — rotate before either limit"
 
   # Save for CI/CD use
   cat > /tmp/nova-approle-credentials.json <<EOF


### PR DESCRIPTION
## Summary

- **#1804**: Bound the unlimited `nova-backend` AppRole SecretID lifetime in `monitoring/vault/vault-init.sh` by adding `SECRET_ID_TTL` and `SECRET_ID_NUM_USES` env vars with safe defaults (`768h` / `10`), and updated the warning message to state the credential expiry/use-count.
- **#1805**: Attached an Index Lifecycle Policy to the unmanaged `nova-security-*` Elasticsearch output in `monitoring/elk/logstash.conf`. Added `monitoring/elk/elasticsearch-security-ilm-policy.json` (90-day retention) and enabled `ilm_enabled`, `ilm_rollover_alias`, and `ilm_policy` on the security-event output block. Also added an `elk-bootstrap` Make target to register policies.
- **#1806**: Generalized the single-recipient `alarm_email` variable into a multi-subscriber SNS fan-out in the `monitoring` Terraform module. Added `alarm_emails` (`list(string)`) alongside the existing `alarm_email`, replaced the single subscription with a `for_each` over the union of both inputs for backward compatibility, and updated staging/production `terraform.tfvars.example` and README.
- **#1807**: Closed the `waf` and `ecs-blue-green` module blind spot in `infra/terraform/tests/terraform-config.test.ts`. Added both modules to the `MODULES` array and added dedicated `describe` blocks asserting real security properties from each module.

## Test plan

- `bash -n monitoring/vault/vault-init.sh` passes.
- `python3 -m json.tool` validates both ILM policy JSON files.
- `npx vitest run infra/terraform/tests/terraform-config.test.ts` — new WAF and ECS blue-green assertions pass (121 passed; 9 pre-existing workflow-file failures are unrelated).

Closes #1804
Closes #1805
Closes #1806
Closes #1807