### PR TITLE
fix & feat: resolve issues #1816, #1817, #1821, #1818

### DIFF
--- a/backend/src/services/auditRetentionJob.test.ts
+++ b/backend/src/services/auditRetentionJob.test.ts
@@ -238,6 +238,39 @@ describe("runAuditRetention", () => {
 
     expect(mockArchiveAuditRecords).toHaveBeenCalledTimes(2);
   });
+
+  it("honors custom retentionDays below 91 so every purged record is archived first", async () => {
+    const customRetentionDays = 30; // below 91
+    const logs = [
+      makeLog(10),  // 10 days old - keep in hot store
+      makeLog(45),  // 45 days old - within the (30, 91) gap: must be archived before purge
+      makeLog(120), // 120 days old - must be archived before purge
+    ];
+    mockGetAuditLogs.mockResolvedValue(logs);
+    mockArchiveAuditRecords.mockResolvedValue(makeArchiveResult(2, "warm"));
+
+    const purged = await runAuditRetention(customRetentionDays);
+
+    expect(purged).toBe(2);
+    expect(mockArchiveAuditRecords).toHaveBeenCalled();
+
+    // Check that warm archival cutoff was derived from customRetentionDays (30 days ago, not hardcoded 91)
+    const [warmCutoffArg, tier] = mockArchiveAuditRecords.mock.calls[0];
+    expect(tier).toBe("warm");
+    expect(warmCutoffArg).toBeInstanceOf(Date);
+
+    const warmCutoffDays =
+      (Date.now() - warmCutoffArg.getTime()) / (24 * 60 * 60 * 1000);
+    expect(warmCutoffDays).toBeCloseTo(30, 0);
+
+    // Verify all purged records fall within the archival cutoff window
+    const [purgeCutoffArg] = mockPurgeAuditLogs.mock.calls[0];
+    const purgedRecords = logs.filter((l) => l.timestamp < purgeCutoffArg);
+    expect(purgedRecords).toHaveLength(2);
+    for (const record of purgedRecords) {
+      expect(record.timestamp.getTime()).toBeLessThan(warmCutoffArg.getTime());
+    }
+  });
 });
 
 // ── Checkpoint resumability ───────────────────────────────────────────────────

--- a/backend/src/services/auditRetentionJob.ts
+++ b/backend/src/services/auditRetentionJob.ts
@@ -56,7 +56,8 @@ export async function runAuditArchival(
 ): Promise<{ warm: number; cold: number }> {
   const now = Date.now();
 
-  const warmCutoff = new Date(now - WARM_DAYS_START * 24 * 60 * 60 * 1000);
+  const warmDays = Math.min(WARM_DAYS_START, retentionDays);
+  const warmCutoff = new Date(now - warmDays * 24 * 60 * 60 * 1000);
   const coldCutoff = new Date(now - COLD_DAYS_START * 24 * 60 * 60 * 1000);
 
   const startedAt = new Date().toISOString();
@@ -141,6 +142,15 @@ export async function runAuditRetention(
 
   // Phase 1: archive before delete.
   await runAuditArchival(retentionDays);
+
+  // Invariant check: ensure archival cutoff encompasses everything to be purged.
+  const warmDays = Math.min(WARM_DAYS_START, retentionDays);
+  const archivalWarmCutoff = new Date(Date.now() - warmDays * 24 * 60 * 60 * 1000);
+  if (archivalWarmCutoff.getTime() < cutoff.getTime()) {
+    throw new Error(
+      `Invariant violation: archival cutoff (${archivalWarmCutoff.toISOString()}) is older than purge cutoff (${cutoff.toISOString()}). Purge aborted to prevent data loss.`
+    );
+  }
 
   // Phase 2: delete from hot store.
   const allLogs = await Database.getAuditLogs();

--- a/backend/src/services/streamReconciliation.test.ts
+++ b/backend/src/services/streamReconciliation.test.ts
@@ -16,7 +16,7 @@ describe("StreamReconciliationService", () => {
     vi.restoreAllMocks();
   });
 
-  it("flags a divergence and publishes stream.divergence_detected when balances mismatch", async () => {
+  it("flags a divergence and publishes stream.divergence_detected when balances genuinely mismatch", async () => {
     const publishSpy = vi.spyOn(eventBus, "publish");
     const prisma = mockPrisma([
       {
@@ -30,6 +30,7 @@ describe("StreamReconciliationService", () => {
     ]);
 
     const service = new StreamReconciliationService(prisma, 300_000);
+    vi.spyOn(service as any, "fetchOnChainBalance").mockResolvedValue(BigInt(500));
     const result = await service.reconcile();
 
     expect(result.divergences).toHaveLength(1);
@@ -37,18 +38,39 @@ describe("StreamReconciliationService", () => {
       streamId: 1,
       field: "balance",
       projectedValue: "1000",
-      onChainValue: "0",
+      onChainValue: "500",
     });
 
     expect(publishSpy).toHaveBeenCalledWith("stream.divergence_detected", {
       streamId: 1,
       field: "balance",
-      onChainValue: "0",
+      onChainValue: "500",
       projectedValue: "1000",
     });
   });
 
-  it("does not publish an event when the projected balance matches on-chain state", async () => {
+  it("does not flag a divergence when on-chain fetch matches projected active stream balance", async () => {
+    const publishSpy = vi.spyOn(eventBus, "publish");
+    const prisma = mockPrisma([
+      {
+        streamId: 1,
+        creator: "GCREATOR",
+        recipient: "GRECIPIENT",
+        amount: BigInt(1000),
+        claimedAt: null,
+        status: StreamStatus.CREATED,
+      },
+    ]);
+
+    const service = new StreamReconciliationService(prisma, 300_000);
+    vi.spyOn(service as any, "fetchOnChainBalance").mockResolvedValue(BigInt(1000));
+    const result = await service.reconcile();
+
+    expect(result.divergences).toHaveLength(0);
+    expect(publishSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not publish an event when the projected balance matches on-chain state for claimed stream", async () => {
     const publishSpy = vi.spyOn(eventBus, "publish");
     const prisma = mockPrisma([
       {
@@ -62,13 +84,35 @@ describe("StreamReconciliationService", () => {
     ]);
 
     const service = new StreamReconciliationService(prisma, 300_000);
+    vi.spyOn(service as any, "fetchOnChainBalance").mockResolvedValue(BigInt(0));
     const result = await service.reconcile();
 
     expect(result.divergences).toHaveLength(0);
     expect(publishSpy).not.toHaveBeenCalled();
   });
 
-  it("reports a divergence per mismatched stream across multiple streams", async () => {
+  it("skips divergence reporting when on-chain fetch returns null (transient error)", async () => {
+    const publishSpy = vi.spyOn(eventBus, "publish");
+    const prisma = mockPrisma([
+      {
+        streamId: 1,
+        creator: "GCREATOR",
+        recipient: "GRECIPIENT",
+        amount: BigInt(1000),
+        claimedAt: null,
+        status: StreamStatus.CREATED,
+      },
+    ]);
+
+    const service = new StreamReconciliationService(prisma, 300_000);
+    vi.spyOn(service as any, "fetchOnChainBalance").mockResolvedValue(null);
+    const result = await service.reconcile();
+
+    expect(result.divergences).toHaveLength(0);
+    expect(publishSpy).not.toHaveBeenCalled();
+  });
+
+  it("reports a divergence per genuinely mismatched stream across multiple streams", async () => {
     const publishSpy = vi.spyOn(eventBus, "publish");
     const prisma = mockPrisma([
       {
@@ -98,11 +142,25 @@ describe("StreamReconciliationService", () => {
     ]);
 
     const service = new StreamReconciliationService(prisma, 300_000);
+    vi.spyOn(service as any, "fetchOnChainBalance").mockImplementation(
+      async (streamId: number) => {
+        if (streamId === 1) return BigInt(1000); // Matches projected
+        if (streamId === 2) return BigInt(0);    // Matches projected
+        if (streamId === 3) return BigInt(200);  // Mismatches projected (500 vs 200)
+        return null;
+      }
+    );
     const result = await service.reconcile();
 
     expect(result.totalStreams).toBe(3);
-    expect(result.divergences.map((d) => d.streamId)).toEqual([1, 3]);
-    expect(publishSpy).toHaveBeenCalledTimes(2);
+    expect(result.divergences.map((d) => d.streamId)).toEqual([3]);
+    expect(publishSpy).toHaveBeenCalledTimes(1);
+    expect(publishSpy).toHaveBeenCalledWith("stream.divergence_detected", {
+      streamId: 3,
+      field: "balance",
+      onChainValue: "200",
+      projectedValue: "500",
+    });
   });
 
   it("defaults to a 5-minute reconciliation interval", () => {

--- a/backend/src/services/streamReconciliation.ts
+++ b/backend/src/services/streamReconciliation.ts
@@ -1,5 +1,7 @@
 import { PrismaClient, StreamStatus } from "@prisma/client";
+import axios from "axios";
 import { logger } from "../lib/logger";
+import { stellarConfig } from "../lib/stellar";
 import { eventBus } from "./eventBus";
 
 export interface StreamDivergence {
@@ -36,15 +38,26 @@ export class StreamReconciliationService {
   private prisma: PrismaClient;
   private reconciliationIntervalMs: number;
   private lastReconciliation?: Date;
+  private horizonUrl: string;
+  private factoryContractId: string;
 
   constructor(
     prisma: PrismaClient,
     reconciliationIntervalMs: number = parseInt(
       process.env.STREAM_RECONCILIATION_INTERVAL_MS || "300000"
-    ) // 5 minutes default
+    ), // 5 minutes default
+    config: { horizonUrl?: string; factoryContractId?: string } = {}
   ) {
     this.prisma = prisma;
     this.reconciliationIntervalMs = reconciliationIntervalMs;
+    this.horizonUrl =
+      config.horizonUrl ||
+      process.env.STELLAR_HORIZON_URL ||
+      stellarConfig.horizonUrl;
+    this.factoryContractId =
+      config.factoryContractId ||
+      process.env.FACTORY_CONTRACT_ID ||
+      stellarConfig.factoryContractId;
   }
 
   async reconcile(): Promise<StreamReconciliationResult> {
@@ -151,14 +164,82 @@ export class StreamReconciliationService {
 
   private async fetchOnChainBalance(streamId: number): Promise<bigint | null> {
     try {
-      // This would call the on-chain contract via Web3/blockchain API
-      // For now, this is a placeholder that would be implemented with actual chain integration
-      // In production, this would call a blockchain RPC or contract query
-      return BigInt(0);
+      if (!this.factoryContractId) {
+        return null;
+      }
+
+      const response = await axios.get(
+        `${this.horizonUrl}/contracts/${this.factoryContractId}/events`,
+        {
+          params: {
+            topic: `vlt_cr_v1,${streamId}`,
+            limit: 10,
+            order: "desc",
+          },
+          timeout: 10000,
+        }
+      );
+
+      const records = response.data?._embedded?.records || [];
+      if (records.length === 0) {
+        // Fallback query across recent contract events to locate this stream
+        const fallbackResponse = await axios.get(
+          `${this.horizonUrl}/contracts/${this.factoryContractId}/events`,
+          {
+            params: {
+              limit: 50,
+              order: "desc",
+            },
+            timeout: 10000,
+          }
+        );
+        const fallbackRecords = fallbackResponse.data?._embedded?.records || [];
+        const matching = fallbackRecords.find(
+          (r: any) =>
+            r.topic?.[1] === String(streamId) ||
+            r.value?.stream_id === streamId ||
+            r.value?.streamId === streamId
+        );
+        if (matching) {
+          return this.parseStreamBalanceFromEvent(matching);
+        }
+        return null;
+      }
+
+      return this.parseStreamBalanceFromEvent(records[0]);
     } catch (err) {
-      logger.warn(`Failed to fetch on-chain balance for stream ${streamId}`);
+      logger.warn(
+        `Failed to fetch on-chain balance for stream ${streamId}: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
       return null;
     }
+  }
+
+  private parseStreamBalanceFromEvent(event: any): bigint {
+    const topic = event?.topic?.[0];
+    if (
+      topic === "vlt_cl_v1" ||
+      topic === "vlt_cn_v1" ||
+      topic === "strm_cl_v1" ||
+      topic === "strm_cn_v1"
+    ) {
+      return BigInt(0);
+    }
+    const value = event?.value;
+    if (value === undefined || value === null) {
+      return BigInt(0);
+    }
+    if (typeof value === "object") {
+      if (value.amount !== undefined) {
+        return BigInt(value.amount);
+      }
+      if (Array.isArray(value) && value.length >= 3) {
+        return BigInt(value[2]);
+      }
+    }
+    return BigInt(value.toString());
   }
 
   getLastReconciliationTime(): Date | undefined {

--- a/contracts/governance/src/governance_test.rs
+++ b/contracts/governance/src/governance_test.rs
@@ -447,6 +447,21 @@ fn is_paused_reflects_state() {
 // ─── [EDGE] Edge cases ────────────────────────────────────────────────────
 
 #[test]
+fn get_admin_returns_initial_and_transferred_admin() {
+    let (env, contract_id, admin) = setup();
+    let c = client(&env, &contract_id);
+
+    // Verify get_admin returns the address passed to initialize
+    assert_eq!(c.get_admin(), admin);
+
+    let new_admin = Address::generate(&env);
+    c.transfer_admin(&admin, &new_admin);
+
+    // Verify get_admin returns the new address immediately after transfer_admin succeeds
+    assert_eq!(c.get_admin(), new_admin);
+}
+
+#[test]
 fn transfer_admin_succeeds() {
     let (env, contract_id, admin) = setup();
     let c = client(&env, &contract_id);

--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -341,6 +341,14 @@ impl GovernanceContract {
         storage::is_paused(&env)
     }
 
+    /// Get the current contract administrator address.
+    ///
+    /// # Returns
+    /// The [`Address`] of the current administrator.
+    pub fn get_admin(env: Env) -> Address {
+        storage::get_admin(&env)
+    }
+
     // ── Proposals ───────────────────────────────────────────────────────────
 
     /// Create a new governance proposal.

--- a/scripts/deployment/README.md
+++ b/scripts/deployment/README.md
@@ -29,6 +29,12 @@ npm run deploy
 # Deploy to mainnet
 npm run deploy -- --network mainnet
 
+# Deploy to multiple regions (testnet)
+npm run deploy:multi-region
+
+# Deploy to multiple regions (mainnet)
+npm run deploy:multi-region -- --network mainnet
+
 # Verify deployment
 npm run verify
 ```
@@ -87,6 +93,18 @@ Options:
   --help, -h                   Show help message
 ```
 
+#### Multi-Region Deploy Command
+
+```bash
+npm run deploy:multi-region -- [options]
+
+Options:
+  --network <testnet|mainnet>  Target network (default: testnet)
+  --sequential                 Deploy regions sequentially (default: parallel)
+  --regions <id,id,...>        Comma-separated region IDs to include
+  --help, -h                   Show help message
+```
+
 ## Advanced Usage
 
 ### Custom Fee Configuration
@@ -118,6 +136,103 @@ npm run deploy -- --network mainnet
 npm run verify -- \
   --contract-id CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX \
   --network testnet
+```
+
+## Multi-Region Deployment
+
+Nova Launch supports geo-distributed deployments across multiple Stellar endpoint regions. A "region" corresponds to a specific Horizon REST and Soroban RPC endpoint pair. Deploying across multiple regions enables geo-distributed read traffic and redundancy while sharing the same underlying ledger state.
+
+The multi-region deployment workflow is driven by `deployMultiRegion.ts` (`npm run deploy:multi-region`) and orchestrated by `multiRegionOrchestrator.ts`.
+
+### Relationship to Single-Region Deployment
+
+While the single-region `npm run deploy` command deploys to a single endpoint configured via local `.env`, `npm run deploy:multi-region`:
+1. **Reuses Orchestrator Core**: Reuses `DeploymentOrchestrator` under the hood for each configured region, ensuring consistent deployment, initialization, and verification logic.
+2. **Parallel or Sequential Execution**: Supports deploying across all regions concurrently in parallel (default) or sequentially (`--sequential`).
+3. **Partial Failure Resilience**: Employs a fail-partial strategy where a failure in one region does not abort deployments to other regions.
+4. **Incremental Registry Updates**: Atomically updates the centralized `multi-region-deployments.json` registry after each successful region deployment.
+5. **WASM Hash Consistency**: Verifies WASM hash consistency across all successful region deployments to detect any race conditions or mismatched build artifacts.
+
+### Built-in Region Presets
+
+Predefined presets are defined in `scripts/deployment/multiRegionTypes.ts`:
+
+#### Testnet Regions (`TESTNET_REGIONS`)
+- **`testnet-primary`**: Testnet Primary (SDF)
+  - Horizon URL: `https://horizon-testnet.stellar.org`
+  - Soroban RPC URL: `https://soroban-testnet.stellar.org`
+  - Admin / Treasury Keys: `admin` / `treasury`
+  - Base / Metadata Fees: `70000000` / `30000000` stroops
+  - Environment File: `../../.env.testnet`
+
+#### Mainnet Regions (`MAINNET_REGIONS`)
+- **`mainnet-us-east`**: Mainnet US-East (SDF)
+  - Horizon URL: `https://horizon.stellar.org`
+  - Soroban RPC URL: `https://soroban-mainnet.stellar.org`
+  - Admin / Treasury Keys: `admin-mainnet` / `treasury-mainnet`
+  - Environment File: `../../.env.mainnet`
+- **`mainnet-eu-west`**: Mainnet EU-West (Lobstr)
+  - Horizon URL: `https://horizon.stellar.lobstr.co`
+  - Soroban RPC URL: `https://rpc.stellar.lobstr.co`
+  - Admin / Treasury Keys: `admin-mainnet` / `treasury-mainnet`
+  - Environment File: `../../.env.mainnet.eu`
+- **`mainnet-ap-south`**: Mainnet AP-South (SatoshiPay)
+  - Horizon URL: `https://stellar-horizon.satoshipay.io`
+  - Soroban RPC URL: `https://soroban-mainnet.stellar.org`
+  - Admin / Treasury Keys: `admin-mainnet` / `treasury-mainnet`
+  - Environment File: `../../.env.mainnet.ap`
+
+### Adding a New Region (`RegionConfig`)
+
+To configure additional deployment regions, contributors can define objects implementing the `RegionConfig` interface:
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | `string` | Unique region identifier (e.g. `"mainnet-us-east"`, `"eu-west"`). |
+| `label` | `string` | Human-readable label (e.g. `"Mainnet US-East (SDF)"`). |
+| `network` | `'testnet' \| 'mainnet'` | Stellar network this region belongs to. |
+| `horizonUrl` | `string` | Horizon REST API URL for this region. |
+| `sorobanRpcUrl` | `string` | Soroban RPC URL for this region. |
+| `adminKeyName` | `string` | Admin key name in the local Soroban keystore. |
+| `treasuryKeyName` | `string` | Treasury key name in the local Soroban keystore. |
+| `baseFee` | `number` | Base fee in stroops. |
+| `metadataFee` | `number` | Metadata fee in stroops. |
+| `wasmPath` | `string` | Path to the compiled contract WASM file. |
+| `envFile` | `string` | Path to the `.env` file to update after deployment. |
+
+### Deployment Registry (`multi-region-deployments.json`)
+
+Successful multi-region deployments are written to `multi-region-deployments.json` in the root repository directory.
+
+#### Purpose and Downstream Consumers
+- **Frontend & API Gateway**: Downstream consumers (frontend client applications, routing gateways, indexers) read `multi-region-deployments.json` to discover contract IDs, Horizon URLs, and RPC endpoints to route user traffic to the nearest healthy region.
+- **Atomic Persistence**: Entries are written per-region immediately upon deployment success (`writeRegistryEntry`), ensuring partial progress is preserved.
+
+#### Registry Format (`MultiRegionRegistry`)
+
+The registry maps region IDs to `RegionRegistry` entries:
+
+```json
+{
+  "mainnet-us-east": {
+    "deployedAt": "2026-01-01T00:00:00.000Z",
+    "regionId": "mainnet-us-east",
+    "network": "mainnet",
+    "contractId": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    "horizonUrl": "https://horizon.stellar.org",
+    "sorobanRpcUrl": "https://soroban-mainnet.stellar.org",
+    "wasmHash": "mock-wasm-hash"
+  },
+  "mainnet-eu-west": {
+    "deployedAt": "2026-01-01T00:00:00.000Z",
+    "regionId": "mainnet-eu-west",
+    "network": "mainnet",
+    "contractId": "CBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+    "horizonUrl": "https://horizon.stellar.lobstr.co",
+    "sorobanRpcUrl": "https://rpc.stellar.lobstr.co",
+    "wasmHash": "mock-wasm-hash"
+  }
+}
 ```
 
 ## Deployment Process


### PR DESCRIPTION
## Overview
This PR resolves four issues across deployment documentation, stream reconciliation, governance contract ABI entry points, and audit log retention archival.

---

### 1. Document `deploy:multi-region` Path (Closes #1816)
- Documented `npm run deploy:multi-region` in `scripts/deployment/README.md` alongside single-region deploy and verify scripts.
- Added comprehensive section on multi-region deployments explaining the orchestrator core, parallel/sequential deployment options, and fail-partial mechanics.
- Documented built-in region presets (`TESTNET_REGIONS` and `MAINNET_REGIONS`) from `multiRegionTypes.ts`.
- Documented all `RegionConfig` fields required to configure additional deployment endpoints.
- Documented the schema and purpose of `multi-region-deployments.json` for frontend and gateway consumers.

### 2. Fix False-Positive-Storm in Stream Reconciliation (Closes #1817)
- Replaced the hardcoded `BigInt(0)` placeholder in `StreamReconciliationService.fetchOnChainBalance` (`backend/src/services/streamReconciliation.ts`) with a real query against Horizon for contract events.
- Preserved the `null`-on-failure contract so transient RPC errors are not reported as false mismatches.
- Updated `backend/src/services/streamReconciliation.test.ts` to assert that matching on-chain and projected balances report no divergence, while genuine mismatches report divergence as expected.

### 3. Expose Read-Only `get_admin` Entry Point on Governance Contract (Closes #1821)
- Added `pub fn get_admin(env: Env) -> Address` to `GovernanceContract` in `contracts/governance/src/lib.rs`, delegating to `storage::get_admin(&env)`.
- Added standard rustdoc documentation matching existing read-only methods (`get_balance`, `is_paused`).
- Added unit tests in `contracts/governance/src/governance_test.rs` validating that `get_admin` returns the initialized admin address and updates correctly after `transfer_admin`.

### 4. Honor `retentionDays` in Audit Archival to Prevent Purge-Before-Archive Data Loss (Closes #1818)
- Updated `runAuditArchival` in `backend/src/services/auditRetentionJob.ts` to derive the warm tier cutoff from `Math.min(WARM_DAYS_START, retentionDays)` instead of ignoring `retentionDays`.
- Added an invariant assertion in `runAuditRetention` ensuring the archival cutoff is always at least as recent as the purge cutoff before invoking `Database.purgeAuditLogs`.
- Added tests in `backend/src/services/auditRetentionJob.test.ts` verifying that when `retentionDays < 91`, all purged records are archived first.

---

Closes #1816
Closes #1817
Closes #1821
Closes #1818