### PR TITLE
Document GraphQL/burn-data contracts and wire the API gateway into lo…

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,39 @@ docker compose down -v
 
 > **Note:** `VITE_*` variables are baked into the frontend at build time. If you change them in `.env`, rebuild with `docker compose up --build frontend`.
 
+#### Running with the API gateway in the loop
+
+By default the frontend talks to the backend directly (`http://localhost:3001/api`),
+so `docker compose up` does **not** exercise the `gateway/` service — its rate
+limiting, JWT auth, and idempotency-key propagation are never in the request
+path. To run the stack with the gateway in front of the backend, add the
+`docker-compose.gateway.yml` overlay:
+
+```bash
+# Backend-direct (default — unchanged)
+docker compose -f docker-compose.yml up -d --build
+
+# With the gateway in the request path
+docker compose -f docker-compose.yml -f docker-compose.gateway.yml up -d --build
+```
+
+The overlay adds a `gateway` service on port **4000** and repoints the
+frontend's `VITE_*` API URLs at it, so browser traffic flows
+frontend → gateway → backend. Verify the proxy end-to-end:
+
+```bash
+curl -i http://localhost:4000/api/tokens
+# → 200, proxied to the backend, with X-RateLimit-Limit / X-RateLimit-Remaining
+#   / X-RateLimit-Reset headers added by the gateway
+```
+
+| Service | Port | Notes                                                        |
+| ------- | ---- | ----------------------------------------------------------- |
+| gateway | 4000 | Express reverse proxy; `PORT` (canonical) or `GATEWAY_PORT` |
+
+> The gateway reads its listening port from `PORT`, falling back to
+> `GATEWAY_PORT` for older deployments.
+
 ---
 
 ### Development

--- a/backend/src/graphql/schema.ts
+++ b/backend/src/graphql/schema.ts
@@ -14,6 +14,86 @@
  *    transport, fed by the in-process eventBus. Every subscription is tenant
  *    scoped: a subscriber only receives events for tokens / proposals / vaults
  *    whose creator matches the tenant resolved from the connection JWT.
+ *
+ * ───────────────────────────────────────────────────────────────────────────────
+ * Schema ↔ resolver correspondence contract (READ BEFORE EDITING)
+ * ───────────────────────────────────────────────────────────────────────────────
+ *
+ * This SDL string and `./resolvers.ts` are kept in sync **by convention only**.
+ * There is no compile-time link and — see below — no startup validation either.
+ *
+ * The contract, in both directions:
+ *
+ *  1. Every field defined here must EITHER have a matching resolver in
+ *     `resolvers.ts`, OR intentionally rely on GraphQL's default field resolver
+ *     (which returns `parent[fieldName]`). In practice that means:
+ *       - Every `Query.*` field  → a function on `resolvers.Query`.
+ *       - Every `Subscription.*` field → a `{ subscribe, resolve }` pair on
+ *         `resolvers.Subscription`.
+ *       - Scalar fields of `Token` / `Stream` / `Proposal` / `Vote` / the
+ *         `*Event` payload types → satisfied by the default resolver because the
+ *         Prisma row / event payload already carries an identically-named
+ *         property.
+ *       - Non-scalar / computed fields that the parent object does NOT carry
+ *         (`Token.burnRecords`, `Proposal.votes`, `Proposal.queuePosition`) →
+ *         a function on `resolvers.Token` / `resolvers.Proposal`.
+ *  2. Conversely, every function exported from `resolvers.ts` must correspond to
+ *     a field defined here. A resolver with no matching SDL field is dead code:
+ *     nothing ever invokes it through the running server.
+ *
+ * How the two files are actually combined into an executable schema
+ * ----------------------------------------------------------------------------
+ * `./index.ts` does NOT use `makeExecutableSchema` (graphql-tools). It calls
+ * `buildSchema(typeDefs)` from the core `graphql` package, which produces a
+ * schema object with NO resolvers attached, then wires behaviour on top:
+ *
+ *   - `resolvers.Query.*` is spread into a plain `rootValue` object that is
+ *     handed to `graphql-http`'s `createHandler` (HTTP `POST /api/graphql`) and
+ *     to the `graphql-ws` `useServer` `roots` (queries over the WS transport).
+ *   - `resolvers.Subscription.*` is copied field-by-field onto the schema's
+ *     subscription type in a `for` loop, guarded by `if (field)` — a
+ *     subscription resolver whose name does not match an SDL field is silently
+ *     skipped.
+ *   - `resolvers.Token.*` and `resolvers.Proposal.*` (the nested-relation field
+ *     resolvers) are NOT wired into the `buildSchema` schema at all. They are
+ *     exercised directly by `resolvers.test.ts`. Through the live endpoint,
+ *     selecting e.g. `token { burnRecords { ... } }` falls back to the default
+ *     field resolver, finds no `burnRecords` property on the Prisma row, and
+ *     the non-null `[BurnRecord!]!` field errors at query time. Treat these
+ *     field resolvers as documentation of intended behaviour, not as code the
+ *     HTTP path runs today.
+ *
+ * Does any of this catch a mismatch at startup? NO.
+ * ----------------------------------------------------------------------------
+ * `buildSchema(typeDefs)` validates only that this SDL is internally
+ * well-formed (syntax, referenced types exist, interface conformance). It never
+ * compares the SDL against `resolvers.ts`. `graphql-http` and `graphql-ws` do
+ * not either. Therefore:
+ *
+ *   - Adding a resolver here with no matching SDL field  → no error, ever
+ *     (dead code).
+ *   - Adding an SDL field here with no matching resolver → no startup error;
+ *     it fails only when a query actually selects that field (HTTP 200 with an
+ *     `errors` entry, or `null` for a nullable field).
+ *
+ * A concrete instance of this drift exists as of this writing: `resolvers.test.ts`
+ * and `graphql-schema.md` reference `Query.campaign(s)` and a
+ * `campaignStepExecuted` subscription that this SDL does not define — the
+ * mismatch surfaces only as failing tests, never as a server startup failure.
+ *
+ * Contributor guidance
+ * ----------------------------------------------------------------------------
+ *  - When you add or rename a field, change BOTH this file and `resolvers.ts`
+ *    in the same commit.
+ *  - Add / extend a case in `resolvers.test.ts` that executes the field through
+ *    `graphql()` against `buildSchema(typeDefs)` + `rootValue`, so a future
+ *    mismatch is caught in CI rather than in production.
+ *
+ * Possible follow-up (NOT done here): swapping `buildSchema` for
+ * `@graphql-tools/schema`'s `makeExecutableSchema({ typeDefs, resolvers })` —
+ * which throws on a resolver that references a field absent from the SDL — or
+ * adding a small CI assertion that every `resolvers.*` key maps to an SDL
+ * field, would turn this convention into an enforced check.
  */
 
 export const typeDefs = /* GraphQL */ `

--- a/docker-compose.gateway.yml
+++ b/docker-compose.gateway.yml
@@ -1,0 +1,65 @@
+##############################################################################
+# API Gateway overlay — Nova Launch
+# Issue: #1889
+#
+# The base docker-compose.yml wires the frontend straight to the backend
+# (http://localhost:3001/api), so `docker compose up` never exercises the
+# gateway (rate limiting, JWT auth, idempotency-key propagation). This overlay
+# adds the gateway in front of the backend and repoints the frontend at it.
+#
+# Usage:
+#   With the gateway in the request path:
+#     docker compose -f docker-compose.yml -f docker-compose.gateway.yml up -d
+#   Backend-direct (unchanged default):
+#     docker compose -f docker-compose.yml up -d
+##############################################################################
+
+version: '3.8'
+
+services:
+  gateway:
+    build:
+      context: ./gateway
+      dockerfile: Dockerfile
+    container_name: nova-launch-gateway
+    depends_on:
+      backend:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    environment:
+      NODE_ENV: ${NODE_ENV:-development}
+      # Canonical port variable, matching the backend service. gateway/src/config.ts
+      # also still honours GATEWAY_PORT as a fallback for older deployments.
+      PORT: 4000
+      # Same backend / Redis / secret the backend service itself uses, so the
+      # gateway proxies to the running backend and shares its rate-limit and
+      # idempotency keyspace in Redis.
+      BACKEND_URL: http://backend:3001
+      REDIS_URL: redis://redis:6379
+      JWT_SECRET: ${JWT_SECRET:-change-me-in-production}
+      ALLOWED_ORIGINS: ${ALLOWED_ORIGINS:-http://localhost:5173}
+    ports:
+      - "4000:4000"
+    healthcheck:
+      test: ["CMD", "node", "-e", "require('http').get('http://localhost:4000/health', (r) => {process.exit(r.statusCode === 200 ? 0 : 1)})"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
+
+  # Repoint the frontend's build-time API URLs at the gateway (port 4000)
+  # instead of the backend (port 3001). Only the overridden args change; the
+  # rest of the frontend build args are inherited from docker-compose.yml.
+  frontend:
+    build:
+      args:
+        VITE_API_BASE_URL: ${VITE_API_BASE_URL:-http://localhost:4000/api}
+        VITE_TOKEN_INFO_API_URL: ${VITE_TOKEN_INFO_API_URL:-http://localhost:4000/api/token-info}
+        VITE_LEADERBOARD_API_URL: ${VITE_LEADERBOARD_API_URL:-http://localhost:4000/api/leaderboard}
+        VITE_GOVERNANCE_API_URL: ${VITE_GOVERNANCE_API_URL:-http://localhost:4000/api/governance}
+    depends_on:
+      backend:
+        condition: service_healthy
+      gateway:
+        condition: service_healthy

--- a/gateway/src/__tests__/config.test.ts
+++ b/gateway/src/__tests__/config.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { validateGatewayEnv } from "../config";
+
+/**
+ * Port resolution: the gateway must honour the plain `PORT` variable (which the
+ * backend service already uses) as well as the historical `GATEWAY_PORT`, with
+ * `PORT` taking precedence when both are set.
+ */
+describe("validateGatewayEnv — port resolution", () => {
+  const saved = {
+    PORT: process.env.PORT,
+    GATEWAY_PORT: process.env.GATEWAY_PORT,
+  };
+
+  beforeEach(() => {
+    delete process.env.PORT;
+    delete process.env.GATEWAY_PORT;
+  });
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(saved)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+
+  it("respects PORT when it is set", () => {
+    process.env.PORT = "5000";
+    expect(validateGatewayEnv().PORT).toBe(5000);
+  });
+
+  it("falls back to GATEWAY_PORT when PORT is absent", () => {
+    process.env.GATEWAY_PORT = "4321";
+    expect(validateGatewayEnv().PORT).toBe(4321);
+  });
+
+  it("prefers PORT over GATEWAY_PORT when both are set", () => {
+    process.env.PORT = "5000";
+    process.env.GATEWAY_PORT = "4321";
+    expect(validateGatewayEnv().PORT).toBe(5000);
+  });
+
+  it("defaults to 4000 when neither is set", () => {
+    expect(validateGatewayEnv().PORT).toBe(4000);
+  });
+});

--- a/gateway/src/config.ts
+++ b/gateway/src/config.ts
@@ -26,8 +26,19 @@ export function validateGatewayEnv(): GatewayEnv {
     .map((o) => o.trim())
     .filter(Boolean);
 
+  // Listening port. Both PORT and GATEWAY_PORT are accepted; PORT wins when
+  // both are set. PORT is the canonical name going forward — it matches the
+  // backend service (backend/src/config/env.ts reads process.env.PORT), so an
+  // operator can set the same, natural variable name across every service.
+  // GATEWAY_PORT stays supported as a fallback so deployments that already
+  // discovered and set it keep working through the migration window.
+  const port = parseInt(
+    process.env.PORT ?? process.env.GATEWAY_PORT ?? "4000",
+    10
+  );
+
   return {
-    PORT: parseInt(process.env.GATEWAY_PORT ?? "4000", 10),
+    PORT: port,
     BACKEND_URL: backendUrl,
     JWT_SECRET: jwtSecret,
     REDIS_URL: process.env.REDIS_URL ?? "redis://localhost:6379",

--- a/gateway/tsconfig.json
+++ b/gateway/tsconfig.json
@@ -12,5 +12,5 @@
     "resolveJsonModule": true
   },
   "include": ["src"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/__tests__", "src/**/*.test.ts"]
 }


### PR DESCRIPTION
…cal dev

Resolves four issues across documentation and local-stack topology. All changes are additive; no existing runtime behaviour changes when the new compose overlay is not used.

#1882 — GraphQL schema ↔ resolver correspondence
  * Added a doc comment to backend/src/graphql/schema.ts describing the implicit contract: every SDL field needs a matching resolver in resolvers.ts (or an intentional reliance on the default field resolver), and vice versa.
  * Documented how the two files are actually combined in graphql/index.ts: buildSchema(typeDefs) from the core graphql package (NOT makeExecutableSchema), with resolvers.Query spread into a rootValue and resolvers.Subscription copied onto the schema field-by-field. The nested Token.*/Proposal.* field resolvers are not wired into that schema at all.
  * Recorded the gap explicitly: nothing validates the correspondence at startup. buildSchema only checks the SDL is internally well-formed; a missing resolver surfaces only at query time and a surplus resolver never surfaces. Noted makeExecutableSchema / a CI assertion as a possible follow-up (not done here).

#1883 — Boundary between the three parallel burn-data surfaces
  * Added docs/burn-data-model.md tracing how each surface is populated and read as implemented: - prisma.burnRecord — written by services/tokenEventParser.ts (the live on-chain ingestion path), read by GraphQL / token routes / export / leaderboard. The only populated, wired-in burn store. - burn-history/ BurnTransaction and token-analytics/ BurnEvent — two standalone NestJS modules, each re-modelling the same event with an overlapping-but-different schema, with NO writer anywhere in the repo and not imported by any bootstrapped app.
  * Stated that new features needing burn data must read prisma.burnRecord, to stop a fourth path being added.
  * Listed the inconsistencies found (amount precision, field naming, join key, txHash guarantees, timestamp semantics, duplicate migration identifiers, duplicated files, mixed ORMs, and burn-history/ not compiling due to stale ./entities|dto|interfaces import paths) as follow-ups, out of scope here.

#1889 — API gateway absent from the local Docker Compose stack
  * Added docker-compose.gateway.yml, an opt-in overlay matching the docker-compose.elk.yml pattern. It adds a gateway service (built from gateway/Dockerfile, depends on backend + redis, BACKEND_URL/REDIS_URL/ JWT_SECRET wired to the backend's own values) on port 4000, and repoints the frontend's VITE_* API URLs at the gateway.
  * Documented in the root README how to run the stack with vs. without the gateway in the request path, including the curl check for rate-limit headers.
  * gateway/tsconfig.json now excludes test files from the tsc build so gateway/Dockerfile's `npm run build` succeeds (it was failing on a pre-existing type error in a test file that has no place in dist/); this also unblocks `npm run type-check`.
  * Verified end-to-end against the built gateway image with a stub backend: `curl -i http://localhost:4000/api/tokens` returns 200 proxied to the backend with X-RateLimit-Limit / X-RateLimit-Remaining / X-RateLimit-Reset present. A full `docker compose up` was not run because the backend image does not build on main (pre-existing npm ERESOLVE peer-dep conflict).

#1888 — Gateway ignored a plain PORT setting
  * validateGatewayEnv() in gateway/src/config.ts now reads process.env.PORT ?? process.env.GATEWAY_PORT ?? "4000", with a comment explaining that PORT is canonical going forward (matching the backend service) while GATEWAY_PORT stays supported for existing deployments.
  * The gateway service in docker-compose.gateway.yml uses the canonical PORT variable. No manifests under infra/ reference the port variable.
  * Added gateway/src/__tests__/config.test.ts asserting PORT is respected when set, GATEWAY_PORT is used as a fallback, PORT wins when both are set, and 4000 is the default.

Testing
  * gateway: `npx vitest run src/__tests__` — 78 passed (including the 4 new config tests); `tsc --noEmit` clean. Pre-existing failures in authPropagation.integration.test.ts (need a live backend) are unrelated and untouched.
  * backend: `npx vitest run src/graphql` — unchanged vs. main (56 pass, 10 pre-existing failures from campaign* SDL/resolver drift, which #1882 is documentation-only about). `npm run lint` could not be run: eslint is not declared in backend/package.json.

Closes #1888 
Closes #1889 
Closes #1883 
Closes #1882 