### PR TITLE
Fix gateway dead-letter route, harden JWT secrets, document metrics +…

### DIFF
--- a/backend/src/__tests__/contractIdMisconfig.test.ts
+++ b/backend/src/__tests__/contractIdMisconfig.test.ts
@@ -25,6 +25,7 @@ async function runValidateEnv(env: Record<string, string>) {
   vi.stubEnv('FACTORY_CONTRACT_ID', env.FACTORY_CONTRACT_ID ?? '');
   vi.stubEnv('DATABASE_URL', env.DATABASE_URL ?? 'postgresql://localhost/test');
   vi.stubEnv('JWT_SECRET', env.JWT_SECRET ?? 'super-secret-jwt-key-for-testing');
+  vi.stubEnv('ADMIN_JWT_SECRET', env.ADMIN_JWT_SECRET ?? 'super-secret-admin-jwt-key-for-testing');
 
   const { validateEnv } = await import('../config/env');
   return validateEnv();

--- a/backend/src/__tests__/jwtSecretProductionGuard.test.ts
+++ b/backend/src/__tests__/jwtSecretProductionGuard.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Backend startup — JWT secret production guard (Issue #1887)
+ *
+ * docker-compose.yml ships fallback literals for JWT_SECRET
+ * (`change-me-in-production`) and ADMIN_JWT_SECRET
+ * (`change-me-admin-in-production`). Both are committed to a public repo, so a
+ * production process started with either must fail fast via validateEnv().
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/** Runs validateEnv() with the given env overrides, isolated from other tests. */
+async function runValidateEnv(env: Record<string, string>) {
+  vi.resetModules();
+  vi.stubEnv('NODE_ENV', env.NODE_ENV ?? 'production');
+  vi.stubEnv('STELLAR_NETWORK', env.STELLAR_NETWORK ?? 'testnet');
+  vi.stubEnv('FACTORY_CONTRACT_ID', env.FACTORY_CONTRACT_ID ?? 'C' + 'A'.repeat(55));
+  vi.stubEnv('DATABASE_URL', env.DATABASE_URL ?? 'postgresql://localhost/test');
+  vi.stubEnv('JWT_SECRET', env.JWT_SECRET ?? 'super-secret-jwt-key-for-testing');
+  vi.stubEnv('ADMIN_JWT_SECRET', env.ADMIN_JWT_SECRET ?? 'super-secret-admin-key-for-testing');
+
+  const { validateEnv } = await import('../config/env');
+  return validateEnv();
+}
+
+describe('Backend startup — JWT secret production guard', () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it('throws in production when JWT_SECRET is the docker-compose default', async () => {
+    await expect(
+      runValidateEnv({ JWT_SECRET: 'change-me-in-production' })
+    ).rejects.toThrow(/JWT_SECRET must be set to a secure value in production/);
+  });
+
+  it('throws in production when ADMIN_JWT_SECRET is the docker-compose default', async () => {
+    await expect(
+      runValidateEnv({ ADMIN_JWT_SECRET: 'change-me-admin-in-production' })
+    ).rejects.toThrow(/ADMIN_JWT_SECRET must be set to a secure value in production/);
+  });
+
+  it('throws in production when either secret is empty', async () => {
+    await expect(runValidateEnv({ JWT_SECRET: '' })).rejects.toThrow(/JWT_SECRET/);
+    await expect(runValidateEnv({ ADMIN_JWT_SECRET: '' })).rejects.toThrow(
+      /ADMIN_JWT_SECRET/
+    );
+  });
+
+  it('still throws for the legacy placeholder secret', async () => {
+    await expect(
+      runValidateEnv({ JWT_SECRET: 'your-secret-key-change-in-production' })
+    ).rejects.toThrow(/JWT_SECRET/);
+  });
+
+  it('accepts strong secrets in production', async () => {
+    const env = await runValidateEnv({
+      JWT_SECRET: 'a-real-long-random-production-secret',
+      ADMIN_JWT_SECRET: 'a-different-real-long-random-admin-secret',
+    });
+    expect(env.JWT_SECRET).toBe('a-real-long-random-production-secret');
+    expect(env.ADMIN_JWT_SECRET).toBe('a-different-real-long-random-admin-secret');
+  });
+
+  it('does not enforce the guard outside production', async () => {
+    const env = await runValidateEnv({
+      NODE_ENV: 'development',
+      JWT_SECRET: 'change-me-in-production',
+      ADMIN_JWT_SECRET: 'change-me-admin-in-production',
+    });
+    expect(env.NODE_ENV).toBe('development');
+  });
+});

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -28,6 +28,33 @@ export interface BackendEnv {
   FACTORY_CONTRACT_ID: string;
   DATABASE_URL: string;
   JWT_SECRET: string;
+  ADMIN_JWT_SECRET: string;
+}
+
+/**
+ * Secret values that are publicly known — placeholder strings and the fallback
+ * literals committed in `docker-compose.yml`
+ * (`JWT_SECRET: ${JWT_SECRET:-change-me-in-production}` /
+ * `ADMIN_JWT_SECRET: ${ADMIN_JWT_SECRET:-change-me-admin-in-production}`).
+ * Any of these reaching a `NODE_ENV=production` process means anyone can forge a
+ * token, so `validateEnv()` fails fast on them.
+ */
+const INSECURE_SECRET_VALUES = new Set([
+  'your-secret-key-change-in-production',
+  'change-me-in-production',
+  'change-me-admin-in-production',
+  'dev-secret-key-change-me',
+  'dev-admin-secret-key-change-me',
+]);
+
+function assertSecureProductionSecret(name: string, value: string): void {
+  if (!value || INSECURE_SECRET_VALUES.has(value)) {
+    throw new Error(
+      `${name} must be set to a secure value in production` +
+      (value ? ` — the committed default "${value}" is publicly known` : '') +
+      '. Override it via .env / your environment (see .env.example).'
+    );
+  }
 }
 
 export function validateEnv(): BackendEnv {
@@ -67,11 +94,12 @@ export function validateEnv(): BackendEnv {
   const jwtSecret =
     process.env.JWT_SECRET ||
     (isProduction ? '' : 'dev-secret-key-change-me');
-  if (
-    isProduction &&
-    (!jwtSecret || jwtSecret === 'your-secret-key-change-in-production')
-  ) {
-    throw new Error('JWT_SECRET must be set to a secure value in production.');
+  const adminJwtSecret =
+    process.env.ADMIN_JWT_SECRET ||
+    (isProduction ? '' : 'dev-admin-secret-key-change-me');
+  if (isProduction) {
+    assertSecureProductionSecret('JWT_SECRET', jwtSecret);
+    assertSecureProductionSecret('ADMIN_JWT_SECRET', adminJwtSecret);
   }
 
   return {
@@ -84,5 +112,6 @@ export function validateEnv(): BackendEnv {
     FACTORY_CONTRACT_ID: factoryContractId,
     DATABASE_URL: databaseUrl,
     JWT_SECRET: jwtSecret,
+    ADMIN_JWT_SECRET: adminJwtSecret,
   };
 }

--- a/backend/src/graphql/index.ts
+++ b/backend/src/graphql/index.ts
@@ -178,6 +178,49 @@ interface ConnectionExtra {
  * JWT validation as the REST tenancy middleware. Accepts the token via an
  * `authorization` / `Authorization` ("Bearer <jwt>") field or a bare
  * `authToken` field. Returns null when no valid tenant can be derived.
+ *
+ * ---------------------------------------------------------------------------
+ * GraphQL subscription connection_init JWT-to-tenant handshake contract
+ * ---------------------------------------------------------------------------
+ * This function (called from `onConnect` below) is the *only* place GraphQL
+ * subscriptions authenticate. It is an independent JWT-parsing path — REST and
+ * GraphQL Query traffic never flow through here — so it must stay compatible
+ * with whatever token shape `TokenService.generateTokenPair` produces. A
+ * change to the JWT claims or signing secret on one side without the other
+ * silently breaks realtime subscriptions while REST/Query traffic keeps
+ * working (and vice versa).
+ *
+ * Where the JWT is read from:
+ *   The graphql-ws client sends a `connection_init` message whose `payload`
+ *   becomes `ctx.connectionParams`. The token is taken from, in order:
+ *     params.authorization  -> params.Authorization  -> params.authToken
+ *   A leading "Bearer " prefix is stripped; the remainder is the raw JWT.
+ *
+ * Which claim populates SubscriptionContext.tenant.id:
+ *   `extractTenantFromJwt` (../middleware/tenancy) runs `jwt.verify(token,
+ *   JWT_SECRET)` and reads `payload.tenantId ?? payload.tenant_id`. That value
+ *   must pass `validateTenantId` (1–64 chars of [A-Za-z0-9_-]) and becomes
+ *   `tenant.id`. `payload.tenantName`, if a string, becomes `tenant.name`.
+ *   The signing secret is `process.env.JWT_SECRET` (falls back to
+ *   "dev-secret-key" only when unset — dev/test convenience).
+ *
+ * Missing / invalid / expired token — how "unauthenticated connections never
+ * receive any events" (see resolvers.ts `SubscriptionContext`) is enforced:
+ *   - No params, no recognised token field, or a non-string/empty token
+ *     -> this function returns null.
+ *   - Bad signature, expired (`exp`), malformed, or missing/invalid tenant
+ *     claim -> `jwt.verify` throws or `validateTenantId` fails; the `catch`
+ *     in `extractTenantFromJwt` returns null.
+ *   - `onConnect` returns `false` on a null tenant, so graphql-ws rejects the
+ *     handshake and closes the socket with code 4403 — the client never
+ *     reaches `onSubscribe`, so zero events are ever delivered. There is no
+ *     "anonymous" code path: without a resolved `tenant.id`, `tenantOwnsEvent`
+ *     in resolvers.ts would also return false.
+ *
+ * Executable spec: src/graphql/__tests__/subscriptions.integration.test.ts
+ *   ("delivers a tokenDeployed event to an authenticated subscriber",
+ *    "does not deliver another tenant's events",
+ *    "rejects a connection with no/invalid JWT").
  */
 function resolveTenantFromConnectionParams(
   params: Record<string, unknown> | undefined
@@ -227,7 +270,11 @@ export function attachGraphqlSubscriptions(
       subscribe,
       roots: { query: rootValue, mutation: rootValue, subscription: rootValue },
 
-      // Validate the JWT on the connection_init handshake and stash the tenant.
+      // connection_init handshake: parse the JWT from ctx.connectionParams,
+      // resolve the tenant, and stash it on ctx.extra. Full contract (token
+      // location, claim mapping, missing/invalid-token behaviour, and the
+      // coupling to TokenService.generateTokenPair) is documented on
+      // `resolveTenantFromConnectionParams` above.
       onConnect: (ctx) => {
         const tenant = resolveTenantFromConnectionParams(
           ctx.connectionParams as Record<string, unknown> | undefined

--- a/backend/src/graphql/resolvers.ts
+++ b/backend/src/graphql/resolvers.ts
@@ -73,6 +73,15 @@ export const SUBSCRIPTION_TOPICS = {
  * connection JWT during the graphql-ws `connection_init` handshake (see
  * graphql/index.ts). It is undefined only for unauthenticated connections,
  * which never receive any events.
+ *
+ * The full handshake contract — where the JWT is read from in the
+ * `connection_init` payload, that `tenantId` / `tenant_id` populates
+ * `tenant.id`, how a missing/invalid/expired token is rejected (4403 close,
+ * zero events), and the requirement that this path stay compatible with
+ * `TokenService.generateTokenPair` — is documented on
+ * `resolveTenantFromConnectionParams` in graphql/index.ts. Keep the two in
+ * sync; the executable spec is
+ * src/graphql/__tests__/subscriptions.integration.test.ts.
  */
 export interface SubscriptionContext {
   tenant?: { id: string; name?: string };

--- a/backend/src/lib/metrics/index.ts
+++ b/backend/src/lib/metrics/index.ts
@@ -1,13 +1,16 @@
 /**
- * Metrics re-export shim.
+ * Canonical Prometheus metrics module for the backend.
  *
- * The canonical implementation lives in `monitoring/metrics/prometheus-config.ts`
- * (workspace root). This shim re-exports everything from there so that backend
- * source files can import from a path that stays within `src/` and is therefore
- * compatible with the TypeScript `rootDir: "./src"` constraint.
+ * This file holds the REAL implementation (backed by `prom-client`). It is the
+ * one wired into `src/index.ts` via `createMetricsMiddleware()` and exposed at
+ * `GET /metrics` for Prometheus to scrape. All new backend metrics belong here.
  *
- * If you ever move the monitoring package to a separate npm workspace, update
- * only this file.
+ * Do NOT confuse this with `src/monitoring/metrics/prometheus-config.ts`, which
+ * is an all-no-op stub with nearly identical export names
+ * (`httpRequestDuration`, `errorTotal`, …). Anything registered against that
+ * stub is silently discarded. It survives only because a few services still
+ * import `IntegrationMetrics` from it (see the header comment in that file and
+ * the companion "wire services to real metrics" issue).
  */
 
 // prom-client is a direct dependency of the backend (see package.json).

--- a/backend/src/monitoring/metrics/prometheus-config.ts
+++ b/backend/src/monitoring/metrics/prometheus-config.ts
@@ -1,3 +1,31 @@
+/**
+ * ⚠️ NO-OP STUB — NOT THE LIVE METRICS MODULE ⚠️
+ *
+ * Every export in this file (metrics, `register`, `IntegrationMetrics`,
+ * `MetricsCollector`, `createMetricsMiddleware`) is a no-op: `.inc()`,
+ * `.observe()`, `.set()` and the `record*` helpers do nothing, and
+ * `register.metrics()` returns an empty string. Nothing recorded here is ever
+ * scraped by Prometheus.
+ *
+ * The REAL, canonical Prometheus implementation (backed by `prom-client`, wired
+ * into `index.ts` via `createMetricsMiddleware()` and exposed at `GET /metrics`)
+ * lives in `backend/src/lib/metrics/index.ts`. Add or update metrics THERE.
+ *
+ * Why this stub still exists: three services still import `IntegrationMetrics`
+ * from this path instead of the real module —
+ *   - src/services/notificationService.ts
+ *   - src/services/webhookDeliveryService.ts
+ *   - src/services/stellarEventListener.ts
+ * so their integration-metric calls are currently silently discarded. Wiring
+ * those imports to `lib/metrics` is tracked by the companion "wire services to
+ * real metrics" issue; once that lands this file has no importers and should be
+ * deleted outright.
+ *
+ * Beware: export names here (`httpRequestDuration`, `errorTotal`, …) are nearly
+ * identical to the real module's, so an import from the wrong path compiles
+ * cleanly and produces a metric that is never recorded.
+ */
+
 type LabelValues = Record<string, string | number | boolean | undefined>;
 
 class NoopMetric {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,8 +44,17 @@ services:
       NODE_ENV: development
       PORT: 3001
       DATABASE_URL: postgresql://${POSTGRES_USER:-nova_user}:${POSTGRES_PASSWORD:-nova_password}@postgres:5432/nova_launch
+      # ⚠️ LOCAL DEVELOPMENT ONLY. These fallback secrets are committed to a
+      # public repo, so anyone can forge access/admin tokens against them.
+      # Before ANY non-local deployment you MUST override JWT_SECRET and
+      # ADMIN_JWT_SECRET via .env or the environment — copy .env.example to
+      # .env and set strong random values. A NODE_ENV=production backend
+      # started with either of these defaults fails fast in
+      # backend/src/config/env.ts (validateEnv()).
       JWT_SECRET: ${JWT_SECRET:-change-me-in-production}
       JWT_EXPIRES_IN: ${JWT_EXPIRES_IN:-24h}
+      # ⚠️ LOCAL DEVELOPMENT ONLY — see the note above JWT_SECRET. Override via
+      # .env / environment (see .env.example) before any non-local deployment.
       ADMIN_JWT_SECRET: ${ADMIN_JWT_SECRET:-change-me-admin-in-production}
       ADMIN_JWT_EXPIRES_IN: ${ADMIN_JWT_EXPIRES_IN:-8h}
       STELLAR_NETWORK: ${STELLAR_NETWORK:-testnet}

--- a/gateway/src/__tests__/app.test.ts
+++ b/gateway/src/__tests__/app.test.ts
@@ -146,6 +146,33 @@ describe("Per-route requiresAuth flag", () => {
   });
 });
 
+// ── Webhook dead-letter admin recovery route reachability ────────────────────
+
+describe("/api/webhooks-deadletter proxying", () => {
+  const app = createApp({ env: ENV, redis: mockRedis() });
+
+  it("does not fall through to the 404 handler for /api/webhooks-deadletter/anything", async () => {
+    const res = await request(app)
+      .get("/api/webhooks-deadletter/anything")
+      .set("Authorization", `Bearer ${validToken()}`);
+    // Reaches the proxy layer (backend is absent → 502), never the 404 fallback.
+    expect(res.status).not.toBe(404);
+  });
+
+  it("enforces auth on /api/webhooks-deadletter (requiresAuth: true), not a 404", async () => {
+    const res = await request(app).get("/api/webhooks-deadletter/failed");
+    expect(res.status).toBe(401);
+  });
+
+  it("passes auth with a valid token and proxies (may 502 — that's fine)", async () => {
+    const res = await request(app)
+      .post("/api/webhooks-deadletter/retry/123")
+      .set("Authorization", `Bearer ${validToken()}`);
+    expect(res.status).not.toBe(401);
+    expect(res.status).not.toBe(404);
+  });
+});
+
 // ── CORS ──────────────────────────────────────────────────────────────────────
 
 describe("CORS", () => {

--- a/gateway/src/__tests__/routes.test.ts
+++ b/gateway/src/__tests__/routes.test.ts
@@ -39,6 +39,21 @@ describe("ROUTES", () => {
     expect(wh?.requiresAuth).toBe(true);
   });
 
+  it("webhook dead-letter admin routes require auth and use the strict tier", () => {
+    const dl = ROUTES.find((r) => r.prefix === "/api/webhooks-deadletter");
+    expect(dl).toBeDefined();
+    expect(dl?.requiresAuth).toBe(true);
+    expect(dl?.tier).toBe("strict");
+  });
+
+  it("registers /api/webhooks-deadletter before the more general /api/webhooks", () => {
+    const dlIndex = ROUTES.findIndex((r) => r.prefix === "/api/webhooks-deadletter");
+    const whIndex = ROUTES.findIndex((r) => r.prefix === "/api/webhooks");
+    expect(dlIndex).toBeGreaterThanOrEqual(0);
+    expect(whIndex).toBeGreaterThanOrEqual(0);
+    expect(dlIndex).toBeLessThan(whIndex);
+  });
+
   it("leaderboard routes do not require auth", () => {
     const lb = ROUTES.find((r) => r.prefix === "/api/leaderboard");
     expect(lb?.requiresAuth).toBe(false);

--- a/gateway/src/routes.ts
+++ b/gateway/src/routes.ts
@@ -30,6 +30,9 @@ export const RATE_LIMIT_TIERS: Record<RateLimitTier, { windowMs: number; max: nu
 export const ROUTES: RouteConfig[] = [
   { prefix: "/api/admin",      tier: "strict",  requiresAuth: true  },
   { prefix: "/api/governance", tier: "strict",  requiresAuth: true  },
+  // More specific prefix listed before "/api/webhooks" so the route-registration
+  // loop in app.ts registers it first and the broader entry can never shadow it.
+  { prefix: "/api/webhooks-deadletter", tier: "strict", requiresAuth: true },
   { prefix: "/api/webhooks",   tier: "strict",  requiresAuth: true  },
   { prefix: "/api/tokens",     tier: "default", requiresAuth: false },
   { prefix: "/api/dividends",  tier: "default", requiresAuth: false },


### PR DESCRIPTION
… subscription handshake

Resolves four issues across the gateway and backend:

#1886 — Gateway: add missing /api/webhooks-deadletter route entry
  The gateway only proxies prefixes listed in ROUTES, so every webhook
  dead-letter admin recovery endpoint (list/retry/requeue failed deliveries)
  404'd through the gateway despite being fully implemented in the backend
  (mounted at v1Router.use("/webhooks-deadletter", ...)).
  - Add { prefix: "/api/webhooks-deadletter", tier: "strict", requiresAuth: true } to gateway/src/routes.ts, listed before the more general "/api/webhooks" entry so app.ts's in-order registration loop can never let the broader prefix shadow it (Express also segment-boundaries mount paths, so the two were already distinct — the ordering makes the intent explicit).
  - Tests: routes.test.ts asserts the new entry's tier/auth and its ordering vs "/api/webhooks"; app.test.ts asserts /api/webhooks-deadletter/* reaches the proxy layer (401 without a token, 502 with one) instead of the 404 fallback.

#1880 — Docs: GraphQL subscription connection_init JWT-to-tenant handshake
  The handshake that resolvers.ts's SubscriptionContext depends on had no
  contract documentation of its own.
  - Add a doc block to resolveTenantFromConnectionParams in graphql/index.ts (the function the connection_init onConnect handler calls) describing: where the JWT is read from in ctx.connectionParams (authorization -> Authorization -> authToken, "Bearer " stripped), which claim populates tenant.id (payload.tenantId ?? payload.tenant_id, via extractTenantFromJwt, validated by validateTenantId), and how a missing/invalid/expired token is rejected (null tenant -> onConnect returns false -> 4403 close -> zero events, never reaching onSubscribe).
  - Flag the coupling: this independent JWT path must stay compatible with TokenService.generateTokenPair's token shape or realtime subscriptions break silently while REST/Query traffic keeps working.
  - Bidirectional cross-reference between graphql/index.ts and resolvers.ts, and cite subscriptions.integration.test.ts as the executable spec.
  - No behaviour change; existing subscription tests still describe the same behaviour.

#1881 — Docs: clarify real vs stubbed Prometheus metrics modules
  Two modules with near-identical export names (httpRequestDuration,
  errorTotal, ...) coexisted with no docblock pointing at the other.
  - monitoring/metrics/prometheus-config.ts: prominent header stating it is an all-no-op stub, naming the three services that still import IntegrationMetrics from it (notificationService, webhookDeliveryService, stellarEventListener), and pointing to lib/metrics as the real implementation.
  - lib/metrics/index.ts: corrected the now-inaccurate "re-export shim" docblock to state plainly that this is the canonical module — the one wired into index.ts via createMetricsMiddleware() and exposed at GET /metrics.
  - Stub file left in place (its importers are addressed by the companion "wire services to real metrics" issue).

#1887 — Security: loud defaults + real enforcement for weak compose JWT secrets
  docker-compose.yml committed JWT_SECRET=${JWT_SECRET:-change-me-in-production}
  and ADMIN_JWT_SECRET=${ADMIN_JWT_SECRET:-change-me-admin-in-production}, both
  publicly known signing secrets.
  - docker-compose.yml: prominent comments above both lines stating the defaults are local-development-only and must be overridden via .env / environment (referencing .env.example) before any non-local deployment.
  - Cross-check result: backend/src/config/env.ts validateEnv() only rejected an empty JWT_SECRET or the exact legacy string "your-secret-key-change-in-production" — it would NOT have caught "change-me-in-production", and never checked ADMIN_JWT_SECRET at all. Fixed the enforcement point: an INSECURE_SECRET_VALUES blocklist (placeholder + committed compose/dev defaults) checked for both JWT_SECRET and ADMIN_JWT_SECRET when NODE_ENV=production; ADMIN_JWT_SECRET added to BackendEnv. Local dev is unaffected (guard only runs in production).
  - Tests: jwtSecretProductionGuard.test.ts verifies a production run with the exact committed compose defaults (and the empty / legacy-placeholder cases) fails fast, while strong secrets pass and non-production is not gated. contractIdMisconfig.test.ts's shared runValidateEnv helper now also stubs ADMIN_JWT_SECRET.
  - `docker compose config` still parses.

Pre-existing, unrelated test failures left untouched: 3 in src/graphql/__tests__/subscriptions.test.ts (missing campaignStepExecuted resolver) and 4 in src/__tests__/contractIdMisconfig.test.ts (StellarEventListener module-load prom-client double-registration).

Closes #1886 
Closes #1880 
Closes #1881 
Closes #1887 