### PR TITLE
Fix 4 critical auth security issues (#1838 #1839 #1840 #1841)

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -84,7 +84,9 @@ export class AuthController {
     status: 429,
     description: "Too many nonce requests — rate limit exceeded",
   })
-  getNonce(@Query("publicKey") publicKey: string): NonceResponseDto {
+  async getNonce(
+    @Query("publicKey") publicKey: string
+  ): Promise<NonceResponseDto> {
     return this.authService.requestNonce(publicKey);
   }
 
@@ -110,8 +112,7 @@ export class AuthController {
       typical: {
         summary: "Standard wallet login",
         value: {
-          publicKey:
-            "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
+          publicKey: "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
           signature:
             "aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789+/aBcDeFgHiJkLmNoPqRsTuVwXyZ012=",
           nonce: "3f7e1b2a-9c4d-4e8f-a1b2-c3d4e5f60718",
@@ -126,7 +127,8 @@ export class AuthController {
     content: {
       "application/json": {
         example: {
-          accessToken: "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJHQUFaST...",
+          accessToken:
+            "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJHQUFaST...",
           refreshToken:
             "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJHQUFaST...",
           expiresIn: 900,
@@ -144,7 +146,10 @@ export class AuthController {
       "application/json": {
         example: {
           statusCode: 400,
-          message: ["publicKey should not be empty", "signature should not be empty"],
+          message: [
+            "publicKey should not be empty",
+            "signature should not be empty",
+          ],
           error: "Bad Request",
         },
       },
@@ -214,7 +219,8 @@ export class AuthController {
     content: {
       "application/json": {
         example: {
-          accessToken: "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJHQUFaSS...",
+          accessToken:
+            "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJHQUFaSS...",
           refreshToken:
             "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJHQUFaSS...",
           expiresIn: 900,
@@ -264,7 +270,7 @@ export class AuthController {
       },
     },
   })
-  refresh(@Body() dto: RefreshTokenDto): AuthResponseDto {
+  async refresh(@Body() dto: RefreshTokenDto): Promise<AuthResponseDto> {
     return this.authService.refreshTokens(dto);
   }
 
@@ -314,9 +320,9 @@ export class AuthController {
       },
     },
   })
-  logout(@CurrentUser() user: JwtPayloadDto): void {
+  async logout(@CurrentUser() user: JwtPayloadDto): Promise<void> {
     if (user.jti) {
-      this.authService.logout(user.jti);
+      await this.authService.logout(user.jti);
     }
   }
 

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -32,7 +32,7 @@ export class AuthService {
   /**
    * Step 1: Client requests a nonce to sign.
    */
-  requestNonce(publicKey: string): NonceResponseDto {
+  async requestNonce(publicKey: string): Promise<NonceResponseDto> {
     if (!this.stellarSig.isValidPublicKey(publicKey)) {
       throw new BadRequestException("Invalid Stellar public key");
     }
@@ -50,7 +50,7 @@ export class AuthService {
       throw new BadRequestException("Invalid Stellar public key");
     }
 
-    const nonceValid = this.nonceService.consumeNonce(nonce, publicKey);
+    const nonceValid = await this.nonceService.consumeNonce(nonce, publicKey);
     if (!nonceValid) {
       throw new UnauthorizedException("Invalid or expired nonce");
     }
@@ -83,7 +83,9 @@ export class AuthService {
    * Implements family rotation with reuse-detection.
    */
   async refreshTokens(dto: RefreshTokenDto): Promise<AuthResponseDto> {
-    const payload = this.tokenService.verifyRefreshToken(dto.refreshToken);
+    const payload = await this.tokenService.verifyRefreshToken(
+      dto.refreshToken
+    );
 
     // Generate the next pair before rotating so we have the new token string
     const nextPair = this.tokenService.generateTokenPair(payload.walletAddress);
@@ -112,9 +114,9 @@ export class AuthService {
       }
     }
 
-    // Revoke old JTI in the in-memory store (backward-compat with legacy tokens)
+    // Revoke old JTI (backward-compat with legacy tokens)
     if (payload.jti) {
-      this.tokenService.revokeToken(payload.jti);
+      await this.tokenService.revokeToken(payload.jti);
     }
 
     return nextPair;
@@ -123,8 +125,8 @@ export class AuthService {
   /**
    * Revoke a specific token by JTI (e.g., on logout).
    */
-  logout(jti: string): void {
-    this.tokenService.revokeToken(jti);
+  async logout(jti: string): Promise<void> {
+    await this.tokenService.revokeToken(jti);
     this.logger.log(`Token revoked on logout: ${jti}`);
   }
 }

--- a/backend/src/auth/cors.config.ts
+++ b/backend/src/auth/cors.config.ts
@@ -1,6 +1,14 @@
 import { CorsOptions } from "@nestjs/common/interfaces/external/cors-options.interface";
 
 export function buildCorsOptions(allowedOrigins: string[]): CorsOptions {
+  if (allowedOrigins.includes("*")) {
+    throw new Error(
+      "CORS misconfiguration: wildcard '*' cannot be combined with credentials: true. " +
+        "This would allow any origin to make authenticated cross-origin requests. " +
+        "Use an explicit list of allowed origins instead."
+    );
+  }
+
   return {
     origin: (origin, callback) => {
       // Allow server-to-server calls (no origin header)
@@ -9,7 +17,7 @@ export function buildCorsOptions(allowedOrigins: string[]): CorsOptions {
         return;
       }
 
-      if (allowedOrigins.includes("*") || allowedOrigins.includes(origin)) {
+      if (allowedOrigins.includes(origin)) {
         callback(null, true);
       } else {
         callback(new Error(`Origin ${origin} not allowed by CORS policy`));

--- a/backend/src/auth/jwt.strategy.ts
+++ b/backend/src/auth/jwt.strategy.ts
@@ -24,7 +24,7 @@ export class JwtStrategy extends PassportStrategy(Strategy, "jwt") {
       throw new UnauthorizedException("Invalid token type");
     }
 
-    if (payload.jti && this.tokenService.isRevoked(payload.jti)) {
+    if (payload.jti && (await this.tokenService.isRevoked(payload.jti))) {
       throw new UnauthorizedException("Token has been revoked");
     }
 

--- a/backend/src/auth/nonce.service.spec.ts
+++ b/backend/src/auth/nonce.service.spec.ts
@@ -175,9 +175,7 @@ describe("NonceService (Redis-backed)", () => {
       const { nonce } = service.generateNonce("GPUBKEY1");
       await new Promise((r) => setImmediate(r)); // let SET settle
 
-      await expect(service.consumeNonce(nonce, "GPUBKEY1")).resolves.toBe(
-        true
-      );
+      await expect(service.consumeNonce(nonce, "GPUBKEY1")).resolves.toBe(true);
     });
 
     it("returns false on second consumption (replay protection)", async () => {
@@ -200,9 +198,9 @@ describe("NonceService (Redis-backed)", () => {
       const { nonce } = service.generateNonce("GPUBKEY1");
       await new Promise((r) => setImmediate(r));
 
-      await expect(
-        service.consumeNonce(nonce, "GDIFFERENTKEY")
-      ).resolves.toBe(false);
+      await expect(service.consumeNonce(nonce, "GDIFFERENTKEY")).resolves.toBe(
+        false
+      );
     });
 
     it("returns false for an expired nonce", async () => {

--- a/backend/src/auth/nonce.service.ts
+++ b/backend/src/auth/nonce.service.ts
@@ -52,34 +52,34 @@ export class NonceService implements OnModuleDestroy {
     // Safety-net cleanup: scan for any nonce keys whose TTL has already fired
     // but whose entries were somehow not evicted (e.g., Redis maxmemory policy
     // set to noeviction). In normal operation Redis TTL handles eviction.
-    this.cleanupInterval = setInterval(
-      () => this.cleanupUsedNonces(),
-      60_000
-    );
+    this.cleanupInterval = setInterval(() => this.cleanupUsedNonces(), 60_000);
   }
 
   /**
    * Generates a one-time nonce for the given public key and stores it in
    * Redis with a TTL equal to NONCE_EXPIRY_MS.  The key format is
    * `nonce:<uuid>` and the value is a JSON-encoded NonceEntry.
+   *
+   * Throws on Redis write failure to prevent dead-on-arrival nonces.
    */
-  generateNonce(publicKey: string): NonceResponseDto {
+  async generateNonce(publicKey: string): Promise<NonceResponseDto> {
     const nonce = uuidv4();
     const expiresAt = Date.now() + AUTH_CONSTANTS.NONCE_EXPIRY_MS;
     const entry: NonceEntry = { publicKey, expiresAt, used: false };
 
-    // Fire-and-forget; we return the dto synchronously.  The SET is atomic
-    // and the TTL ensures automatic expiry even if the process crashes.
-    this.redis
-      .set(
+    try {
+      await this.redis.set(
         `${NONCE_KEY_PREFIX}${nonce}`,
         JSON.stringify(entry),
         "EX",
         NONCE_TTL_SECONDS
-      )
-      .catch((err) =>
-        this.logger.error(`Failed to store nonce in Redis: ${err.message}`)
       );
+    } catch (err) {
+      this.logger.error(
+        `Failed to store nonce in Redis: ${(err as Error).message}`
+      );
+      throw new Error("Failed to generate nonce: Redis write failed");
+    }
 
     const message = `${AUTH_CONSTANTS.STELLAR_MESSAGE_PREFIX}${nonce}`;
     return { nonce, expiresAt, message };
@@ -165,9 +165,7 @@ export class NonceService implements OnModuleDestroy {
         this.logger.debug(`Cleanup removed ${cleaned} used nonce key(s)`);
       }
     } catch (err) {
-      this.logger.error(
-        `Nonce cleanup error: ${(err as Error).message}`
-      );
+      this.logger.error(`Nonce cleanup error: ${(err as Error).message}`);
     }
   }
 

--- a/backend/src/auth/refresh-token-family.service.ts
+++ b/backend/src/auth/refresh-token-family.service.ts
@@ -36,9 +36,12 @@ export async function createTokenFamily(
 /**
  * Rotate a refresh token within its family.
  *
+ * Uses a conditional update to atomically check that the token exists and is
+ * not yet used, preventing concurrent rotations from both succeeding.
+ *
  * Throws TokenFamilyError with:
  *  - REUSE_DETECTED — if the presented token was already used (entire family invalidated)
- *  - INVALID_TOKEN  — if the token is not found in the store
+ *  - INVALID_TOKEN  — if the token is not found in the store or is already used
  */
 export async function rotateTokenFamily(
   currentToken: string,
@@ -46,30 +49,48 @@ export async function rotateTokenFamily(
   nextExpiresAt: Date
 ): Promise<{ familyId: string }> {
   return (prisma as any).$transaction(async (tx: any) => {
+    // Atomically mark token as used only if it exists and is not yet used.
+    // This prevents two concurrent requests from both succeeding.
+    const updateResult = await tx.refreshToken.updateMany({
+      where: { token: currentToken, used: false },
+      data: { used: true },
+    });
+
+    // If updateMany affected 0 rows, either the token doesn't exist or it's already used.
+    // Re-fetch to determine which case applies so we can throw the appropriate error.
+    if (updateResult.count === 0) {
+      const record = await tx.refreshToken.findUnique({
+        where: { token: currentToken },
+      });
+
+      if (!record) {
+        throw new TokenFamilyError("INVALID_TOKEN", "Refresh token not found");
+      }
+
+      if (record.used) {
+        // Reuse detected — invalidate the whole family to contain the breach
+        await tx.refreshToken.deleteMany({
+          where: { familyId: record.familyId },
+        });
+        throw new TokenFamilyError(
+          "REUSE_DETECTED",
+          "Refresh token reuse detected — entire family invalidated"
+        );
+      }
+    }
+
+    // If we reach here, updateResult.count === 1, meaning we successfully marked
+    // the token as used. Fetch the record to get its familyId.
     const record = await tx.refreshToken.findUnique({
       where: { token: currentToken },
     });
 
     if (!record) {
-      throw new TokenFamilyError("INVALID_TOKEN", "Refresh token not found");
-    }
-
-    if (record.used) {
-      // Reuse detected — invalidate the whole family to contain the breach
-      await tx.refreshToken.deleteMany({
-        where: { familyId: record.familyId },
-      });
       throw new TokenFamilyError(
-        "REUSE_DETECTED",
-        "Refresh token reuse detected — entire family invalidated"
+        "INVALID_TOKEN",
+        "Refresh token not found after update"
       );
     }
-
-    // Mark current token as used
-    await tx.refreshToken.update({
-      where: { token: currentToken },
-      data: { used: true },
-    });
 
     // Issue new token in the same family
     await tx.refreshToken.create({
@@ -96,9 +117,7 @@ export async function invalidateFamily(familyId: string): Promise<void> {
  * Intended to be called by a periodic cleanup job.
  */
 export async function pruneExpiredFamilies(): Promise<{ deleted: number }> {
-  const cutoff = new Date(
-    Date.now() - FAMILY_TTL_DAYS * 24 * 60 * 60 * 1000
-  );
+  const cutoff = new Date(Date.now() - FAMILY_TTL_DAYS * 24 * 60 * 60 * 1000);
   const result = await (prisma as any).refreshToken.deleteMany({
     where: { expiresAt: { lt: cutoff } },
   });

--- a/backend/src/auth/token.service.edge-cases.spec.ts
+++ b/backend/src/auth/token.service.edge-cases.spec.ts
@@ -184,7 +184,8 @@ describe("Issue #1066: JWT expiry, clock-skew, and tampering edge cases", () => 
 
       // Tamper with the signature
       const parts = validToken.split(".");
-      const tamperedSignature = Buffer.from("tampered-signature").toString("base64url");
+      const tamperedSignature =
+        Buffer.from("tampered-signature").toString("base64url");
       const tamperedToken = `${parts[0]}.${parts[1]}.${tamperedSignature}`;
 
       expect(() => {

--- a/backend/src/auth/token.service.ts
+++ b/backend/src/auth/token.service.ts
@@ -2,19 +2,36 @@ import { Injectable, Logger, UnauthorizedException } from "@nestjs/common";
 import { JwtService } from "@nestjs/jwt";
 import { ConfigService } from "@nestjs/config";
 import { v4 as uuidv4 } from "uuid";
+import Redis from "ioredis";
 import { AUTH_CONSTANTS } from "../auth.constants";
 import { AuthResponseDto, JwtPayloadDto } from "./dto/auth.dto";
+
+const REVOKED_JTI_PREFIX = "revoked_jti:";
 
 @Injectable()
 export class TokenService {
   private readonly logger = new Logger(TokenService.name);
-  // In production store revoked JTIs in Redis with TTL
-  private readonly revokedTokens = new Set<string>();
+  private readonly redis: Redis;
+  // Fallback in-memory store for local/test environments when Redis is unavailable
+  private readonly revokedTokensLocal = new Set<string>();
+  private readonly useRedis: boolean;
 
   constructor(
     private readonly jwtService: JwtService,
-    private readonly configService: ConfigService
-  ) {}
+    private readonly configService: ConfigService,
+    redisClient?: Redis
+  ) {
+    this.redis =
+      redisClient ??
+      new Redis({
+        host: process.env.REDIS_HOST ?? "localhost",
+        port: Number(process.env.REDIS_PORT ?? 6379),
+        password: process.env.REDIS_PASSWORD,
+        lazyConnect: true,
+      });
+    // Use Redis if REDIS_URL is configured (indicates production)
+    this.useRedis = Boolean(process.env.REDIS_URL);
+  }
 
   generateTokenPair(walletAddress: string): AuthResponseDto {
     const jti = uuidv4();
@@ -52,7 +69,7 @@ export class TokenService {
     };
   }
 
-  verifyAccessToken(token: string): JwtPayloadDto {
+  async verifyAccessToken(token: string): Promise<JwtPayloadDto> {
     try {
       const payload = this.jwtService.verify<JwtPayloadDto>(token, {
         secret: this.configService.get<string>("JWT_ACCESS_SECRET"),
@@ -62,7 +79,7 @@ export class TokenService {
         throw new UnauthorizedException("Invalid token type");
       }
 
-      if (payload.jti && this.revokedTokens.has(payload.jti)) {
+      if (payload.jti && (await this.isRevoked(payload.jti))) {
         throw new UnauthorizedException("Token has been revoked");
       }
 
@@ -75,7 +92,7 @@ export class TokenService {
     }
   }
 
-  verifyRefreshToken(token: string): JwtPayloadDto {
+  async verifyRefreshToken(token: string): Promise<JwtPayloadDto> {
     try {
       const payload = this.jwtService.verify<JwtPayloadDto>(token, {
         secret: this.configService.get<string>("JWT_REFRESH_SECRET"),
@@ -85,7 +102,7 @@ export class TokenService {
         throw new UnauthorizedException("Invalid token type");
       }
 
-      if (payload.jti && this.revokedTokens.has(payload.jti)) {
+      if (payload.jti && (await this.isRevoked(payload.jti))) {
         throw new UnauthorizedException("Refresh token has been revoked");
       }
 
@@ -98,12 +115,46 @@ export class TokenService {
     }
   }
 
-  revokeToken(jti: string): void {
-    this.revokedTokens.add(jti);
-    this.logger.log(`Token revoked: ${jti}`);
+  async revokeToken(jti: string): Promise<void> {
+    try {
+      if (this.useRedis) {
+        // Store in Redis with TTL matching the max token lifetime (15 min for access, 7d for refresh)
+        // Use a conservative TTL of 7 days for refresh tokens
+        const ttlSeconds = 7 * 24 * 60 * 60;
+        await this.redis.set(
+          `${REVOKED_JTI_PREFIX}${jti}`,
+          "1",
+          "EX",
+          ttlSeconds
+        );
+      } else {
+        // Fallback to local store for testing/development
+        this.revokedTokensLocal.add(jti);
+      }
+      this.logger.log(`Token revoked: ${jti}`);
+    } catch (err) {
+      this.logger.error(
+        `Failed to revoke token ${jti} in Redis: ${(err as Error).message} — falling back to local store`
+      );
+      // Fallback: still record locally so this instance honors the revocation
+      this.revokedTokensLocal.add(jti);
+    }
   }
 
-  isRevoked(jti: string): boolean {
-    return this.revokedTokens.has(jti);
+  async isRevoked(jti: string): Promise<boolean> {
+    try {
+      if (this.useRedis) {
+        const exists = await this.redis.exists(`${REVOKED_JTI_PREFIX}${jti}`);
+        return exists === 1;
+      } else {
+        return this.revokedTokensLocal.has(jti);
+      }
+    } catch (err) {
+      this.logger.error(
+        `Failed to check revocation status for ${jti} in Redis: ${(err as Error).message}`
+      );
+      // Fail-safe: assume revoked if Redis is down (safer than allowing potentially compromised tokens)
+      return true;
+    }
   }
 }


### PR DESCRIPTION
## Summary

This PR fixes four critical authentication and authorization security issues discovered in the backend authentication services.

## Issues Fixed

**#1838 - Unawaited Redis Write in NonceService.generateNonce**
- Made `generateNonce()` async and await the Redis write
- Now throws explicit error on Redis failure instead of returning dead-on-arrival nonce
- Prevents generic "Invalid or expired nonce" errors that mask actual infrastructure issues

**#1839 - Concurrent-Rotation Race in rotateTokenFamily**
- Replaced separate findUnique + update with atomic updateMany with conditional WHERE clause
- Ensures only one refresh succeeds when two concurrent requests use the same token
- Prevents token duplication and enforces reuse-detection design

**#1840 - Credentialed-Wildcard CORS Bug**
- Added check to throw error if wildcard '*' combined with credentials: true
- Prevents any origin from making authenticated cross-origin requests
- Requires explicit origin list instead of dangerous wildcard config

**#1841 - Per-Instance JWT Revocation Gap**
- Moved revoked JTI tracking from in-memory Set to Redis-backed store
- Makes token revocation visible across all backend instances
- Follows same Redis-with-TTL pattern as NonceService for consistency
- Includes fallback to local store for test/development environments

## Test Plan

- [x] Type checking passes (tsc)
- [x] Format checking passes (prettier)
- [x] All modified auth services compile without errors
- [ ] Run full test suite (`npm test -- --run`) to verify no regressions
- [ ] Verify CI/CD workflow checks pass

Closes #1838
Closes #1839
Closes #1840
Closes #1841