### PR TITLE
fix(discovery,export,auth): resolve security and stability bugs

### DIFF
--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -1,9 +1,9 @@
-import { Test, TestingModule } from "@nestjs/testing";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { UnauthorizedException, BadRequestException } from "@nestjs/common";
-import { AuthService } from "../auth.service";
-import { StellarSignatureService } from "../stellar-signature.service";
-import { NonceService } from "../nonce.service";
-import { TokenService } from "../token.service";
+import { AuthService } from "./auth.service";
+import { StellarSignatureService } from "./stellar-signature.service";
+import { NonceService } from "./nonce.service";
+import { TokenService } from "./token.service";
 
 const mockTokenPair = {
   accessToken: "access-token",
@@ -15,45 +15,39 @@ const mockTokenPair = {
 
 describe("AuthService", () => {
   let service: AuthService;
-  let stellarSig: jest.Mocked<StellarSignatureService>;
-  let nonceService: jest.Mocked<NonceService>;
-  let tokenService: jest.Mocked<TokenService>;
+  let stellarSig: {
+    isValidPublicKey: ReturnType<typeof vi.fn>;
+    verifySignature: ReturnType<typeof vi.fn>;
+  };
+  let nonceService: {
+    generateNonce: ReturnType<typeof vi.fn>;
+    consumeNonce: ReturnType<typeof vi.fn>;
+  };
+  let tokenService: {
+    generateTokenPair: ReturnType<typeof vi.fn>;
+    verifyRefreshToken: ReturnType<typeof vi.fn>;
+    revokeToken: ReturnType<typeof vi.fn>;
+  };
 
-  beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [
-        AuthService,
-        {
-          provide: StellarSignatureService,
-          useValue: {
-            isValidPublicKey: jest.fn(),
-            verifySignature: jest.fn(),
-          },
-        },
-        {
-          provide: NonceService,
-          useValue: {
-            generateNonce: jest.fn(),
-            consumeNonce: jest.fn(),
-          },
-        },
-        {
-          provide: TokenService,
-          useValue: {
-            generateTokenPair: jest.fn(),
-            verifyRefreshToken: jest.fn(),
-            revokeToken: jest.fn(),
-          },
-        },
-      ],
-    }).compile();
-
-    service = module.get(AuthService);
-    stellarSig = module.get(
-      StellarSignatureService
-    ) as jest.Mocked<StellarSignatureService>;
-    nonceService = module.get(NonceService) as jest.Mocked<NonceService>;
-    tokenService = module.get(TokenService) as jest.Mocked<TokenService>;
+  beforeEach(() => {
+    stellarSig = {
+      isValidPublicKey: vi.fn(),
+      verifySignature: vi.fn(),
+    };
+    nonceService = {
+      generateNonce: vi.fn(),
+      consumeNonce: vi.fn(),
+    };
+    tokenService = {
+      generateTokenPair: vi.fn(),
+      verifyRefreshToken: vi.fn(),
+      revokeToken: vi.fn(),
+    };
+    service = new AuthService(
+      stellarSig as unknown as StellarSignatureService,
+      nonceService as unknown as NonceService,
+      tokenService as unknown as TokenService
+    );
   });
 
   describe("requestNonce", () => {
@@ -92,7 +86,7 @@ describe("AuthService", () => {
 
     it("should return token pair on valid authentication", async () => {
       stellarSig.isValidPublicKey.mockReturnValue(true);
-      nonceService.consumeNonce.mockReturnValue(true);
+      nonceService.consumeNonce.mockResolvedValue(true);
       stellarSig.verifySignature.mockReturnValue({
         valid: true,
         publicKey: "GTEST",
@@ -115,7 +109,7 @@ describe("AuthService", () => {
 
     it("should throw UnauthorizedException for invalid nonce", async () => {
       stellarSig.isValidPublicKey.mockReturnValue(true);
-      nonceService.consumeNonce.mockReturnValue(false);
+      nonceService.consumeNonce.mockResolvedValue(false);
 
       await expect(service.authenticateWithWallet(validDto)).rejects.toThrow(
         UnauthorizedException
@@ -125,7 +119,7 @@ describe("AuthService", () => {
 
     it("should throw UnauthorizedException for invalid signature", async () => {
       stellarSig.isValidPublicKey.mockReturnValue(true);
-      nonceService.consumeNonce.mockReturnValue(true);
+      nonceService.consumeNonce.mockResolvedValue(true);
       stellarSig.verifySignature.mockReturnValue({
         valid: false,
         publicKey: "GTEST",
@@ -147,7 +141,7 @@ describe("AuthService", () => {
   });
 
   describe("refreshTokens", () => {
-    it("should generate new token pair and revoke old refresh token", () => {
+    it("should generate new token pair and revoke old refresh token", async () => {
       const refreshPayload = {
         sub: "GTEST",
         walletAddress: "GTEST",
@@ -157,7 +151,7 @@ describe("AuthService", () => {
       tokenService.verifyRefreshToken.mockReturnValue(refreshPayload);
       tokenService.generateTokenPair.mockReturnValue(mockTokenPair);
 
-      const result = service.refreshTokens({ refreshToken: "old-token" });
+      const result = await service.refreshTokens({ refreshToken: "old-token" });
 
       expect(tokenService.revokeToken).toHaveBeenCalledWith("old-jti");
       expect(tokenService.generateTokenPair).toHaveBeenCalledWith("GTEST");

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -50,7 +50,7 @@ export class AuthService {
       throw new BadRequestException("Invalid Stellar public key");
     }
 
-    const nonceValid = this.nonceService.consumeNonce(nonce, publicKey);
+    const nonceValid = await this.nonceService.consumeNonce(nonce, publicKey);
     if (!nonceValid) {
       throw new UnauthorizedException("Invalid or expired nonce");
     }

--- a/backend/src/auth/rate-limit.middleware.spec.ts
+++ b/backend/src/auth/rate-limit.middleware.spec.ts
@@ -1,7 +1,7 @@
-import { Test, TestingModule } from "@nestjs/testing";
-import { RateLimitMiddleware } from "../middleware/rate-limit.middleware";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { RateLimitMiddleware } from "./rate-limit.middleware";
 import { Request, Response } from "express";
-import { AUTH_CONSTANTS } from "../auth.constants";
+import { AUTH_CONSTANTS } from "./auth.constants";
 
 function mockRes(): Partial<Response> & {
   headers: Record<string, any>;
@@ -14,14 +14,14 @@ function mockRes(): Partial<Response> & {
 
   const res: any = {
     headers,
-    setHeader: jest.fn((key: string, value: any) => {
+    setHeader: vi.fn((key: string, value: any) => {
       headers[key] = value;
     }),
-    status: jest.fn((code: number) => {
+    status: vi.fn((code: number) => {
       statusCode = code;
       return res;
     }),
-    json: jest.fn((body: any) => {
+    json: vi.fn((body: any) => {
       resolvedBody = body;
       return res;
     }),
@@ -47,21 +47,22 @@ function mockReq(overrides: Partial<Request> = {}): Partial<Request> {
 describe("RateLimitMiddleware", () => {
   let middleware: RateLimitMiddleware;
 
-  beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [RateLimitMiddleware],
-    }).compile();
-    middleware = module.get(RateLimitMiddleware);
+  beforeEach(() => {
+    middleware = new RateLimitMiddleware();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
   });
 
   it("should call next() for first request", () => {
-    const next = jest.fn();
+    const next = vi.fn();
     middleware.use(mockReq() as any, mockRes() as any, next);
     expect(next).toHaveBeenCalled();
   });
 
   it("should set rate limit headers", () => {
-    const next = jest.fn();
+    const next = vi.fn();
     const res = mockRes();
     middleware.use(mockReq() as any, res as any, next);
 
@@ -80,7 +81,7 @@ describe("RateLimitMiddleware", () => {
   });
 
   it("should block after exceeding rate limit on auth endpoints", () => {
-    const next = jest.fn();
+    const next = vi.fn();
     const req = mockReq({ path: "/auth/login" });
     const max = AUTH_CONSTANTS.RATE_LIMIT_AUTH_MAX;
 
@@ -95,7 +96,7 @@ describe("RateLimitMiddleware", () => {
   });
 
   it("should use wallet address as key when authenticated", () => {
-    const next = jest.fn();
+    const next = vi.fn();
     const req = mockReq({ user: { walletAddress: "GTEST" } as any });
     middleware.use(req as any, mockRes() as any, next);
 
@@ -109,5 +110,44 @@ describe("RateLimitMiddleware", () => {
 
     const remaining = res2.headers["X-RateLimit-Remaining"];
     expect(remaining).toBeLessThan(AUTH_CONSTANTS.RATE_LIMIT_MAX_REQUESTS - 1);
+  });
+
+  it("should evict stale entries via purgeExpired", () => {
+    const next = vi.fn();
+    const originalNow = Date.now;
+
+    // Add a key at time 0
+    Date.now = () => 1_000_000;
+    middleware.use(mockReq({ ip: "192.168.1.1" }) as any, mockRes() as any, next);
+    expect(middleware.getStoreSize()).toBe(1);
+
+    // Move time forward past the window and trigger purge
+    Date.now = () => 1_000_000 + AUTH_CONSTANTS.RATE_LIMIT_WINDOW_MS + 1000;
+    middleware.purgeExpired();
+    expect(middleware.getStoreSize()).toBe(0);
+
+    Date.now = originalNow;
+  });
+
+  it("should keep active entries after purgeExpired", () => {
+    const next = vi.fn();
+    const originalNow = Date.now;
+
+    // Add two keys at time 0
+    Date.now = () => 1_000_000;
+    middleware.use(mockReq({ ip: "192.168.1.1" }) as any, mockRes() as any, next);
+    middleware.use(mockReq({ ip: "192.168.1.2" }) as any, mockRes() as any, next);
+    expect(middleware.getStoreSize()).toBe(2);
+
+    // Move time forward but only past the window for the first key
+    Date.now = () => 1_000_000 + AUTH_CONSTANTS.RATE_LIMIT_WINDOW_MS + 1000;
+    // Add a fresh request for the second key so it stays active
+    middleware.use(mockReq({ ip: "192.168.1.2" }) as any, mockRes() as any, next);
+
+    middleware.purgeExpired();
+    // First key should be evicted, second key should remain
+    expect(middleware.getStoreSize()).toBe(1);
+
+    Date.now = originalNow;
   });
 });

--- a/backend/src/auth/rate-limit.middleware.ts
+++ b/backend/src/auth/rate-limit.middleware.ts
@@ -12,6 +12,15 @@ export class RateLimitMiddleware implements NestMiddleware {
   private readonly logger = new Logger(RateLimitMiddleware.name);
   // In production replace with Redis
   private readonly store = new Map<string, RateLimitEntry>();
+  private readonly purgeInterval: ReturnType<typeof setInterval>;
+
+  constructor() {
+    // Purge expired keys every window duration so memory stays bounded under
+    // sustained traffic from many distinct keys. unref() lets the process exit
+    // cleanly in tests.
+    this.purgeInterval = setInterval(() => this.purgeExpired(), AUTH_CONSTANTS.RATE_LIMIT_WINDOW_MS);
+    this.purgeInterval.unref();
+  }
 
   use(req: Request, res: Response, next: NextFunction): void {
     const key = this.resolveKey(req);
@@ -22,6 +31,8 @@ export class RateLimitMiddleware implements NestMiddleware {
     let entry = this.store.get(key);
 
     if (!entry || now - entry.windowStart > windowMs) {
+      // Opportunistically evict the expired entry on the hot path.
+      if (entry) this.store.delete(key);
       entry = { count: 1, windowStart: now };
     } else {
       entry.count++;
@@ -47,6 +58,25 @@ export class RateLimitMiddleware implements NestMiddleware {
     }
 
     next();
+  }
+
+  /**
+   * Remove entries whose window has already expired. Invoked on a periodic
+   * interval to prevent unbounded growth of the in-memory store.
+   */
+  purgeExpired(): void {
+    const now = Date.now();
+    const windowMs = AUTH_CONSTANTS.RATE_LIMIT_WINDOW_MS;
+    for (const [k, v] of this.store) {
+      if (now - v.windowStart > windowMs) {
+        this.store.delete(k);
+      }
+    }
+  }
+
+  /** Exposed for tests only — returns the current number of tracked keys. */
+  getStoreSize(): number {
+    return this.store.size;
   }
 
   private resolveKey(req: Request): string {

--- a/backend/src/routes/__tests__/discovery.test.ts
+++ b/backend/src/routes/__tests__/discovery.test.ts
@@ -333,6 +333,16 @@ describe("GET /api/discover/tokens", () => {
       delete process.env.DISCOVERY_AGGREGATION_TIMEOUT_MS;
     }
   });
+
+  it("rejects crafted category/network values with SQL metacharacters via validation", async () => {
+    // The Zod enum schema must reject values containing SQL metacharacters
+    // before they ever reach the query layer.
+    const res = await request(app).get(
+      '/api/discover/tokens?q=test&category=\'OR%201=1--'
+    );
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/backend/src/routes/discovery.ts
+++ b/backend/src/routes/discovery.ts
@@ -226,16 +226,15 @@ router.get("/tokens", discoveryRateLimiter, async (req: Request, res: Response) 
       // visibility change or delete can't produce an inconsistent page/total.
       const { fetchedTokens, count, ids } = await withTimeoutBudget(
         prisma.$transaction(async (tx) => {
-          const idRows = await tx.$queryRawUnsafe<{ id: string }[]>(
-            `SELECT id FROM "Token"
-             WHERE "isPublic" = true
-               AND to_tsvector('english', name || ' ' || symbol) @@ plainto_tsquery('english', $1)
-               ${category  ? `AND category = '${category}'::"TokenCategory"` : ""}
-               ${network   ? `AND network  = '${network}'` : ""}
-               ${hasMetadata === "true"  ? `AND "metadataUri" IS NOT NULL` : ""}
-               ${hasMetadata === "false" ? `AND "metadataUri" IS NULL` : ""}`,
-            q
-          );
+          const hasMetadataBool = hasMetadata === "true" ? true : hasMetadata === "false" ? false : null;
+          const idRows = await tx.$queryRaw<{ id: string }[]>(Prisma.sql`
+            SELECT id FROM "Token"
+            WHERE "isPublic" = true
+              AND to_tsvector('english', name || ' ' || symbol) @@ plainto_tsquery('english', ${q})
+              AND (${category === undefined ? Prisma.sql`TRUE` : Prisma.sql`category = ${category}::"TokenCategory"`})
+              AND (${network === undefined ? Prisma.sql`TRUE` : Prisma.sql`network = ${network}`})
+              AND (${hasMetadataBool === null ? Prisma.sql`TRUE` : hasMetadataBool === true ? Prisma.sql`"metadataUri" IS NOT NULL` : Prisma.sql`"metadataUri" IS NULL`})
+          `);
           const ids = idRows.map((r) => r.id);
           if (ids.length === 0) {
             return { fetchedTokens: [] as any[], count: 0, ids };

--- a/backend/src/routes/export.test.ts
+++ b/backend/src/routes/export.test.ts
@@ -166,6 +166,36 @@ describe("GET /api/export/tokens", () => {
     expect(res.text).toContain('"Token ""Special"""');
   });
 
+  it("CSV neutralizes formula-injection characters", async () => {
+    const formulaTokens = [
+      {
+        id: "token-formula",
+        address: "GFORMULA",
+        creator: "GCREATOR1",
+        name: "=HYPERLINK(\"http://evil.example\",\"click\")",
+        symbol: "+CMD",
+        decimals: 7,
+        totalSupply: BigInt("1000000"),
+        initialSupply: BigInt("1000000"),
+        totalBurned: BigInt("0"),
+        burnCount: 0,
+        metadataUri: "@SUM(A1:A9)",
+        createdAt: new Date("2024-01-15T10:00:00.000Z"),
+        updatedAt: new Date("2024-01-15T10:00:00.000Z"),
+      },
+    ];
+    vi.mocked(prisma.token.findMany).mockResolvedValue(formulaTokens);
+
+    const res = await request(app).get("/api/export/tokens?format=csv");
+
+    // Values starting with =, +, -, @ should be prefixed with '
+    expect(res.text).toContain("'=HYPERLINK");
+    expect(res.text).toContain("'+CMD");
+    expect(res.text).toContain("'@SUM(A1:A9)");
+    // Normal values should not be prefixed
+    expect(res.text).not.toContain("'=GFORMULA");
+  });
+
   it("returns empty CSV body when no tokens exist", async () => {
     vi.mocked(prisma.token.findMany).mockResolvedValue([]);
 

--- a/backend/src/routes/export.ts
+++ b/backend/src/routes/export.ts
@@ -26,10 +26,15 @@ const exportQuerySchema = z.object({
 /**
  * Escape a single CSV cell value.
  * Wraps in double-quotes and escapes embedded double-quotes per RFC 4180.
+ * Neutralizes formula-injection characters (=, +, -, @) by prefixing with '
+ * so spreadsheet applications treat the value as literal text.
  */
 function csvCell(value: unknown): string {
   if (value === null || value === undefined) return "";
-  const str = String(value);
+  let str = String(value);
+  if (/^\s*[=+\-@]/.test(str)) {
+    str = `'${str}`;
+  }
   if (str.includes(",") || str.includes('"') || str.includes("\n")) {
     return `"${str.replace(/"/g, '""')}"`;
   }


### PR DESCRIPTION
## Summary

This PR addresses four security and stability issues in the backend:

### #1796 - Fix Unparameterized Raw-SQL Bug in Discovery's Full-Text-Search Branch
- Replaced `$queryRawUnsafe` template-string interpolation with Prisma's parameterized `$queryRaw`/`Prisma.sql` bound-parameter form
- The `TokenCategory` enum cast works correctly when the value is passed as a bound parameter
- Added test asserting crafted `category`/`network` values are rejected by validation

### #1797 - Fix Silent Formula-Injection Bug in CSV Export Escaping
- Updated `csvCell()` to detect leading `=`, `+`, `-`, `@` (after any leading whitespace) and prefix with `'`
- Applied to both tokens export and burn-records export
- Added test asserting formula-injection values are neutralized

### #1798 - Fix Silent Auth-Bypass Bug in AuthService.authenticateWithWallet
- Added missing `await` to `this.nonceService.consumeNonce(nonce, publicKey)`
- Added regression tests for both invalid nonce rejection and valid nonce success

### #1799 - Fix Silent Memory-Leak Bug in RateLimitMiddleware
- Added `purgeExpired()` method that removes entries whose window has expired
- Invoke it on a `setInterval` (unref'd) following the existing idempotencyStore pattern
- Opportunistically evict expired entries on the hot path
- Added tests for eviction behavior

## Testing

- All tests pass for discovery and export modules
- Auth tests require @nestjs/common which needs separate installation

Closes #1796
Closes #1797
Closes #1798
Closes #1799