### PR TITLE
Stellar Wave: timeout guard, WAF SNS alarm, frontend outlier detection, PagerDuty runbook links

### DIFF
--- a/backend/src/middleware/timeout.test.ts
+++ b/backend/src/middleware/timeout.test.ts
@@ -28,6 +28,15 @@ function makeApp(timeoutMs: number, handlerDelayMs?: number) {
     // Simulate a second write after headers sent — middleware must not crash
   });
 
+  // A handler that, unaware the timeout already fired, writes to `res` after
+  // the configured timeout has elapsed. Before the post-timeout guard this
+  // would throw "Cannot set headers after they are sent".
+  app.get("/late-write", (_req: Request, res: Response) => {
+    setTimeout(() => {
+      res.json({ ok: true });
+    }, handlerDelayMs ?? timeoutMs * 2);
+  });
+
   return app;
 }
 
@@ -128,5 +137,27 @@ describe("createTimeoutMiddleware()", () => {
 
   it("DEFAULT_TIMEOUT_MS is 30000", () => {
     expect(DEFAULT_TIMEOUT_MS).toBe(30_000);
+  });
+});
+
+// ─── Post-timeout write guard (real timers) ───────────────────────────────
+// Exercises the path where the middleware has already sent the 503 and the
+// still-running downstream handler later attempts to write to `res`. Uses
+// real timers (not vi.useFakeTimers) so the response actually flushes and
+// the late write can be observed.
+describe("createTimeoutMiddleware() post-timeout write guard", () => {
+  it("does not crash when the handler writes after the timeout has fired", async () => {
+    const app = makeApp(30, 60);
+
+    const res = await request(app).get("/late-write");
+
+    expect(res.status).toBe(503);
+    expect(res.body.success).toBe(false);
+    expect(res.body.error.code).toBe("REQUEST_TIMEOUT");
+
+    // Keep the test alive past the handler's delayed write so any thrown
+    // "Cannot set headers after they are sent" surfaces here instead of as an
+    // unhandled rejection after the test completes.
+    await new Promise((r) => setTimeout(r, 120));
   });
 });

--- a/backend/src/middleware/timeout.ts
+++ b/backend/src/middleware/timeout.ts
@@ -56,6 +56,18 @@ export function createTimeoutMiddleware(timeoutMs: number = getTimeoutMs()) {
           timestamp: new Date().toISOString(),
         });
       }
+
+      // The downstream handler is still running concurrently. Once we have
+      // sent the timeout response, any later attempt by that handler to write
+      // to `res` (e.g. res.json()/res.send()/res.end()) would throw
+      // "Cannot set headers after they are sent" and surface as an unhandled
+      // rejection. Neutralise those late writes so they become safe no-ops.
+      const noop = function (): Response {
+        return res;
+      };
+      res.json = noop as unknown as Response["json"];
+      res.send = noop as unknown as Response["send"];
+      res.end = (noop as unknown as Response["end"]).bind(res);
     }, timeoutMs);
 
     // Attach the flag so downstream handlers can check it if needed.

--- a/docs/PRODUCTION_INTEGRATION_RUNBOOK.md
+++ b/docs/PRODUCTION_INTEGRATION_RUNBOOK.md
@@ -201,3 +201,37 @@ After rollback:
 | `scripts/smoke-test.sh` | Contract-level smoke tests |
 | `scripts/fullstack-smoke-test.sh` | Frontend + backend + chain integration |
 | `scripts/verify-deployment.sh` | Post-deploy verification |
+
+---
+
+## High API Error Rate
+
+Triggered by `alertHighApiErrorRate` (PagerDuty event type `api-error-rate-high`, P2/error severity).
+
+Symptoms:
+
+- Backend 5xx rate exceeds the configured threshold (5% in production, 20% in staging).
+- PagerDuty incident fired with dedup key `nova-api-high-error-rate`.
+
+Triage:
+
+1. Check the API CloudWatch dashboard (`module.monitoring.api_dashboard_name`) for the error-rate and latency panels.
+2. Correlate the spike with a recent deploy (`kubectl rollout history` / ECS task revisions) or a downstream dependency outage.
+3. Pull recent structured logs with the same `correlationId` to find the failing endpoints.
+4. If a single endpoint is responsible, throttle or disable the feature flag; otherwise roll back the last deploy.
+
+## Database Connection Pool Exhausted
+
+Triggered by `alertDatabasePoolExhausted` (PagerDuty event type equivalent to `db-connection-loss`, P1/critical severity).
+
+Symptoms:
+
+- Prisma reports no available connections (`TimedOut fetching a new connection` / pool exhausted).
+- PagerDuty incident fired with dedup key `nova-db-pool-exhausted`.
+
+Triage:
+
+1. Check the RDS instance metrics (connections, CPU, freeable memory) and the `backend_log_group_name` for pool-wait timeouts.
+2. Confirm no long-running migration or batch job is holding connections open.
+3. Scale the connection limit or restart the backend service to recycle leaked connections.
+4. If the database itself is unhealthy, follow the DB-connection-loss runbook and fail over to the standby.

--- a/infra/terraform/environments/production/main.tf
+++ b/infra/terraform/environments/production/main.tf
@@ -171,6 +171,9 @@ module "waf" {
   log_retention_days               = 90
   blocked_requests_alarm_threshold = 500
 
+  # Notify on-call when the WAF starts blocking an unusual volume of requests.
+  sns_topic_arn = module.monitoring.sns_topic_arn
+
   tags = local.common_tags
 }
 

--- a/infra/terraform/environments/staging/main.tf
+++ b/infra/terraform/environments/staging/main.tf
@@ -201,6 +201,9 @@ module "waf" {
   log_retention_days               = 7
   blocked_requests_alarm_threshold = 2000
 
+  # Notify on-call when the WAF starts blocking an unusual volume of requests.
+  sns_topic_arn = module.monitoring.sns_topic_arn
+
   tags = local.common_tags
 }
 

--- a/infra/terraform/modules/waf/main.tf
+++ b/infra/terraform/modules/waf/main.tf
@@ -280,5 +280,11 @@ resource "aws_cloudwatch_metric_alarm" "waf_blocked_requests" {
     Rule   = "ALL"
   }
 
+  # Wire the alarm into the shared SNS alerting path when a topic ARN is
+  # supplied. An empty value disables notifications so the module still works
+  # standalone (e.g. isolated terraform plan runs).
+  alarm_actions = var.sns_topic_arn != "" ? [var.sns_topic_arn] : []
+  ok_actions    = var.sns_topic_arn != "" ? [var.sns_topic_arn] : []
+
   tags = var.tags
 }

--- a/infra/terraform/modules/waf/variables.tf
+++ b/infra/terraform/modules/waf/variables.tf
@@ -57,6 +57,12 @@ variable "blocked_requests_alarm_threshold" {
   default     = 1000
 }
 
+variable "sns_topic_arn" {
+  description = "Optional SNS topic ARN to notify when the waf_blocked_requests alarm changes state. Empty string disables notifications (module works standalone)."
+  type        = string
+  default     = ""
+}
+
 variable "tags" {
   description = "Tags to apply to all resources"
   type        = map(string)

--- a/istio/__tests__/manifests.test.js
+++ b/istio/__tests__/manifests.test.js
@@ -270,7 +270,7 @@ describe('destination-rules.yaml', () => {
     expect(dr.spec.trafficPolicy.tls.mode).toBe('DISABLE');
   });
 
-  it.each(['backend', 'gateway'])('%s has outlier detection (circuit breaker)', (name) => {
+  it.each(['backend', 'gateway', 'frontend'])('%s has outlier detection (circuit breaker)', (name) => {
     const dr = find(destRules, 'DestinationRule', name);
     expect(dr.spec.trafficPolicy.outlierDetection).toBeDefined();
     expect(dr.spec.trafficPolicy.outlierDetection.consecutive5xxErrors).toBeGreaterThan(0);

--- a/istio/destination-rules.yaml
+++ b/istio/destination-rules.yaml
@@ -61,6 +61,13 @@ spec:
     connectionPool:
       http:
         http1MaxPendingRequests: 100
+    # Same circuit-breaker parity as backend/gateway so a frontend outage
+    # returning 5xx is ejected from the mesh's routing table.
+    outlierDetection:
+      consecutive5xxErrors: 5
+      interval: 30s
+      baseEjectionTime: 30s
+      maxEjectionPercent: 50
 ---
 # ── redis (TCP — no mTLS upgrade, passthrough) ────────────────────────────────
 apiVersion: networking.istio.io/v1beta1

--- a/monitoring/pagerduty/incident-response.test.ts
+++ b/monitoring/pagerduty/incident-response.test.ts
@@ -300,6 +300,9 @@ describe("PagerDuty Incident Response", () => {
         const parsed = JSON.parse(capturedBody);
         expect(parsed.payload.severity).toBe("critical");
         expect(parsed.dedup_key).toBe("nova-api-high-error-rate");
+        expect(parsed.links).toBeInstanceOf(Array);
+        expect(parsed.links.length).toBeGreaterThan(0);
+        expect(parsed.links[0].href).toContain("PRODUCTION_INTEGRATION_RUNBOOK.md");
       } finally {
         process.env.PAGERDUTY_ROUTING_KEY = original;
       }
@@ -361,6 +364,9 @@ describe("PagerDuty Incident Response", () => {
         const parsed = JSON.parse(capturedBody);
         expect(parsed.payload.severity).toBe("critical");
         expect(parsed.dedup_key).toBe("nova-db-pool-exhausted");
+        expect(parsed.links).toBeInstanceOf(Array);
+        expect(parsed.links.length).toBeGreaterThan(0);
+        expect(parsed.links[0].href).toContain("PRODUCTION_INTEGRATION_RUNBOOK.md");
       } finally {
         process.env.PAGERDUTY_ROUTING_KEY = original;
       }

--- a/monitoring/pagerduty/incident-response.ts
+++ b/monitoring/pagerduty/incident-response.ts
@@ -304,6 +304,12 @@ export function alertHighApiErrorRate(
     dedupKey: "nova-api-high-error-rate",
     source: "backend-api",
     customDetails: { errorRate, ...details },
+    links: [
+      {
+        href: "https://github.com/Emmyt24/Nova-launch/blob/main/docs/PRODUCTION_INTEGRATION_RUNBOOK.md#high-api-error-rate",
+        text: "Runbook: High API Error Rate",
+      },
+    ],
   });
 }
 
@@ -315,6 +321,12 @@ export function alertDatabasePoolExhausted(details?: Record<string, unknown>) {
     dedupKey: "nova-db-pool-exhausted",
     source: "prisma",
     customDetails: details,
+    links: [
+      {
+        href: "https://github.com/Emmyt24/Nova-launch/blob/main/docs/PRODUCTION_INTEGRATION_RUNBOOK.md#database-connection-pool-exhausted",
+        text: "Runbook: Database Connection Pool Exhausted",
+      },
+    ],
   });
 }
 

--- a/monitoring/pagerduty/package.json
+++ b/monitoring/pagerduty/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "nova-launch-pagerduty",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "vitest": "1.6.1"
+  }
+}


### PR DESCRIPTION
## Summary
Resolves four Stellar Wave issues with additive, low-risk changes:

- **#1800** — `createTimeoutMiddleware` now monkey-patches `res.json`/`res.send`/`res.end` to no-ops after the 503 is sent, so a still-running downstream handler's late write is silently ignored instead of throwing "Cannot set headers after they are sent".
- **#1801** — Added an optional `sns_topic_arn` input to the `waf` module (defaults to `""` so it stays standalone) and wired `alarm_actions`/`ok_actions` on `waf_blocked_requests`; the staging and production root modules now pass `module.monitoring.sns_topic_arn`.
- **#1802** — Added `outlierDetection` (circuit breaker) to the `frontend` DestinationRule mirroring `backend`/`gateway`, and extended the `it.each` test to include `frontend`.
- **#1803** — `alertHighApiErrorRate` and `alertDatabasePoolExhausted` now attach a non-empty `links` array to `PRODUCTION_INTEGRATION_RUNBOOK.md` (with new runbook sections), and tests assert the links are present.

## Test plan
- `backend`: `npx vitest run src/middleware/timeout.test.ts` — new post-timeout-write test passes.
- `infra/terraform/tests`: structural/security assertions pass (9 pre-existing GitHub-workflow failures are unrelated to these changes).
- `istio`: `npm test` — 59/59 pass incl. new `frontend` outlier-detection assertion.
- `monitoring/pagerduty`: `npx vitest run incident-response.test.ts` — 18/18 pass incl. new links assertions.

Closes #1800
Closes #1801
Closes #1802
Closes #1803