### PR TITLE
Fix unbacked value creation and enforcement gaps in vault, treasury, quorum, and compliance

### DIFF
--- a/contracts/token-factory/src/burn.rs
+++ b/contracts/token-factory/src/burn.rs
@@ -28,6 +28,20 @@ fn burn_inner(env: &Env, caller: &Address, token_index: u32, amount: i128) -> Re
         return Err(Error::TokenPaused);
     }
 
+    // Compliance gate (#1853): jurisdiction is derived from contract storage,
+    // never supplied by the caller.
+    let jurisdiction = storage::get_token_jurisdiction(env, &info.address);
+    crate::compliance_reporting::check_compliance(
+        env,
+        jurisdiction,
+        crate::compliance_reporting::TransferParams {
+            token_address: info.address.clone(),
+            from: caller.clone(),
+            to: caller.clone(),
+            amount,
+        },
+    )?;
+
     let balance = storage::get_balance(env, token_index, caller);
     if balance < amount {
         return Err(Error::InsufficientBalance);
@@ -103,6 +117,20 @@ fn admin_burn_inner(
     if storage::is_token_paused(env, token_index) {
         return Err(Error::TokenPaused);
     }
+
+    // Compliance gate (#1853): jurisdiction is derived from contract storage,
+    // never supplied by the caller.
+    let jurisdiction = storage::get_token_jurisdiction(env, &info.address);
+    crate::compliance_reporting::check_compliance(
+        env,
+        jurisdiction,
+        crate::compliance_reporting::TransferParams {
+            token_address: info.address.clone(),
+            from: holder.clone(),
+            to: holder.clone(),
+            amount,
+        },
+    )?;
 
     let balance = storage::get_balance(env, token_index, holder);
     if balance < amount {

--- a/contracts/token-factory/src/compliance_reporting.rs
+++ b/contracts/token-factory/src/compliance_reporting.rs
@@ -319,6 +319,41 @@ pub fn get_jurisdiction_rules(env: &Env, jurisdiction: &String) -> Vec<Complianc
         .unwrap_or_else(|| Vec::new(env))
 }
 
+/// Assign the compliance jurisdiction that `mint`/`burn`/`admin_burn` enforce
+/// rules against for `token_address` (admin only).
+///
+/// This is the sole way a token's jurisdiction is set — it is never left to
+/// the caller of a balance-mutating operation to supply arbitrarily.
+///
+/// # Errors
+/// * `Error::Unauthorized` – Caller is not the admin.
+/// * `Error::TokenNotFound` – `token_address` is not a registered token.
+pub fn set_token_jurisdiction(
+    env: &Env,
+    admin: &Address,
+    token_address: Address,
+    jurisdiction: String,
+) -> Result<(), Error> {
+    admin.require_auth();
+    let stored_admin = storage::get_admin(env).ok_or(Error::MissingAdmin)?;
+    if *admin != stored_admin {
+        return Err(Error::Unauthorized);
+    }
+
+    if storage::get_token_info_by_address(env, &token_address).is_none() {
+        return Err(Error::TokenNotFound);
+    }
+
+    storage::set_token_jurisdiction(env, &token_address, &jurisdiction);
+    Ok(())
+}
+
+/// Return the compliance jurisdiction currently assigned to `token_address`
+/// (the default jurisdiction if none has been explicitly assigned).
+pub fn get_token_jurisdiction(env: &Env, token_address: &Address) -> String {
+    storage::get_token_jurisdiction(env, token_address)
+}
+
 /// Evaluate every compliance rule registered for `jurisdiction` against
 /// `params`, emitting a `ComplianceCheckPassed`/`ComplianceCheckFailed` event
 /// and rejecting the transfer if any rule fails.
@@ -928,6 +963,115 @@ mod tests {
             check_compliance(&env, jurisdiction, params).unwrap();
         });
         assert_eq!(env.events().all().len(), before + 1);
+    }
+
+    // ── Enforcement on real token operations (#1853) ──────────────────────────
+
+    fn create_test_token(env: &Env, client: &TokenFactoryClient, creator: &Address) -> Address {
+        client.create_token(
+            creator,
+            &soroban_sdk::String::from_str(env, "Test"),
+            &soroban_sdk::String::from_str(env, "TST"),
+            &7u32,
+            &1_000_000i128,
+            &None,
+            &1_000_000i128,
+        )
+    }
+
+    /// A `TransfersSuspended` rule registered for a token's jurisdiction
+    /// actually blocks `mint`, not just the standalone `check_compliance` query.
+    #[test]
+    fn test_transfers_suspended_blocks_mint() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin, _contract_id) = setup(&env);
+
+        let token_address = create_test_token(&env, &client, &admin);
+        let token_index = 0u32;
+        let recipient = Address::generate(&env);
+
+        let jurisdiction =
+            soroban_sdk::String::from_str(&env, storage::DEFAULT_COMPLIANCE_JURISDICTION);
+        client.add_compliance_rule(&admin, &jurisdiction, &ComplianceRuleType::TransfersSuspended);
+
+        let balance_before = storage::get_balance(&env, token_index, &recipient);
+        let result = client.try_mint(&admin, &token_index, &recipient, &1_000i128);
+        assert_eq!(result, Err(Ok(Error::ComplianceCheckFailed)));
+
+        // No value moved: the rejected mint must not have mutated balances.
+        assert_eq!(storage::get_balance(&env, token_index, &recipient), balance_before);
+        let _ = token_address;
+    }
+
+    /// A `TransfersSuspended` rule registered for a token's jurisdiction
+    /// actually blocks `burn`, not just the standalone `check_compliance` query.
+    #[test]
+    fn test_transfers_suspended_blocks_burn() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin, _contract_id) = setup(&env);
+
+        create_test_token(&env, &client, &admin);
+        let token_index = 0u32;
+
+        let jurisdiction =
+            soroban_sdk::String::from_str(&env, storage::DEFAULT_COMPLIANCE_JURISDICTION);
+        client.add_compliance_rule(&admin, &jurisdiction, &ComplianceRuleType::TransfersSuspended);
+
+        let balance_before = storage::get_balance(&env, token_index, &admin);
+        let result = client.try_burn(&admin, &token_index, &100i128);
+        assert_eq!(result, Err(Ok(Error::ComplianceCheckFailed)));
+
+        // No value moved: the rejected burn must not have mutated balances/supply.
+        assert_eq!(storage::get_balance(&env, token_index, &admin), balance_before);
+    }
+
+    /// Mint succeeds normally once the blocking rule is removed, and a rule
+    /// registered under a *different* jurisdiction never affects this token.
+    #[test]
+    fn test_mint_unaffected_by_other_jurisdiction_rule() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin, _contract_id) = setup(&env);
+
+        create_test_token(&env, &client, &admin);
+        let token_index = 0u32;
+        let recipient = Address::generate(&env);
+
+        // A TransfersSuspended rule for an unrelated jurisdiction must not
+        // affect this token, which is assigned the default jurisdiction.
+        client.add_compliance_rule(
+            &admin,
+            &soroban_sdk::String::from_str(&env, "EU"),
+            &ComplianceRuleType::TransfersSuspended,
+        );
+
+        client.mint(&admin, &token_index, &recipient, &1_000i128);
+        assert_eq!(storage::get_balance(&env, token_index, &recipient), 1_000i128);
+    }
+
+    /// A `TransfersSuspended` rule registered for a token's jurisdiction
+    /// actually blocks `admin_burn` as well.
+    #[test]
+    fn test_transfers_suspended_blocks_admin_burn() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin, _contract_id) = setup(&env);
+
+        create_test_token(&env, &client, &admin);
+        let token_index = 0u32;
+
+        client.add_compliance_rule(
+            &admin,
+            &soroban_sdk::String::from_str(&env, storage::DEFAULT_COMPLIANCE_JURISDICTION),
+            &ComplianceRuleType::TransfersSuspended,
+        );
+
+        let balance_before = storage::get_balance(&env, token_index, &admin);
+        let result = client.try_admin_burn(&admin, &token_index, &admin, &100i128);
+        assert_eq!(result, Err(Ok(Error::ComplianceCheckFailed)));
+        assert_eq!(storage::get_balance(&env, token_index, &admin), balance_before);
     }
 }
 

--- a/contracts/token-factory/src/dynamic_quorum.rs
+++ b/contracts/token-factory/src/dynamic_quorum.rs
@@ -288,11 +288,12 @@ pub fn check_and_trigger_reactive_recalculation(
     let pct_change = ((supply_changed as u128 * 100) / last_supply.unsigned_abs() as u128) as u32;
 
     if pct_change >= threshold_pct {
-        // Trigger immediate recalculation by recording a fresh participation snapshot
-        // that uses the current governance config as the new baseline
-        let admin = storage::get_admin(env).ok_or(Error::MissingAdmin)?;
-        let _ = record_participation(env, &admin, env.ledger().sequence() as u64, 50, 100)?;
-
+        // A large supply movement is not a real voting-participation
+        // observation, so it must never be fed into `record_participation`
+        // (that would inject a fabricated data point into the average
+        // `compute_effective_quorum` blends over). Just emit the trigger
+        // signal — `compute_effective_quorum` still recalculates against
+        // the existing, untouched snapshot history on every call.
         emit_reactive_recalculation_triggered(env, event_id, pct_change);
     }
 
@@ -386,7 +387,7 @@ mod tests {
     use super::*;
     use crate::{TokenFactory, TokenFactoryClient};
     use proptest::prelude::*;
-    use soroban_sdk::{testutils::Address as _, Address, Env};
+    use soroban_sdk::{testutils::Address as _, Address, Env, FromVal, Symbol};
 
     fn setup(env: &Env) -> (TokenFactoryClient, Address, Address) {
         let contract_id = env.register_contract(None, TokenFactory);
@@ -731,13 +732,52 @@ mod tests {
         let new_supply = (initial_supply as f64 * 1.15) as i128;
         let before_count = env.as_contract(&contract_id, || get_snapshot_count(&env));
 
+        let events_before = env.events().all().len();
         env.as_contract(&contract_id, || {
             check_and_trigger_reactive_recalculation(&env, 2, new_supply).unwrap()
         });
 
         let after_count = env.as_contract(&contract_id, || get_snapshot_count(&env));
-        // Should have recorded a new participation snapshot due to reactive trigger
-        assert!(after_count > before_count);
+        // The reactive trigger must NOT fabricate a participation snapshot (#1852).
+        assert_eq!(after_count, before_count);
+
+        // It still emits a distinct signal event for observers.
+        let events = env.events().all();
+        assert_eq!(events.len(), events_before + 1);
+        let (_contract, topics, _data) = events.get(events.len() - 1).unwrap();
+        let event_name = Symbol::from_val(&env, &topics.get(0).unwrap());
+        assert_eq!(event_name, symbol_short!("qrm_trig"));
+    }
+
+    #[test]
+    fn test_reactive_recalculation_does_not_skew_effective_quorum() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (_, admin, contract_id) = setup(&env);
+
+        let initial_supply = 100_000_000i128;
+        env.as_contract(&contract_id, || {
+            set_supply_change_threshold(&env, &admin, 10).unwrap()
+        });
+        env.as_contract(&contract_id, || {
+            check_and_trigger_reactive_recalculation(&env, 1, initial_supply).unwrap()
+        });
+
+        // No real participation snapshots exist yet, so the effective quorum
+        // is just the clamped base quorum.
+        let before = env.as_contract(&contract_id, || compute_effective_quorum(&env));
+
+        // Trigger a large (>10%) supply change.
+        let new_supply = (initial_supply as f64 * 1.5) as i128;
+        env.as_contract(&contract_id, || {
+            check_and_trigger_reactive_recalculation(&env, 2, new_supply).unwrap()
+        });
+
+        // The fabricated 50% participation point must not have been injected:
+        // the effective quorum is unaffected by the trigger.
+        let after = env.as_contract(&contract_id, || compute_effective_quorum(&env));
+        assert_eq!(before, after);
+        assert_eq!(env.as_contract(&contract_id, || get_snapshot_count(&env)), 0);
     }
 
     #[test]

--- a/contracts/token-factory/src/lib.rs
+++ b/contracts/token-factory/src/lib.rs
@@ -4080,6 +4080,27 @@ impl TokenFactory {
         compliance_reporting::get_jurisdiction_rules(&env, &jurisdiction)
     }
 
+    /// Assign the compliance jurisdiction that `mint`/`burn`/`admin_burn`
+    /// enforce rules against for `token_address` (admin only).
+    ///
+    /// # Errors
+    /// * `Error::Unauthorized`  – Caller is not the admin.
+    /// * `Error::TokenNotFound` – `token_address` is not a registered token.
+    pub fn set_token_jurisdiction(
+        env: Env,
+        admin: Address,
+        token_address: Address,
+        jurisdiction: soroban_sdk::String,
+    ) -> Result<(), Error> {
+        compliance_reporting::set_token_jurisdiction(&env, &admin, token_address, jurisdiction)
+    }
+
+    /// Return the compliance jurisdiction currently assigned to `token_address`
+    /// (the default jurisdiction if none has been explicitly assigned).
+    pub fn get_token_jurisdiction(env: Env, token_address: Address) -> soroban_sdk::String {
+        compliance_reporting::get_token_jurisdiction(&env, &token_address)
+    }
+
     // ═══════════════════════════════════════════════════════
     //  Multi-Signature Admin Operations
     // ═══════════════════════════════════════════════════════

--- a/contracts/token-factory/src/mint.rs
+++ b/contracts/token-factory/src/mint.rs
@@ -107,6 +107,22 @@ pub fn mint(env: &Env, token_index: u32, to: &Address, amount: i128) -> Result<(
     // Get token info
     let mut token_info = storage::get_token_info(env, token_index).ok_or(Error::TokenNotFound)?;
 
+    // Compliance gate (#1853): reject the mint if a registered rule (e.g.
+    // TransfersSuspended) rejects it for this token's jurisdiction. The
+    // jurisdiction is derived from contract storage, never supplied by the
+    // caller.
+    let jurisdiction = storage::get_token_jurisdiction(env, &token_info.address);
+    crate::compliance_reporting::check_compliance(
+        env,
+        jurisdiction,
+        crate::compliance_reporting::TransferParams {
+            token_address: token_info.address.clone(),
+            from: to.clone(),
+            to: to.clone(),
+            amount,
+        },
+    )?;
+
     // Validate max supply constraint
     validate_max_supply(token_info.total_supply, amount, token_info.max_supply)?;
 

--- a/contracts/token-factory/src/storage.rs
+++ b/contracts/token-factory/src/storage.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{Address, Env, Vec};
+use soroban_sdk::{Address, Env, String, Vec};
 
 use crate::commit_reveal::{CommitRecord, CommitRevealSession};
 use crate::types::{
@@ -1603,6 +1603,34 @@ pub fn get_freeze_cooldown(env: &Env, token_address: &Address) -> u64 {
         .persistent()
         .get(&crate::types::DataKey::FreezeCooldown(token_address.clone()))
         .unwrap_or(0)
+}
+
+// ============================================================
+// Storage Functions - Compliance Jurisdiction (#1853)
+// ============================================================
+
+/// Jurisdiction code assigned to a token that hasn't had one explicitly set.
+pub const DEFAULT_COMPLIANCE_JURISDICTION: &str = "GLOBAL";
+
+/// Return the compliance jurisdiction assigned to `token_address`.
+///
+/// Falls back to [`DEFAULT_COMPLIANCE_JURISDICTION`] when no jurisdiction has
+/// been explicitly assigned, so this always returns a deterministic,
+/// contract-derived value rather than something a caller supplies.
+pub fn get_token_jurisdiction(env: &Env, token_address: &Address) -> String {
+    env.storage()
+        .persistent()
+        .get(&DataKey::TokenJurisdiction(token_address.clone()))
+        .unwrap_or_else(|| String::from_str(env, DEFAULT_COMPLIANCE_JURISDICTION))
+}
+
+/// Assign a compliance jurisdiction to `token_address` (admin only; see
+/// `compliance_reporting::set_token_jurisdiction` for the authorized entry point).
+pub fn set_token_jurisdiction(env: &Env, token_address: &Address, jurisdiction: &String) {
+    env.storage().persistent().set(
+        &DataKey::TokenJurisdiction(token_address.clone()),
+        jurisdiction,
+    );
 }
 
 // ── Governance storage functions ───────────────────────────

--- a/contracts/token-factory/src/treasury.rs
+++ b/contracts/token-factory/src/treasury.rs
@@ -1,6 +1,6 @@
 use crate::storage;
 use crate::types::{Error, TreasuryPolicy, WithdrawalPeriod};
-use soroban_sdk::{Address, Env};
+use soroban_sdk::{token, Address, Env};
 
 /// Default daily withdrawal cap (100 XLM in stroops)
 const DEFAULT_DAILY_CAP: i128 = 100_0000000;
@@ -185,6 +185,13 @@ pub fn withdraw_fees(
     // Record withdrawal
     record_withdrawal(env, amount)?;
 
+    // Actually move the funds: fee income is collected in the same
+    // `fee_token` used by `token_creation.rs`, and accumulates in this
+    // contract's own custody, so pay it out from there.
+    let fee_token = storage::get_fee_token(env).ok_or(Error::MissingTreasury)?;
+    let token_client = token::Client::new(env, &fee_token);
+    token_client.transfer(&env.current_contract_address(), recipient, &amount);
+
     // Emit event
     crate::events::emit_treasury_withdrawal(env, recipient, amount);
 
@@ -321,6 +328,7 @@ mod tests {
     use super::*;
     use soroban_sdk::{
         testutils::{Address as _, Ledger},
+        token::StellarAssetClient,
         Env,
     };
 
@@ -522,27 +530,75 @@ mod tests {
         assert!(policy.allowlist_enabled);
     }
 
+    /// Registers a real Stellar Asset Contract as the treasury's fee token and
+    /// mints `amount` of it into the factory contract's own custody, so
+    /// `withdraw_fees` exercises a genuine token transfer.
+    fn fund_treasury(env: &Env, contract_id: &Address, amount: i128) -> Address {
+        let token_admin = Address::generate(env);
+        let token = env.register_stellar_asset_contract_v2(token_admin).address();
+        env.as_contract(contract_id, || {
+            storage::set_fee_token(env, &token);
+        });
+        StellarAssetClient::new(env, &token).mint(contract_id, &amount);
+        token
+    }
+
     #[test]
     fn test_withdraw_fees_full_flow() {
         let (env, admin, contract_id) = setup();
         let recipient = Address::generate(&env);
+        let token = fund_treasury(&env, &contract_id, 100_0000000);
+        let token_client = token::Client::new(&env, &token);
 
         // First withdrawal
         env.as_contract(&contract_id, || {
             withdraw_fees(&env, &admin, &recipient, 40_0000000).unwrap();
         });
         assert_eq!(env.as_contract(&contract_id, || get_remaining_capacity(&env)), 60_0000000);
+        assert_eq!(token_client.balance(&recipient), 40_0000000);
 
         // Second withdrawal
         env.as_contract(&contract_id, || {
             withdraw_fees(&env, &admin, &recipient, 30_0000000).unwrap();
         });
         assert_eq!(env.as_contract(&contract_id, || get_remaining_capacity(&env)), 30_0000000);
+        assert_eq!(token_client.balance(&recipient), 70_0000000);
 
         // Third withdrawal should fail (would exceed cap)
         let result =
             env.as_contract(&contract_id, || withdraw_fees(&env, &admin, &recipient, 40_0000000));
         assert_eq!(result, Err(Error::WithdrawalCapExceeded));
+        // Balance must be unaffected by the rejected withdrawal.
+        assert_eq!(token_client.balance(&recipient), 70_0000000);
+    }
+
+    #[test]
+    fn test_withdraw_fees_credits_recipient_balance() {
+        let (env, admin, contract_id) = setup();
+        let recipient = Address::generate(&env);
+        let token = fund_treasury(&env, &contract_id, 50_0000000);
+        let token_client = token::Client::new(&env, &token);
+
+        assert_eq!(token_client.balance(&recipient), 0);
+
+        env.as_contract(&contract_id, || {
+            withdraw_fees(&env, &admin, &recipient, 25_0000000).unwrap();
+        });
+
+        assert_eq!(token_client.balance(&recipient), 25_0000000);
+        assert_eq!(token_client.balance(&contract_id), 25_0000000);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_withdraw_fees_without_fee_token_configured_fails() {
+        let (env, admin, contract_id) = setup();
+        let recipient = Address::generate(&env);
+
+        // No fee token has been configured and the contract holds no funds.
+        env.as_contract(&contract_id, || {
+            withdraw_fees(&env, &admin, &recipient, 10_0000000).unwrap();
+        });
     }
 
     #[test]

--- a/contracts/token-factory/src/types.rs
+++ b/contracts/token-factory/src/types.rs
@@ -1003,6 +1003,9 @@ pub enum DataKey {
     NextStakingPoolId,
     /// A user's stake within a pool: (pool_id, staker) → StakeInfo
     UserStake(u64, Address),
+    /// Compliance jurisdiction assigned to a token, keyed by token address.
+    /// Falls back to a default jurisdiction when unset (#1853).
+    TokenJurisdiction(Address),
 }
 
 /// A point-in-time record of a token holder's balance.

--- a/contracts/token-factory/src/vault.rs
+++ b/contracts/token-factory/src/vault.rs
@@ -6,7 +6,7 @@ use crate::{
     storage,
     types::{Error, VaultStatus},
 };
-use soroban_sdk::{symbol_short, Address, Env};
+use soroban_sdk::{symbol_short, token, Address, Env};
 
 // ── Circuit breaker public API ────────────────────────────────────────────────
 
@@ -97,11 +97,21 @@ pub fn fund_vault(env: &Env, vault_id: u64, funder: &Address, amount: i128) -> R
         return Err(Error::InvalidParameters);
     }
 
-    vault.total_amount = vault
+    let new_total = vault
         .total_amount
         .checked_add(amount)
         .ok_or(Error::ArithmeticError)?;
 
+    // Escrow the funder's tokens into contract custody before persisting the
+    // new total: if the transfer fails (insufficient balance/allowance), the
+    // whole call aborts and `total_amount` is left untouched. This mirrors
+    // the real-value-transfer pattern in `bridge.rs::lock_tokens` and
+    // `fractionalization.rs::fractionalize`, and matches how `claim_vault`
+    // later pays out `vault.token` from contract custody.
+    let token_client = token::Client::new(env, &vault.token);
+    token_client.transfer(funder, &env.current_contract_address(), &amount);
+
+    vault.total_amount = new_total;
     storage::set_vault(env, &vault)?;
     emit_vault_funded(env, vault_id, funder, amount);
 
@@ -228,13 +238,31 @@ mod tests {
     use proptest::prelude::*;
     use soroban_sdk::{
         testutils::{Address as _, Events},
+        token::StellarAssetClient,
         Address, BytesN, Env, FromVal, Symbol, Val,
     };
 
+    /// Registers a real Stellar Asset Contract token, so `fund_vault` exercises
+    /// a genuine token transfer rather than internal accounting.
+    fn setup_token(env: &Env) -> Address {
+        let token_admin = Address::generate(env);
+        env.register_stellar_asset_contract_v2(token_admin).address()
+    }
+
     fn seed_vault(env: &Env, vault_id: u64, status: VaultStatus, total_amount: i128) {
+        seed_vault_with_token(env, vault_id, status, total_amount, Address::generate(env))
+    }
+
+    fn seed_vault_with_token(
+        env: &Env,
+        vault_id: u64,
+        status: VaultStatus,
+        total_amount: i128,
+        token: Address,
+    ) {
         let vault = Vault {
             id: vault_id,
-            token: Address::generate(env),
+            token,
             owner: Address::generate(env),
             creator: Address::generate(env),
             total_amount,
@@ -321,12 +349,30 @@ mod tests {
 
         let vault_id = 1;
         let funder = Address::generate(&env);
-        seed_vault(&env, vault_id, VaultStatus::Active, i128::MAX - 10);
+        let token = setup_token(&env);
+        StellarAssetClient::new(&env, &token).mint(&funder, &10);
+        seed_vault_with_token(&env, vault_id, VaultStatus::Active, i128::MAX - 10, token.clone());
 
         fund_vault(&env, vault_id, &funder, 10).unwrap();
 
         let vault = storage::get_vault(&env, vault_id).unwrap();
         assert_eq!(vault.total_amount, i128::MAX);
+        assert_eq!(soroban_sdk::token::Client::new(&env, &token).balance(&funder), 0);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_fund_vault_insufficient_balance_fails() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let vault_id = 1;
+        let funder = Address::generate(&env);
+        let token = setup_token(&env);
+        // Funder has zero balance and no prior deposit — the transfer must panic.
+        seed_vault_with_token(&env, vault_id, VaultStatus::Active, 1_000, token);
+
+        let _ = fund_vault(&env, vault_id, &funder, 100);
     }
 
     #[test]
@@ -337,7 +383,9 @@ mod tests {
         let vault_id = 1;
         let funder = Address::generate(&env);
         let amount = 42;
-        seed_vault(&env, vault_id, VaultStatus::Active, 100);
+        let token = setup_token(&env);
+        StellarAssetClient::new(&env, &token).mint(&funder, &amount);
+        seed_vault_with_token(&env, vault_id, VaultStatus::Active, 100, token.clone());
 
         let before = env.events().all().len();
         fund_vault(&env, vault_id, &funder, amount).unwrap();
@@ -355,6 +403,7 @@ mod tests {
 
         assert_eq!(event_funder, funder);
         assert_eq!(event_amount, amount);
+        assert_eq!(soroban_sdk::token::Client::new(&env, &token).balance(&funder), 0);
     }
 
     // ============================================================================
@@ -864,13 +913,15 @@ mod tests {
         let vault_id = 1;
         let owner = Address::generate(&env);
         let funder = Address::generate(&env);
+        let token = setup_token(&env);
+        StellarAssetClient::new(&env, &token).mint(&funder, &500_0000000);
         let initial_amount = 1_000_0000000;
         let funded_amount = 500_0000000;
 
         // Create unlocked vault
         let vault = Vault {
             id: vault_id,
-            token: Address::generate(&env),
+            token,
             owner: owner.clone(),
             creator: Address::generate(&env),
             total_amount: initial_amount,


### PR DESCRIPTION
## Summary

- **closes #1850** — `fund_vault` incremented `vault.total_amount` without ever debiting the funder, letting anyone inflate a vault's claimable value for free. It now escrows the funder's tokens into contract custody via a real token transfer (`token::Client::transfer`) before crediting `total_amount`, matching the pattern in `bridge.rs::lock_tokens` / `fractionalization.rs::fractionalize` and how `claim_vault` already pays `vault.token` out of contract custody.
- **closes #1851** — `withdraw_fees` validated the withdrawal against the cap/allowlist and emitted an event, but never moved any value to the recipient. It now transfers `amount` of the crate's `fee_token` from the contract's own custody to `recipient`.
- **closes #1852** — `check_and_trigger_reactive_recalculation` injected a hardcoded `votes_cast=50, eligible_voters=100` fake snapshot into governance participation history on every large supply change, skewing `compute_effective_quorum`. It now only emits the `qrm_trig` signal event and never touches the participation ring buffer.
- **closes #1853** — `check_compliance` was never called by any real token operation, so registered rules (including `TransfersSuspended`) had zero effect. Added a per-token compliance jurisdiction (storage-derived, defaulting to `"GLOBAL"`, settable only via a new admin-only `set_token_jurisdiction`) and wired `mint`, `burn`, and `admin_burn` to call `check_compliance` before committing state changes.

None of the four public function signatures named in the issues were changed.

## Test plan
Each issue's own description required a regression test, so tests were added alongside each fix:
- [ ] `cargo test --lib vault` — new `test_fund_vault_insufficient_balance_fails`, updated existing funding tests to use real SAC tokens
- [ ] `cargo test --lib treasury` — new `test_withdraw_fees_credits_recipient_balance`, `test_withdraw_fees_without_fee_token_configured_fails`
- [ ] `cargo test --lib dynamic_quorum` — new `test_reactive_recalculation_does_not_skew_effective_quorum`, updated `test_large_supply_change_triggers_reactive_recalculation`
- [ ] `cargo test --lib compliance_reporting` — new `test_transfers_suspended_blocks_mint`, `test_transfers_suspended_blocks_burn`, `test_transfers_suspended_blocks_admin_burn`, `test_mint_unaffected_by_other_jurisdiction_rule`
- [ ] `cargo fmt --check` / `cargo clippy --all-targets --all-features -- -D warnings`

Note: this sandbox has no local Rust toolchain, and the repo has no committed `Cargo.lock`; a fresh dependency resolution here hits ~429 pre-existing compile errors on `upstream/main` itself (unrelated to this change — confirmed identical error signature/count against a clean `upstream/main` checkout), so these commands should be run in CI to confirm green.