### PR TITLE
test(backend): add missing coverage for governance queue, LagWindow, OpenAPI router, and database config

### DIFF
--- a/backend/src/config/database.test.ts
+++ b/backend/src/config/database.test.ts
@@ -1,0 +1,300 @@
+/**
+ * Unit tests — Database config helpers (config/database.ts)
+ *
+ * `Database` is a thin static wrapper around the shared Prisma client that
+ * maps Prisma rows onto the app-level User/Token/AuditLog shapes. Prisma is
+ * mocked throughout so no real database connection is required.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { Database } from "./database";
+
+vi.mock("../lib/prisma", () => ({
+  default: {
+    user: { findUnique: vi.fn(), findMany: vi.fn(), update: vi.fn() },
+    token: { findUnique: vi.fn(), findMany: vi.fn(), update: vi.fn() },
+    adminAuditLog: {
+      create: vi.fn(),
+      findMany: vi.fn(),
+      deleteMany: vi.fn(),
+    },
+  },
+}));
+
+async function getPrisma() {
+  return (await import("../lib/prisma")).default;
+}
+
+const makeUserRow = (o: Record<string, unknown> = {}) => ({
+  id: "user-1",
+  address: "GUSER",
+  role: "user",
+  banned: false,
+  createdAt: new Date("2026-01-01"),
+  lastActive: new Date("2026-01-02"),
+  ...o,
+});
+
+const makeTokenRow = (o: Record<string, unknown> = {}) => ({
+  id: "tok-1",
+  name: "Test Token",
+  symbol: "TST",
+  address: "CTOKEN123",
+  creator: "GCREATOR",
+  totalSupply: BigInt("1000"),
+  totalBurned: BigInt("0"),
+  flagged: false,
+  deleted: false,
+  metadata: null,
+  createdAt: new Date("2026-01-01"),
+  updatedAt: new Date("2026-01-01"),
+  ...o,
+});
+
+const makeAuditLogRow = (o: Record<string, unknown> = {}) => ({
+  id: "log-1",
+  adminId: "admin-1",
+  action: "BAN_USER",
+  resource: "user",
+  resourceId: "user-1",
+  beforeState: null,
+  afterState: null,
+  ipAddress: "127.0.0.1",
+  userAgent: "test-agent",
+  timestamp: new Date("2026-01-01"),
+  ...o,
+});
+
+// ---------------------------------------------------------------------------
+// User operations
+// ---------------------------------------------------------------------------
+
+describe("Database user operations", () => {
+  it("findUserById maps lastActive to updatedAt", async () => {
+    const p = await getPrisma();
+    vi.mocked(p.user.findUnique).mockResolvedValue(makeUserRow() as any);
+
+    const result = await Database.findUserById("user-1");
+
+    expect(result).toMatchObject({
+      id: "user-1",
+      updatedAt: new Date("2026-01-02"),
+    });
+  });
+
+  it("findUserById returns null when the row is not found", async () => {
+    const p = await getPrisma();
+    vi.mocked(p.user.findUnique).mockResolvedValue(null);
+
+    const result = await Database.findUserById("missing");
+    expect(result).toBeNull();
+  });
+
+  it("findUserByAddress queries by address", async () => {
+    const p = await getPrisma();
+    vi.mocked(p.user.findUnique).mockResolvedValue(makeUserRow() as any);
+
+    await Database.findUserByAddress("GUSER");
+
+    expect(p.user.findUnique).toHaveBeenCalledWith({
+      where: { address: "GUSER" },
+    });
+  });
+
+  it("updateUser returns null when the user does not exist", async () => {
+    const p = await getPrisma();
+    vi.mocked(p.user.findUnique).mockResolvedValue(null);
+
+    const result = await Database.updateUser("missing", { banned: true });
+
+    expect(result).toBeNull();
+    expect(p.user.update).not.toHaveBeenCalled();
+  });
+
+  it("updateUser only forwards defined fields to Prisma", async () => {
+    const p = await getPrisma();
+    vi.mocked(p.user.findUnique).mockResolvedValue(makeUserRow() as any);
+    vi.mocked(p.user.update).mockResolvedValue(
+      makeUserRow({ banned: true }) as any
+    );
+
+    await Database.updateUser("user-1", { banned: true });
+
+    expect(p.user.update).toHaveBeenCalledWith({
+      where: { id: "user-1" },
+      data: { banned: true },
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Token operations
+// ---------------------------------------------------------------------------
+
+describe("Database token operations", () => {
+  it("findTokenById maps null metadata to an empty object by default", async () => {
+    const p = await getPrisma();
+    vi.mocked(p.token.findUnique).mockResolvedValue(makeTokenRow() as any);
+
+    const result = await Database.findTokenById("tok-1");
+
+    expect(result?.metadata).toEqual({});
+    expect(result?.totalSupply).toBe("1000");
+    expect(result?.contractAddress).toBe("CTOKEN123");
+  });
+
+  it("findTokenById preserves object metadata when present", async () => {
+    const p = await getPrisma();
+    vi.mocked(p.token.findUnique).mockResolvedValue(
+      makeTokenRow({ metadata: { uri: "ipfs://x" } }) as any
+    );
+
+    const result = await Database.findTokenById("tok-1");
+
+    expect(result?.metadata).toEqual({ uri: "ipfs://x" });
+  });
+
+  it("getAllTokens excludes deleted tokens by default", async () => {
+    const p = await getPrisma();
+    vi.mocked(p.token.findMany).mockResolvedValue([]);
+
+    await Database.getAllTokens();
+
+    expect(p.token.findMany).toHaveBeenCalledWith({
+      where: { deleted: false },
+      orderBy: { createdAt: "asc" },
+    });
+  });
+
+  it("getAllTokens includes deleted tokens when overridden", async () => {
+    const p = await getPrisma();
+    vi.mocked(p.token.findMany).mockResolvedValue([]);
+
+    await Database.getAllTokens(true);
+
+    expect(p.token.findMany).toHaveBeenCalledWith({
+      where: undefined,
+      orderBy: { createdAt: "asc" },
+    });
+  });
+
+  it("softDeleteToken returns false when the token does not exist", async () => {
+    const p = await getPrisma();
+    vi.mocked(p.token.findUnique).mockResolvedValue(null);
+
+    const result = await Database.softDeleteToken("missing");
+
+    expect(result).toBe(false);
+    expect(p.token.update).not.toHaveBeenCalled();
+  });
+
+  it("softDeleteToken marks the token deleted and returns true", async () => {
+    const p = await getPrisma();
+    vi.mocked(p.token.findUnique).mockResolvedValue(makeTokenRow() as any);
+    vi.mocked(p.token.update).mockResolvedValue(
+      makeTokenRow({ deleted: true }) as any
+    );
+
+    const result = await Database.softDeleteToken("tok-1");
+
+    expect(result).toBe(true);
+    expect(p.token.update).toHaveBeenCalledWith({
+      where: { id: "tok-1" },
+      data: { deleted: true },
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Audit log operations
+// ---------------------------------------------------------------------------
+
+describe("Database audit log operations", () => {
+  it("createAuditLog maps null before/after state through", async () => {
+    const p = await getPrisma();
+    vi.mocked(p.adminAuditLog.create).mockResolvedValue(
+      makeAuditLogRow() as any
+    );
+
+    const result = await Database.createAuditLog({
+      adminId: "admin-1",
+      action: "BAN_USER",
+      resource: "user",
+      resourceId: "user-1",
+      beforeState: null,
+      afterState: null,
+      ipAddress: "127.0.0.1",
+      userAgent: "test-agent",
+    });
+
+    expect(result.beforeState).toBeNull();
+    expect(result.afterState).toBeNull();
+    expect(p.adminAuditLog.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        beforeState: undefined,
+        afterState: undefined,
+      }),
+    });
+  });
+
+  it("getAuditLogs applies no filters by default", async () => {
+    const p = await getPrisma();
+    vi.mocked(p.adminAuditLog.findMany).mockResolvedValue([]);
+
+    await Database.getAuditLogs();
+
+    expect(p.adminAuditLog.findMany).toHaveBeenCalledWith({
+      where: {},
+      orderBy: { timestamp: "desc" },
+    });
+  });
+
+  it("getAuditLogs overrides defaults with adminId/action/resource/date filters", async () => {
+    const p = await getPrisma();
+    vi.mocked(p.adminAuditLog.findMany).mockResolvedValue([]);
+
+    const startDate = new Date("2026-01-01");
+    const endDate = new Date("2026-01-31");
+
+    await Database.getAuditLogs({
+      adminId: "admin-1",
+      action: "BAN",
+      resource: "user",
+      startDate,
+      endDate,
+    });
+
+    expect(p.adminAuditLog.findMany).toHaveBeenCalledWith({
+      where: {
+        adminId: "admin-1",
+        action: { contains: "BAN" },
+        resource: "user",
+        timestamp: { gte: startDate, lte: endDate },
+      },
+      orderBy: { timestamp: "desc" },
+    });
+  });
+
+  it("purgeAuditLogs deletes logs older than the given date and returns the count", async () => {
+    const p = await getPrisma();
+    vi.mocked(p.adminAuditLog.deleteMany).mockResolvedValue({ count: 3 });
+
+    const cutoff = new Date("2026-01-01");
+    const result = await Database.purgeAuditLogs(cutoff);
+
+    expect(result).toBe(3);
+    expect(p.adminAuditLog.deleteMany).toHaveBeenCalledWith({
+      where: { timestamp: { lt: cutoff } },
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// initialize (deprecated no-op)
+// ---------------------------------------------------------------------------
+
+describe("Database.initialize", () => {
+  it("is a no-op kept for call-site compatibility", () => {
+    expect(() => Database.initialize()).not.toThrow();
+  });
+});

--- a/backend/src/graphql/resolvers.test.ts
+++ b/backend/src/graphql/resolvers.test.ts
@@ -404,6 +404,91 @@ describe("Query.campaigns", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Query.governanceQueue
+// ---------------------------------------------------------------------------
+
+describe("Query.governanceQueue", () => {
+  it("orders the queue by createdAt ascending and scopes to QUEUED status", async () => {
+    const p = await getPrisma();
+    vi.mocked(p.proposal.findMany).mockResolvedValue([]);
+
+    await resolvers.Query.governanceQueue(undefined, {});
+
+    expect(p.proposal.findMany).toHaveBeenCalledWith({
+      where: { status: "QUEUED" },
+      orderBy: { createdAt: "asc" },
+    });
+  });
+
+  it("filters by proposalType when provided", async () => {
+    const p = await getPrisma();
+    vi.mocked(p.proposal.findMany).mockResolvedValue([]);
+
+    await resolvers.Query.governanceQueue(undefined, { proposalType: "CUSTOM" });
+
+    expect(p.proposal.findMany).toHaveBeenCalledWith({
+      where: { status: "QUEUED", proposalType: "CUSTOM" },
+      orderBy: { createdAt: "asc" },
+    });
+  });
+
+  it("returns proposals across multiple types when unfiltered, in createdAt order", async () => {
+    const p = await getPrisma();
+    const rows = [
+      makeProposal({
+        proposalId: 1,
+        proposalType: "CUSTOM",
+        status: "QUEUED",
+        createdAt: new Date("2026-01-01T00:00:00Z"),
+      }),
+      makeProposal({
+        proposalId: 2,
+        proposalType: "MINT",
+        status: "QUEUED",
+        createdAt: new Date("2026-01-01T00:00:05Z"),
+      }),
+      makeProposal({
+        proposalId: 3,
+        proposalType: "CUSTOM",
+        status: "QUEUED",
+        createdAt: new Date("2026-01-01T00:00:10Z"),
+      }),
+    ];
+    vi.mocked(p.proposal.findMany).mockResolvedValue(rows as any);
+
+    const result = (await resolvers.Query.governanceQueue(undefined, {})) as any[];
+
+    expect(result.map((r) => r.proposalId)).toEqual([1, 2, 3]);
+  });
+
+  it("returns only same-type proposals when filtered by proposalType", async () => {
+    const p = await getPrisma();
+    const rows = [
+      makeProposal({
+        proposalId: 1,
+        proposalType: "CUSTOM",
+        status: "QUEUED",
+        createdAt: new Date("2026-01-01T00:00:00Z"),
+      }),
+      makeProposal({
+        proposalId: 3,
+        proposalType: "CUSTOM",
+        status: "QUEUED",
+        createdAt: new Date("2026-01-01T00:00:10Z"),
+      }),
+    ];
+    vi.mocked(p.proposal.findMany).mockResolvedValue(rows as any);
+
+    const result = (await resolvers.Query.governanceQueue(undefined, {
+      proposalType: "CUSTOM",
+    })) as any[];
+
+    expect(result.map((r) => r.proposalId)).toEqual([1, 3]);
+    expect(result.every((r) => r.proposalType === "CUSTOM")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Field resolvers
 // ---------------------------------------------------------------------------
 
@@ -452,6 +537,59 @@ describe("Proposal.votes", () => {
     )) as any[];
     expect(result).toHaveLength(1);
     expect(result[0].weight).toBe("50");
+  });
+});
+
+describe("Proposal.queuePosition", () => {
+  it("returns null when the proposal is not QUEUED", async () => {
+    const p = await getPrisma();
+
+    const result = await resolvers.Proposal.queuePosition({
+      status: "ACTIVE",
+      proposalType: "CUSTOM",
+      createdAt: new Date("2026-01-01"),
+    });
+
+    expect(result).toBeNull();
+    expect(p.proposal.count).not.toHaveBeenCalled();
+  });
+
+  it("returns the 0-based count of same-type QUEUED proposals created before it", async () => {
+    const p = await getPrisma();
+    vi.mocked(p.proposal.count).mockResolvedValue(2);
+
+    const createdAt = new Date("2026-01-01T00:00:10Z");
+    const result = await resolvers.Proposal.queuePosition({
+      status: "QUEUED",
+      proposalType: "CUSTOM",
+      createdAt,
+    });
+
+    expect(result).toBe(2);
+    expect(p.proposal.count).toHaveBeenCalledWith({
+      where: {
+        status: "QUEUED",
+        proposalType: "CUSTOM",
+        createdAt: { lt: createdAt },
+      },
+    });
+  });
+
+  it("only counts proposals of the same proposalType, not all queued proposals", async () => {
+    const p = await getPrisma();
+    vi.mocked(p.proposal.count).mockResolvedValue(0);
+
+    await resolvers.Proposal.queuePosition({
+      status: "QUEUED",
+      proposalType: "MINT",
+      createdAt: new Date("2026-01-01T00:00:10Z"),
+    });
+
+    expect(p.proposal.count).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ proposalType: "MINT" }),
+      })
+    );
   });
 });
 

--- a/backend/src/lib/openapi/__tests__/router.spec.ts
+++ b/backend/src/lib/openapi/__tests__/router.spec.ts
@@ -1,0 +1,49 @@
+/**
+ * Tests for the OpenAPI documentation router — GET /json and GET / (Swagger UI).
+ */
+
+import { describe, it, expect } from "vitest";
+import request from "supertest";
+import express from "express";
+import router from "../router";
+import { openApiSpec } from "../spec";
+
+function buildApp() {
+  const app = express();
+  app.use("/api/docs", router);
+  return app;
+}
+
+describe("OpenAPI router", () => {
+  describe("GET /json", () => {
+    it("returns application/json content type", async () => {
+      const app = buildApp();
+      const res = await request(app).get("/api/docs/json");
+
+      expect(res.status).toBe(200);
+      expect(res.headers["content-type"]).toMatch(/application\/json/);
+    });
+
+    it("returns a body matching the openApiSpec shape", async () => {
+      const app = buildApp();
+      const res = await request(app).get("/api/docs/json");
+
+      expect(res.body).toMatchObject({
+        openapi: openApiSpec.openapi,
+        info: openApiSpec.info,
+      });
+      expect(res.body.paths).toBeDefined();
+      expect(res.body.components).toBeDefined();
+    });
+  });
+
+  describe("GET /", () => {
+    it("returns a 200 HTML response from Swagger UI", async () => {
+      const app = buildApp();
+      const res = await request(app).get("/api/docs/");
+
+      expect(res.status).toBe(200);
+      expect(res.headers["content-type"]).toMatch(/text\/html/);
+    });
+  });
+});

--- a/backend/src/monitoring/metrics/__tests__/projectionLagThresholds.spec.ts
+++ b/backend/src/monitoring/metrics/__tests__/projectionLagThresholds.spec.ts
@@ -1,0 +1,130 @@
+/**
+ * Tests for LagWindow — the rolling-window lag aggregator's pruning behavior.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { LagWindow } from "../projectionLagThresholds";
+
+describe("LagWindow", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("empty window", () => {
+    it("getMaxLag returns 0 when no measurements recorded", () => {
+      const window = new LagWindow();
+      expect(window.getMaxLag()).toBe(0);
+    });
+
+    it("getAverageLag returns 0 when no measurements recorded", () => {
+      const window = new LagWindow();
+      expect(window.getAverageLag()).toBe(0);
+    });
+
+    it("getCount returns 0 when no measurements recorded", () => {
+      const window = new LagWindow();
+      expect(window.getCount()).toBe(0);
+    });
+  });
+
+  describe("pruning at the window boundary", () => {
+    it("prunes a measurement exactly at the window boundary", () => {
+      const window = new LagWindow(60000);
+      window.record(1000);
+
+      // Advance exactly to the window size — `now - timestamp < windowSizeMs`
+      // is false at the boundary, so the measurement must be pruned.
+      vi.setSystemTime(new Date("2026-01-01T00:01:00.000Z"));
+      window.record(2000);
+
+      expect(window.getCount()).toBe(1);
+      expect(window.getMaxLag()).toBe(2000);
+    });
+
+    it("retains a measurement just inside the window boundary", () => {
+      const window = new LagWindow(60000);
+      window.record(1000);
+
+      vi.setSystemTime(new Date("2026-01-01T00:00:59.999Z"));
+      window.record(2000);
+
+      expect(window.getCount()).toBe(2);
+      expect(window.getMaxLag()).toBe(2000);
+    });
+
+    it("prunes measurements older than the window while retaining recent ones", () => {
+      const window = new LagWindow(60000);
+      window.record(100); // t=0
+      vi.setSystemTime(new Date("2026-01-01T00:00:30.000Z"));
+      window.record(200); // t=30s
+      vi.setSystemTime(new Date("2026-01-01T00:01:10.000Z")); // t=70s, prunes t=0 (70s old, > 60s window)
+      window.record(300);
+
+      expect(window.getCount()).toBe(2);
+      expect(window.getMaxLag()).toBe(300);
+      expect(window.getAverageLag()).toBe(250);
+    });
+  });
+
+  describe("record / getMaxLag / getAverageLag / getCount", () => {
+    it("tracks max lag across multiple measurements", () => {
+      const window = new LagWindow(60000);
+      window.record(500);
+      window.record(1500);
+      window.record(800);
+
+      expect(window.getMaxLag()).toBe(1500);
+    });
+
+    it("computes the average lag across multiple measurements", () => {
+      const window = new LagWindow(60000);
+      window.record(100);
+      window.record(200);
+      window.record(300);
+
+      expect(window.getAverageLag()).toBe(200);
+    });
+
+    it("counts only measurements still within the window", () => {
+      const window = new LagWindow(10000);
+      window.record(100); // t=0
+      vi.setSystemTime(new Date("2026-01-01T00:00:05.000Z"));
+      window.record(200); // t=5s
+      vi.setSystemTime(new Date("2026-01-01T00:00:15.000Z")); // t=15s, prunes t=0 and t=5s (both >= 10s old)
+      window.record(300);
+
+      expect(window.getCount()).toBe(1);
+    });
+
+    it("accepts measurements added out of chronological order", () => {
+      const window = new LagWindow(60000);
+      vi.setSystemTime(new Date("2026-01-01T00:00:20.000Z"));
+      window.record(200);
+      vi.setSystemTime(new Date("2026-01-01T00:00:10.000Z"));
+      window.record(100);
+
+      expect(window.getCount()).toBe(2);
+      expect(window.getMaxLag()).toBe(200);
+      expect(window.getAverageLag()).toBe(150);
+    });
+  });
+
+  describe("clear", () => {
+    it("resets getMaxLag, getAverageLag and getCount to their empty-state values", () => {
+      const window = new LagWindow();
+      window.record(100);
+      window.record(200);
+
+      window.clear();
+
+      expect(window.getMaxLag()).toBe(0);
+      expect(window.getAverageLag()).toBe(0);
+      expect(window.getCount()).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add tests for `Proposal.queuePosition` and `Query.governanceQueue` FIFO ordering edge cases (non-QUEUED proposals, multi-type interleaving, `proposalType` filtering)
- Add `LagWindow` rolling-window pruning tests using a fake clock (empty window, exact-boundary pruning, out-of-order measurements, `clear()`)
- Add `supertest`-based coverage for the OpenAPI docs router (`GET /json` and `GET /`)
- Add coverage for `Database` (config/database.ts) mapping/behavior against a mocked Prisma client, covering default and override paths for `getAllTokens`, `getAuditLogs`, `updateUser`, and related methods

## Test plan
- [x] `npx vitest run src/graphql/resolvers.test.ts` — new queue-ordering assertions pass
- [x] `npx vitest run src/monitoring/metrics/__tests__/projectionLagThresholds.spec.ts` — all `LagWindow` tests pass
- [x] `npx vitest run src/lib/openapi/__tests__/router.spec.ts` — both route assertions pass
- [x] `npx vitest run src/config/database.test.ts` — all new configuration-path assertions pass

Closes #1870
Closes #1871
Closes #1872
Closes #1873