### PR TITLE
test(backend): edge-case coverage for analytics, stellar & burn-histo…

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,12 +1,64 @@
-PORT=3001
+# ─────────────────────────────────────────────────────────────────────────────
+# Core configuration validated at startup by validateEnv() in src/config/env.ts.
+# That function is the source of truth for the variables in this block — see it
+# (and the "Environment Variables" section of README.md) for the exact rules.
+#
+# Rule of thumb: with NODE_ENV=production a missing/invalid required variable
+# makes startup throw; with any other NODE_ENV the development default is used.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Runtime environment. Free-form string; only the exact value "production"
+# changes behaviour (it turns the "required" variables below into hard errors).
+# Optional. Default: "development".
 NODE_ENV=development
+
+# HTTP port the API listens on. Optional; parsed as an integer. Default: 3001.
+PORT=3001
+
+# Selects the Stellar network. Allowed values: "testnet" | "mainnet"; any other
+# value makes startup throw in every environment. Also selects the defaults for
+# the three STELLAR_* URLs/passphrase below. Optional. Default: "testnet".
+STELLAR_NETWORK=testnet
+
+# Horizon REST endpoint. Optional — when unset it is derived from STELLAR_NETWORK:
+#   testnet -> https://horizon-testnet.stellar.org
+#   mainnet -> https://horizon.stellar.org
+STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
+
+# Soroban RPC endpoint. Optional — when unset it is derived from STELLAR_NETWORK:
+#   testnet -> https://soroban-testnet.stellar.org
+#   mainnet -> https://soroban-mainnet.stellar.org
+# STELLAR_SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
+
+# Stellar network passphrase. Optional — when unset it is derived from
+# STELLAR_NETWORK:
+#   testnet -> "Test SDF Network ; September 2015"
+#   mainnet -> "Public Global Stellar Network ; September 2015"
+# STELLAR_NETWORK_PASSPHRASE=Test SDF Network ; September 2015
+
+# Soroban factory contract ID. Format: must match ^C[A-Z2-7]{55}$ (56 chars,
+# starts with "C", base32 body). A malformed value ALWAYS makes startup throw,
+# in every environment. Required in production; in non-production it may be
+# omitted (defaults to an empty string).
+# FACTORY_CONTRACT_ID=
+
+# PostgreSQL connection string. Required in production (startup throws if unset).
+# In non-production it defaults to:
+#   postgresql://postgres:postgres@localhost:5432/postgres?schema=public
+DATABASE_URL=postgresql://user:password@localhost:5432/nova_launch
+
+# Secret used to sign/verify JWTs. Required in production, where it must also NOT
+# be left as the literal "your-secret-key-change-in-production" (that exact value
+# makes startup throw). In non-production it defaults to "dev-secret-key-change-me".
 JWT_SECRET=your-secret-key-change-in-production
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Additional configuration — consumed elsewhere in the app, NOT enforced by
+# validateEnv().
+# ─────────────────────────────────────────────────────────────────────────────
 JWT_EXPIRES_IN=24h
 ADMIN_JWT_SECRET=your-admin-secret-key-change-in-production
 ADMIN_JWT_EXPIRES_IN=8h
-DATABASE_URL=postgresql://user:password@localhost:5432/nova_launch
-STELLAR_NETWORK=testnet
-STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
 FRONTEND_URL=http://localhost:5173
 
 # Redis — used by the distributed rate limiter

--- a/backend/README.md
+++ b/backend/README.md
@@ -58,11 +58,9 @@ Copy `.env.example` to `.env` and configure:
 cp .env.example .env
 ```
 
-Required environment variables:
-
-- `PORT` - Server port (default: 3001)
-- `ADMIN_JWT_SECRET` - Secret for admin JWT tokens
-- `DATABASE_URL` - Database connection string
+`.env.example` documents every variable inline. The core set is validated at
+startup — see [Environment Variables](#environment-variables) below for the
+authoritative rules.
 
 ### Development
 
@@ -102,6 +100,53 @@ npm test backend/src/__tests__/chaos.db-pool.test.ts
 
 This spec covers concurrent query saturation, client acquisition failures,
 and safe shutdown behavior for the pg pool wrapper.
+
+## Environment Variables
+
+Core configuration is validated at startup by `validateEnv()` in
+[`src/config/env.ts`](src/config/env.ts), which is the **source of truth** for
+the variables below. When a required variable is missing or malformed the
+process fails fast with an explanatory error instead of booting in a bad state.
+
+Behaviour depends on `NODE_ENV`:
+
+- **`NODE_ENV=production`** — the "required in production" variables must be
+  present and valid, or startup throws.
+- **any other value** (the default is `development`) — those variables fall back
+  to the development defaults listed below.
+
+A few checks run regardless of `NODE_ENV`: an unknown `STELLAR_NETWORK` and a
+`FACTORY_CONTRACT_ID` that does not match the expected format both always throw.
+
+| Variable | Required in production | Format / allowed values | Development default |
+|---|---|---|---|
+| `NODE_ENV` | no | free-form; only the exact value `production` changes behaviour | `development` |
+| `PORT` | no | integer | `3001` |
+| `STELLAR_NETWORK` | no | `testnet` \| `mainnet` — any other value throws in every environment | `testnet` |
+| `STELLAR_HORIZON_URL` | no | URL | derived from `STELLAR_NETWORK` (see below) |
+| `STELLAR_SOROBAN_RPC_URL` | no | URL | derived from `STELLAR_NETWORK` (see below) |
+| `STELLAR_NETWORK_PASSPHRASE` | no | string | derived from `STELLAR_NETWORK` (see below) |
+| `FACTORY_CONTRACT_ID` | **yes** | `^C[A-Z2-7]{55}$` (56 chars, starts with `C`); a malformed value throws in **every** environment | `""` (empty string) |
+| `DATABASE_URL` | **yes** | PostgreSQL connection string | `postgresql://postgres:postgres@localhost:5432/postgres?schema=public` |
+| `JWT_SECRET` | **yes** | any non-empty string except the literal `your-secret-key-change-in-production` | `dev-secret-key-change-me` |
+
+### Network-derived Stellar defaults
+
+`STELLAR_NETWORK` implicitly selects the defaults for `STELLAR_HORIZON_URL`,
+`STELLAR_SOROBAN_RPC_URL`, and `STELLAR_NETWORK_PASSPHRASE`. Setting any of those
+three explicitly overrides just that one; leaving them unset is the common case,
+so it is easy to miss that switching `STELLAR_NETWORK` moves all three endpoints
+at once.
+
+| `STELLAR_NETWORK` | `STELLAR_HORIZON_URL` | `STELLAR_SOROBAN_RPC_URL` | `STELLAR_NETWORK_PASSPHRASE` |
+|---|---|---|---|
+| `testnet` (default) | `https://horizon-testnet.stellar.org` | `https://soroban-testnet.stellar.org` | `Test SDF Network ; September 2015` |
+| `mainnet` | `https://horizon.stellar.org` | `https://soroban-mainnet.stellar.org` | `Public Global Stellar Network ; September 2015` |
+
+See [`.env.example`](.env.example) for a copy-paste template. Variables consumed
+elsewhere in the app (`ADMIN_JWT_SECRET`, `REDIS_URL`, notification provider
+keys, …) are documented inline in `.env.example` and are **not** enforced by
+`validateEnv()`.
 
 ## Rate Limiting
 

--- a/backend/src/burn-history/__tests__/burn-history.service.spec.ts
+++ b/backend/src/burn-history/__tests__/burn-history.service.spec.ts
@@ -1,0 +1,182 @@
+/**
+ * Cache-key + cache hit/miss coverage for BurnHistoryService.
+ *
+ * Issue: #1874 — there was no test asserting that structurally-different queries
+ * produce different cache keys. If buildCacheKey ever dropped a query parameter,
+ * two different requests would collide and one page would be served the other's
+ * cached, wrong-shaped result.
+ *
+ * No database: the TypeORM repository / query builder and the cache manager are
+ * mocked. `@nestjs/*` packages (and the DTO/entity modules that pull in
+ * class-validator / typeorm) are stubbed because they are not installed in this
+ * workspace and only their decorators / enum values are needed at runtime.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("@nestjs/common", () => ({
+  Injectable: () => (target: unknown) => target,
+  Inject: () => () => {},
+  Logger: class {
+    log() {}
+    error() {}
+    warn() {}
+    debug() {}
+    verbose() {}
+  },
+}));
+vi.mock("@nestjs/typeorm", () => ({ InjectRepository: () => () => {} }));
+vi.mock("@nestjs/cache-manager", () => ({ CACHE_MANAGER: "CACHE_MANAGER" }));
+vi.mock("../burn-transaction.entity", () => ({
+  BurnTransaction: class BurnTransaction {},
+  BurnTransactionType: { SELF: "self", ADMIN: "admin" },
+}));
+vi.mock("../burn-history-query.dto", () => ({
+  BurnHistoryQueryDto: class BurnHistoryQueryDto {},
+  BurnType: { ALL: "all", SELF: "self", ADMIN: "admin" },
+  SortBy: { TIMESTAMP: "timestamp", AMOUNT: "amount", FROM: "from" },
+  SortOrder: { ASC: "asc", DESC: "desc" },
+}));
+
+const { BurnHistoryService } = await import("../burn-history.service");
+const { BurnType, SortBy, SortOrder } = await import("../burn-history-query.dto");
+
+type Query = Record<string, unknown>;
+
+function createService() {
+  const queryBuilder = {
+    select: vi.fn().mockReturnThis(),
+    andWhere: vi.fn().mockReturnThis(),
+    orderBy: vi.fn().mockReturnThis(),
+    skip: vi.fn().mockReturnThis(),
+    take: vi.fn().mockReturnThis(),
+    getCount: vi.fn().mockResolvedValue(0),
+    getMany: vi.fn().mockResolvedValue([]),
+  };
+  const repository = {
+    createQueryBuilder: vi.fn().mockReturnValue(queryBuilder),
+  };
+  const cacheManager = {
+    get: vi.fn().mockResolvedValue(null),
+    set: vi.fn().mockResolvedValue(undefined),
+  };
+  const service = new BurnHistoryService(
+    repository as never,
+    cacheManager as never
+  );
+  return { service, repository, queryBuilder, cacheManager };
+}
+
+/** Reach the private key builder without going through a full request. */
+function keyFor(service: unknown, query: Query): string {
+  return (service as { buildCacheKey(q: Query): string }).buildCacheKey(query);
+}
+
+describe("BurnHistoryService.buildCacheKey — uniqueness", () => {
+  let service: unknown;
+
+  beforeEach(() => {
+    service = createService().service;
+  });
+
+  const base: Query = {
+    tokenAddress: "0xToken",
+    type: BurnType.SELF,
+    startDate: "2024-01-01T00:00:00Z",
+    endDate: "2024-02-01T00:00:00Z",
+    page: 1,
+    limit: 10,
+    sortBy: SortBy.TIMESTAMP,
+    sortOrder: SortOrder.DESC,
+  };
+
+  it("produces a different key when only `page` differs", () => {
+    expect(keyFor(service, { ...base, page: 1 })).not.toBe(
+      keyFor(service, { ...base, page: 2 })
+    );
+  });
+
+  it("produces a different key when only `sortBy` differs", () => {
+    expect(keyFor(service, { ...base, sortBy: SortBy.TIMESTAMP })).not.toBe(
+      keyFor(service, { ...base, sortBy: SortBy.AMOUNT })
+    );
+  });
+
+  it("produces a different key when only `sortOrder` differs", () => {
+    expect(keyFor(service, { ...base, sortOrder: SortOrder.DESC })).not.toBe(
+      keyFor(service, { ...base, sortOrder: SortOrder.ASC })
+    );
+  });
+
+  it("produces a distinct key for every distinguishing query parameter", () => {
+    const variants: Query[] = [
+      base,
+      { ...base, tokenAddress: "0xOther" },
+      { ...base, type: BurnType.ADMIN },
+      { ...base, startDate: "2023-06-01T00:00:00Z" },
+      { ...base, endDate: "2024-03-01T00:00:00Z" },
+      { ...base, page: 2 },
+      { ...base, limit: 25 },
+      { ...base, sortBy: SortBy.FROM },
+      { ...base, sortOrder: SortOrder.ASC },
+    ];
+
+    const keys = variants.map((q) => keyFor(service, q));
+    expect(new Set(keys).size).toBe(variants.length);
+  });
+
+  it("is stable for identical queries", () => {
+    expect(keyFor(service, { ...base })).toBe(keyFor(service, { ...base }));
+  });
+});
+
+describe("BurnHistoryService.getHistory — cache hit / miss", () => {
+  it("serves the cached response and never touches the query builder on a hit", async () => {
+    const { service, repository, cacheManager } = createService();
+    const cached = {
+      success: true,
+      data: [],
+      pagination: { page: 1, limit: 10, total: 0, totalPages: 0 },
+      filters: { sortBy: SortBy.TIMESTAMP, sortOrder: SortOrder.DESC },
+    };
+    cacheManager.get.mockResolvedValueOnce(cached);
+
+    const result = await service.getHistory({});
+
+    expect(result).toBe(cached);
+    expect(repository.createQueryBuilder).not.toHaveBeenCalled();
+    expect(cacheManager.set).not.toHaveBeenCalled();
+  });
+
+  it("falls through to the query builder on a miss and caches under the lookup key", async () => {
+    const { service, repository, queryBuilder, cacheManager } = createService();
+    const query: Query = { tokenAddress: "0xToken", page: 3, limit: 5 };
+
+    const result = await service.getHistory(query);
+
+    // the miss path actually ran a query
+    expect(repository.createQueryBuilder).toHaveBeenCalledTimes(1);
+    expect(queryBuilder.getMany).toHaveBeenCalledTimes(1);
+
+    // it looked up and then stored under the very same key
+    const expectedKey = keyFor(service, query);
+    expect(cacheManager.get).toHaveBeenCalledWith(expectedKey);
+
+    expect(cacheManager.set).toHaveBeenCalledTimes(1);
+    const [storedKey, storedValue, ttl] = cacheManager.set.mock.calls[0];
+    expect(storedKey).toBe(expectedKey);
+    expect(storedValue).toBe(result);
+    expect(ttl).toBe(60_000);
+  });
+
+  it("stores distinct pages under distinct keys (no collision across requests)", async () => {
+    const { service, cacheManager } = createService();
+
+    await service.getHistory({ tokenAddress: "0xToken", page: 1 });
+    await service.getHistory({ tokenAddress: "0xToken", page: 2 });
+
+    const [keyPage1] = cacheManager.set.mock.calls[0];
+    const [keyPage2] = cacheManager.set.mock.calls[1];
+    expect(keyPage1).not.toBe(keyPage2);
+  });
+});

--- a/backend/src/burn-history/burn-history.service.ts
+++ b/backend/src/burn-history/burn-history.service.ts
@@ -4,17 +4,17 @@ import { Repository, SelectQueryBuilder } from "typeorm";
 import { CACHE_MANAGER } from "@nestjs/cache-manager";
 import { Inject } from "@nestjs/common";
 import { Cache } from "cache-manager";
-import { BurnTransaction } from "./entities/burn-transaction.entity";
+import { BurnTransaction } from "./burn-transaction.entity";
 import {
   BurnHistoryQueryDto,
   BurnType,
   SortBy,
   SortOrder,
-} from "./dto/burn-history-query.dto";
+} from "./burn-history-query.dto";
 import {
   BurnHistoryResponse,
   AppliedFilters,
-} from "./interfaces/burn-history.interface";
+} from "./burn-history.interface";
 
 @Injectable()
 export class BurnHistoryService {

--- a/backend/src/token-analytics/__tests__/analytics.service.spec.ts
+++ b/backend/src/token-analytics/__tests__/analytics.service.spec.ts
@@ -1,0 +1,170 @@
+/**
+ * Edge-case coverage for AnalyticsService's guarded arithmetic.
+ *
+ * Issue: #1875 — exercise the zero-division / BigInt-truncation branches that
+ * calcChangePercent, averageBurnAmount and burnFrequencyPerDay guard against.
+ *
+ * The service is a plain class (its constructor accepts an injectable
+ * PrismaDep), so no NestJS testing harness is needed. Its query helpers talk to
+ * a module-level `prisma` client, which we replace with an in-memory fake that
+ * routes each SQL string to a canned result set.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// ─── Fake prisma client ─────────────────────────────────────────────────────
+//
+// getTokenAnalytics() fires a fixed set of raw queries. We route them by a
+// distinctive fragment of their SQL text. The "current period" PeriodStats row
+// is the only one the tests below care about, so it is overridable per-test.
+
+let currentPeriodRow = { volume: "0", count: 0, uniqueBurners: 0 };
+
+const emptyPeriodRow = { volume: "0", count: 0, uniqueBurners: 0 };
+
+function routeQueryRaw(strings: TemplateStringsArray, ...values: unknown[]) {
+  const sql = Array.isArray(strings) ? strings.join(" ? ") : String(strings);
+
+  // countBurnEvents — must be > 0 or getTokenAnalytics throws a 404
+  if (sql.includes("AS cnt")) {
+    return Promise.resolve([{ cnt: 1 }]);
+  }
+
+  // getAllTimeStats
+  if (sql.includes('"totalCount"')) {
+    return Promise.resolve([
+      { totalVolume: "0", totalCount: 0, uniqueBurners: 0 },
+    ]);
+  }
+
+  // getLargestBurn
+  if (sql.includes('"txHash"')) {
+    return Promise.resolve([]);
+  }
+
+  // getBurnTypeDistribution
+  if (sql.includes("GROUP BY burn_type")) {
+    return Promise.resolve([]);
+  }
+
+  // getPeriodStats — called for the current window, the previous window and the
+  // fixed 24h/7d/30d windows. Only the current 90d window (~90 days wide) needs
+  // test-controlled data; every other window returns zeroes.
+  if (sql.includes("AS volume,")) {
+    const start = values[1] as Date;
+    const daysAgo = Math.round((Date.now() - start.getTime()) / 86_400_000);
+    return Promise.resolve([daysAgo === 90 ? currentPeriodRow : emptyPeriodRow]);
+  }
+
+  return Promise.resolve([]);
+}
+
+// Installed before the service module is imported: its module scope resolves
+// `prisma` off the global object, and it instantiates a singleton on load.
+(globalThis as Record<string, unknown>).prisma = {
+  $queryRaw: vi.fn(routeQueryRaw),
+  $queryRawUnsafe: vi.fn(() => Promise.resolve([])),
+  analyticsBucket: { upsert: vi.fn(), findMany: vi.fn() },
+};
+
+const { AnalyticsService } = await import("../analytics.service");
+
+beforeEach(() => {
+  currentPeriodRow = { volume: "0", count: 0, uniqueBurners: 0 };
+});
+
+function makeService() {
+  return new AnalyticsService({ analyticsBucket: {} } as never);
+}
+
+// ─── calcChangePercent: division-by-zero guard ──────────────────────────────
+
+describe("AnalyticsService.calcChangePercent — zero previous period", () => {
+  it("returns 100 when the previous period was zero and the current period grew", () => {
+    const svc = makeService() as unknown as {
+      calcChangePercent(prev: bigint, curr: bigint): number;
+    };
+    expect(svc.calcChangePercent(0n, 100n)).toBe(100);
+  });
+
+  it("returns 0 when both the previous and current periods are zero", () => {
+    const svc = makeService() as unknown as {
+      calcChangePercent(prev: bigint, curr: bigint): number;
+    };
+    expect(svc.calcChangePercent(0n, 0n)).toBe(0);
+  });
+
+  it("still computes a normal percentage when the previous period is non-zero", () => {
+    const svc = makeService() as unknown as {
+      calcChangePercent(prev: bigint, curr: bigint): number;
+    };
+    expect(svc.calcChangePercent(100n, 150n)).toBe(50);
+  });
+
+  it("surfaces the guard through getTokenAnalytics (prev period has no burns)", async () => {
+    currentPeriodRow = { volume: "500", count: 5, uniqueBurners: 2 };
+    const result = await makeService().getTokenAnalytics("0xToken", "90d");
+
+    // previous 90d window returns zeroes -> guard yields 100, not NaN / Infinity
+    expect(result.volumeChangePercent).toBe(100);
+    expect(result.countChangePercent).toBe(100);
+  });
+});
+
+// ─── averageBurnAmount: BigInt truncation ──────────────────────────────────
+
+describe("AnalyticsService.averageBurnAmount — BigInt division truncates", () => {
+  it("truncates a non-evenly-divisible volume/count pair toward zero", async () => {
+    currentPeriodRow = { volume: "7", count: 2, uniqueBurners: 1 };
+    const result = await makeService().getTokenAnalytics("0xToken", "90d");
+
+    // 7n / 2n === 3n — the fractional 0.5 is dropped, not rounded.
+    expect(result.averageBurnAmount).toBe("3");
+    expect(result.averageBurnAmount).not.toBe("3.5");
+    expect(result.averageBurnAmount).not.toBe("4");
+  });
+
+  it("truncates large integer amounts without floating-point drift", async () => {
+    currentPeriodRow = {
+      volume: "1000000000000000000007",
+      count: 2,
+      uniqueBurners: 1,
+    };
+    const result = await makeService().getTokenAnalytics("0xToken", "90d");
+
+    expect(result.averageBurnAmount).toBe("500000000000000000003");
+  });
+
+  it('returns "0" when the current period has no burns (count === 0 guard)', async () => {
+    currentPeriodRow = { volume: "0", count: 0, uniqueBurners: 0 };
+    const result = await makeService().getTokenAnalytics("0xToken", "90d");
+
+    expect(result.averageBurnAmount).toBe("0");
+  });
+});
+
+// ─── burnFrequencyPerDay: zero-duration window guard ───────────────────────
+
+describe("AnalyticsService.burnFrequencyPerDay — zero-duration window", () => {
+  it("returns 0 (not Infinity / NaN) when windowDurationDays is zero", async () => {
+    const svc = makeService();
+    vi.spyOn(
+      svc as unknown as { windowDurationDays(w: unknown): number },
+      "windowDurationDays"
+    ).mockReturnValue(0);
+
+    currentPeriodRow = { volume: "500", count: 5, uniqueBurners: 2 };
+    const result = await svc.getTokenAnalytics("0xToken", "90d");
+
+    expect(result.burnFrequencyPerDay).toBe(0);
+  });
+
+  it("computes a finite rate for a normal (non-zero) window", async () => {
+    currentPeriodRow = { volume: "900", count: 9, uniqueBurners: 3 };
+    const result = await makeService().getTokenAnalytics("0xToken", "90d");
+
+    // 9 burns / 90 days, rounded to 2dp
+    expect(result.burnFrequencyPerDay).toBe(0.1);
+    expect(Number.isFinite(result.burnFrequencyPerDay)).toBe(true);
+  });
+});

--- a/backend/src/token-info/__tests__/stellar.service.spec.ts
+++ b/backend/src/token-info/__tests__/stellar.service.spec.ts
@@ -1,0 +1,259 @@
+/**
+ * Unit tests for the token-info StellarService.
+ *
+ * Issue: #1877 — this Horizon-facing service had no dedicated test file. The
+ * HTTP client is mocked (rxjs Observables via `of` / `throwError`); no real
+ * network calls are made. Each public method is covered for both its success
+ * path and at least one realistic failure mode.
+ *
+ * `@nestjs/common` is stubbed because only its `Logger` is used as a runtime
+ * value and the package is not installed in this workspace; `ConfigService` /
+ * `HttpService` are type-only imports in the service and need no stub.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { of, throwError } from "rxjs";
+
+vi.mock("@nestjs/common", () => ({
+  Injectable: () => (target: unknown) => target,
+  Logger: class {
+    log() {}
+    error() {}
+    warn() {}
+    debug() {}
+    verbose() {}
+  },
+}));
+
+const { StellarService } = await import("../stellar.service");
+
+const HORIZON_URL = "https://horizon-testnet.stellar.org";
+
+function makeResponse<T>(data: T) {
+  return { data, status: 200, statusText: "OK", headers: {}, config: {} };
+}
+
+function createService() {
+  const httpService = { get: vi.fn() };
+  const configService = {
+    get: vi.fn((key: string) =>
+      key === "STELLAR_HORIZON_URL" ? HORIZON_URL : undefined
+    ),
+  };
+  const service = new StellarService(
+    configService as never,
+    httpService as never
+  );
+  return { service, httpService, configService };
+}
+
+describe("StellarService (token-info)", () => {
+  let ctx: ReturnType<typeof createService>;
+
+  beforeEach(() => {
+    ctx = createService();
+  });
+
+  // ── parseAddress ────────────────────────────────────────────────────────
+  describe("parseAddress", () => {
+    it("splits a CODE:ISSUER pair", () => {
+      expect(ctx.service.parseAddress("USDC:GISSUER")).toEqual({
+        assetCode: "USDC",
+        assetIssuer: "GISSUER",
+      });
+    });
+
+    it("treats a bare address as the issuer of an unknown asset", () => {
+      expect(ctx.service.parseAddress("GISSUERONLY")).toEqual({
+        assetCode: "UNKNOWN",
+        assetIssuer: "GISSUERONLY",
+      });
+    });
+  });
+
+  // ── getAssetData ────────────────────────────────────────────────────────
+  describe("getAssetData", () => {
+    it("returns the first Horizon asset record on success", async () => {
+      const record = { asset_code: "USDC", asset_issuer: "GISSUER", amount: "10" };
+      ctx.httpService.get.mockReturnValue(
+        of(makeResponse({ _embedded: { records: [record] } }))
+      );
+
+      const result = await ctx.service.getAssetData("USDC", "GISSUER");
+
+      expect(result).toEqual(record);
+      expect(ctx.httpService.get).toHaveBeenCalledWith(
+        `${HORIZON_URL}/assets?asset_code=USDC&asset_issuer=GISSUER&limit=1`
+      );
+    });
+
+    it("returns null when Horizon has no matching asset", async () => {
+      ctx.httpService.get.mockReturnValue(
+        of(makeResponse({ _embedded: { records: [] } }))
+      );
+
+      expect(await ctx.service.getAssetData("FAKE", "GISSUER")).toBeNull();
+    });
+
+    it("returns null when the Horizon request fails", async () => {
+      ctx.httpService.get.mockReturnValue(
+        throwError(() => new Error("network down"))
+      );
+
+      expect(await ctx.service.getAssetData("USDC", "GISSUER")).toBeNull();
+    });
+
+    it("returns null on a malformed Horizon payload (missing _embedded)", async () => {
+      ctx.httpService.get.mockReturnValue(of(makeResponse({})));
+
+      expect(await ctx.service.getAssetData("USDC", "GISSUER")).toBeNull();
+    });
+  });
+
+  // ── getAssetCreationInfo ────────────────────────────────────────────────
+  describe("getAssetCreationInfo", () => {
+    it("returns creator + timestamp from the create_account operation", async () => {
+      ctx.httpService.get.mockReturnValue(
+        of(
+          makeResponse({
+            _embedded: {
+              records: [
+                {
+                  type: "create_account",
+                  created_at: "2023-01-02T03:04:05Z",
+                  source_account: "GCREATOR",
+                },
+              ],
+            },
+          })
+        )
+      );
+
+      const result = await ctx.service.getAssetCreationInfo("USDC", "GISSUER");
+
+      expect(result).toEqual({
+        creatorAddress: "GCREATOR",
+        createdAt: "2023-01-02T03:04:05Z",
+      });
+    });
+
+    it("falls back to the issuer as creator when no operations are returned", async () => {
+      ctx.httpService.get.mockReturnValue(
+        of(makeResponse({ _embedded: { records: [] } }))
+      );
+
+      const result = await ctx.service.getAssetCreationInfo("USDC", "GISSUER");
+
+      expect(result?.creatorAddress).toBe("GISSUER");
+      expect(typeof result?.createdAt).toBe("string");
+    });
+
+    it("falls back to the issuer as creator when the request fails", async () => {
+      ctx.httpService.get.mockReturnValue(
+        throwError(() => new Error("horizon 500"))
+      );
+
+      const result = await ctx.service.getAssetCreationInfo("USDC", "GISSUER");
+
+      expect(result?.creatorAddress).toBe("GISSUER");
+    });
+  });
+
+  // ── getBurnStatistics ──────────────────────────────────────────────────
+  describe("getBurnStatistics", () => {
+    it("sums payments sent to the issuer and computes the burned percentage", async () => {
+      ctx.httpService.get.mockReturnValue(
+        of(
+          makeResponse({
+            _embedded: {
+              records: [
+                { type: "payment", asset_code: "USDC", to: "GISSUER", amount: "500" },
+                { type: "payment", asset_code: "USDC", to: "GISSUER", amount: "300" },
+                // not a burn — recipient is not the issuer
+                { type: "payment", asset_code: "USDC", to: "GOTHER", amount: "100" },
+                // not a burn — different asset
+                { type: "payment", asset_code: "EURC", to: "GISSUER", amount: "999" },
+              ],
+            },
+          })
+        )
+      );
+
+      const result = await ctx.service.getBurnStatistics("USDC", "GISSUER", "10000");
+
+      expect(result.burnCount).toBe(2);
+      expect(result.totalBurned).toBe("800.0000000");
+      expect(result.percentBurned).toBe("8.0000");
+    });
+
+    it('reports "0.0000" burned percentage when total supply is zero', async () => {
+      ctx.httpService.get.mockReturnValue(
+        of(
+          makeResponse({
+            _embedded: {
+              records: [
+                { type: "payment", asset_code: "USDC", to: "GISSUER", amount: "5" },
+              ],
+            },
+          })
+        )
+      );
+
+      const result = await ctx.service.getBurnStatistics("USDC", "GISSUER", "0");
+
+      expect(result.percentBurned).toBe("0.0000");
+      expect(result.burnCount).toBe(1);
+    });
+
+    it("returns zeroed stats when the Horizon request fails", async () => {
+      ctx.httpService.get.mockReturnValue(
+        throwError(() => new Error("timeout"))
+      );
+
+      expect(
+        await ctx.service.getBurnStatistics("USDC", "GISSUER", "10000")
+      ).toEqual({ totalBurned: "0", burnCount: 0, percentBurned: "0.0000" });
+    });
+  });
+
+  // ── getVolumeData ──────────────────────────────────────────────────────
+  describe("getVolumeData", () => {
+    it("splits trade volume into 24h and 7d buckets", async () => {
+      const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+      const threeDaysAgo = new Date(
+        Date.now() - 3 * 24 * 60 * 60 * 1000
+      ).toISOString();
+
+      ctx.httpService.get.mockReturnValue(
+        of(
+          makeResponse({
+            _embedded: {
+              records: [
+                { base_amount: "1000", counter_amount: "1", ledger_close_time: oneHourAgo },
+                { base_amount: "500", counter_amount: "1", ledger_close_time: threeDaysAgo },
+              ],
+            },
+          })
+        )
+      );
+
+      const result = await ctx.service.getVolumeData("USDC", "GISSUER");
+
+      expect(result.volume24h).toBe("1000.0000000");
+      expect(result.volume7d).toBe("1500.0000000");
+      expect(result.txCount24h).toBe(1);
+    });
+
+    it("returns zeroed volume when the Horizon request fails", async () => {
+      ctx.httpService.get.mockReturnValue(
+        throwError(() => new Error("connection reset"))
+      );
+
+      expect(await ctx.service.getVolumeData("USDC", "GISSUER")).toEqual({
+        volume24h: "0",
+        volume7d: "0",
+        txCount24h: 0,
+      });
+    });
+  });
+});


### PR DESCRIPTION
…ry; document validateEnv

Addresses four backend issues on a single branch.

#1875 — Analytics service zero-division / BigInt-truncation edge cases
  Add backend/src/token-analytics/__tests__/analytics.service.spec.ts. The suite
  instantiates AnalyticsService directly with an in-memory fake in place of the
  prisma client (routing each raw query by a distinctive SQL fragment) and
  covers the guarded arithmetic branches:
    * calcChangePercent when the previous period is zero (returns 100 when the current period grew, 0 when both are zero) plus a non-zero control case, asserted both directly and through getTokenAnalytics.
    * averageBurnAmount BigInt division truncates toward zero for a non-evenly-divisible volume/count pair (7/2 -> "3", never "3.5"/"4"), including a large-integer case, and returns "0" under the count === 0 guard.
    * burnFrequencyPerDay returns 0 (not Infinity/NaN) when windowDurationDays is zero, and a finite rate for a normal window.

#1877 — Missing tests for the token-info Stellar service
  Add backend/src/token-info/__tests__/stellar.service.spec.ts with the HTTP
  client mocked via rxjs Observables (no network calls). Every public method is
  covered for its success path and at least one realistic failure mode:
  getAssetData, getAssetCreationInfo, getBurnStatistics, getVolumeData (success
  + Horizon error / empty / malformed payload) and parseAddress (both input shapes).

#1874 — Cache-key collision gap in the burn-history service
  Add backend/src/burn-history/__tests__/burn-history.service.spec.ts asserting
  buildCacheKey yields distinct keys when only page, only sortBy or only
  sortOrder differ, and a distinct key for every distinguishing parameter
  (tokenAddress, type, startDate, endDate, page, limit, sortBy, sortOrder);
  plus getHistory cache behaviour — a hit returns the cached response without
  touching the query builder or re-caching, and a miss falls through to the
  query builder and stores the result under the exact key it looked up.
  burn-history.service.ts imported its entity/dto/interface from non-existent
  ./entities, ./dto and ./interfaces subfolders; corrected the three paths to
  the sibling modules so the service can be loaded under test.

#1878 — Document the environment variables enforced by validateEnv
  Rewrite backend/.env.example so every variable validateEnv() reads is listed
  with a comment covering production requirement, expected format and
  development default, and add an "Environment Variables" section to
  backend/README.md that points to src/config/env.ts as the source of truth and
  spells out the testnet/mainnet network-default behaviour for
  STELLAR_HORIZON_URL / STELLAR_SOROBAN_RPC_URL / STELLAR_NETWORK_PASSPHRASE.

Verification: npx vitest run over the three new spec files and src/config — 49 tests pass. (Repo-wide `npm run lint` / `npm test` are not runnable in this environment: eslint is not installed and several pre-existing modules depend on uninstalled packages.)

Closes #1878 
Closes #1874 
Closes #1877 
Closes #1875 