### PR TITLE
fix: resolve issues #1788-#1791

### DIFF
--- a/backend/src/__tests__/property.governance-percentage-validation.test.ts
+++ b/backend/src/__tests__/property.governance-percentage-validation.test.ts
@@ -212,17 +212,33 @@ describe('Property 65-F: boundary values 0 and 100 are accepted', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Property 65-G: Pair validation accepts two valid percentages
+// Property 65-G: Pair validation accepts reachable valid percentages
 // ---------------------------------------------------------------------------
-describe('Property 65-G: pair validation accepts two valid percentages', () => {
-  it('accepts any pair of valid percentages', () => {
+describe('Property 65-G: pair validation accepts reachable valid percentages', () => {
+  it('accepts thresholds no greater than quorum, or any threshold with no quorum', () => {
     fc.assert(
       fc.property(validPctArb, validPctArb, (quorum, threshold) => {
         const result = validateGovernancePercentagePair(quorum, threshold);
-        return result.valid === true;
+        return result.valid === (quorum === 0 || threshold <= quorum);
       }),
       { numRuns: 100 },
     );
+  });
+
+  it('rejects a threshold above a positive quorum', () => {
+    expect(validateGovernancePercentagePair(10, 90)).toEqual({
+      valid: false,
+      reason: 'thresholdPct must not exceed quorumPct when quorumPct > 0',
+    });
+  });
+
+  it('accepts equal and lower thresholds', () => {
+    expect(validateGovernancePercentagePair(50, 50).valid).toBe(true);
+    expect(validateGovernancePercentagePair(50, 25).valid).toBe(true);
+  });
+
+  it('accepts any valid threshold when quorum is zero', () => {
+    expect(validateGovernancePercentagePair(0, 100).valid).toBe(true);
   });
 });
 

--- a/backend/src/lib/metrics/__tests__/metrics.test.ts
+++ b/backend/src/lib/metrics/__tests__/metrics.test.ts
@@ -323,6 +323,38 @@ describe("createMetricsMiddleware", () => {
     expect(() => finishCallback?.()).not.toThrow();
   });
 
+  it("uses a bounded label for unmatched paths", () => {
+    const middleware = createMetricsMiddleware();
+    const recordRequest = vi.spyOn(MetricsCollector, "recordHttpRequest");
+    let finishCallback: (() => void) | undefined;
+    const req = {
+      method: "GET",
+      path: "/api/tokens/variable-address",
+      headers: {},
+      route: undefined,
+    };
+    const res = {
+      statusCode: 404,
+      on: (event: string, cb: () => void) => {
+        if (event === "finish") finishCallback = cb;
+      },
+      getHeader: vi.fn().mockReturnValue(undefined),
+    };
+
+    middleware(req, res, vi.fn());
+    finishCallback?.();
+
+    expect(recordRequest).toHaveBeenCalledWith(
+      "GET",
+      "unmatched",
+      404,
+      expect.any(Number),
+      undefined,
+      undefined,
+    );
+    recordRequest.mockRestore();
+  });
+
   it("records request bytes from content-length header", () => {
     const middleware = createMetricsMiddleware();
     const next = vi.fn();

--- a/backend/src/lib/metrics/index.ts
+++ b/backend/src/lib/metrics/index.ts
@@ -682,9 +682,11 @@ export function createMetricsMiddleware() {
       const durationNs = process.hrtime.bigint() - start;
       const durationSeconds = Number(durationNs) / 1e9;
 
-      // Normalise route: use express matched route or fall back to path
-      const route =
-        (req.route?.path as string | undefined) ?? req.path ?? "unknown";
+      // Never use raw req.path here: path parameters create unbounded Prometheus labels.
+      const matchedRoute = req.route?.path as string | undefined;
+      const route = matchedRoute
+        ? `${req.baseUrl ?? ""}${matchedRoute}`
+        : "unmatched";
       const method = req.method ?? "UNKNOWN";
       const statusCode = res.statusCode;
 

--- a/backend/src/lib/validation/governancePercentage.ts
+++ b/backend/src/lib/validation/governancePercentage.ts
@@ -20,6 +20,7 @@
  *
  * Edge cases:
  *   - 0 is valid (e.g. a proposal with no quorum requirement).
+ *   - When quorum is 0, any otherwise-valid threshold is accepted.
  *   - 100 is valid (e.g. unanimous approval required).
  *   - Negative values are always invalid.
  *   - Values > 100 are always invalid.
@@ -87,6 +88,13 @@ export function validateGovernancePercentagePair(
   const thresholdResult = validateGovernancePercentage(thresholdPct);
   if (!thresholdResult.valid) {
     return { valid: false, reason: `thresholdPct: ${thresholdResult.reason}` };
+  }
+
+  if (quorumPct > 0 && thresholdPct > quorumPct) {
+    return {
+      valid: false,
+      reason: 'thresholdPct must not exceed quorumPct when quorumPct > 0',
+    };
   }
 
   return { valid: true };

--- a/backend/src/routes/admin/__tests__/treasury.test.ts
+++ b/backend/src/routes/admin/__tests__/treasury.test.ts
@@ -2,8 +2,25 @@ import { describe, it, expect, vi } from 'vitest';
 import express from 'express';
 import request from 'supertest';
 
-vi.mock('../../middleware/auth', () => ({
+const integrationState = new Map<string, string>();
+
+vi.mock('../../../middleware/auth', () => ({
   authenticateAdmin: (_req: any, _res: any, next: any) => next(),
+}));
+
+vi.mock('../../../lib/prisma', () => ({
+  prisma: {
+    integrationState: {
+      findUnique: vi.fn(({ where }: { where: { key: string } }) => {
+        const value = integrationState.get(where.key);
+        return Promise.resolve(value ? { key: where.key, value } : null);
+      }),
+      upsert: vi.fn(({ create, update, where }: { create: { key: string; value: string }; update: { value: string }; where: { key: string } }) => {
+        integrationState.set(where.key, update.value ?? create.value);
+        return Promise.resolve({ key: where.key, value: update.value ?? create.value });
+      }),
+    },
+  },
 }));
 
 const { default: treasuryRouter } = await import('../treasury');
@@ -11,6 +28,10 @@ const { default: treasuryRouter } = await import('../treasury');
 const app = express();
 app.use(express.json());
 app.use('/', treasuryRouter);
+
+beforeEach(() => {
+  integrationState.clear();
+});
 
 describe('GET /api/admin/treasury/policy', () => {
   it('returns current treasury policy', async () => {
@@ -29,6 +50,13 @@ describe('PUT /api/admin/treasury/policy', () => {
       .send({ dailyCap: '5000000000' });
     expect(res.status).toBe(200);
     expect(res.body.data.dailyCap).toBe('5000000000');
+
+    const freshApp = express();
+    freshApp.use(express.json());
+    const { default: freshTreasuryRouter } = await import('../treasury');
+    freshApp.use('/', freshTreasuryRouter);
+    const persisted = await request(freshApp).get('/');
+    expect(persisted.body.data.dailyCap).toBe('5000000000');
   });
 
   it('rejects non-string dailyCap', async () => {

--- a/backend/src/routes/admin/treasury.ts
+++ b/backend/src/routes/admin/treasury.ts
@@ -5,17 +5,22 @@
 import { Router, Request, Response } from 'express';
 import { authenticateAdmin } from '../../middleware/auth';
 import { successResponse, errorResponse } from '../../utils/response';
+import { prisma } from '../../lib/prisma';
 
 const router = Router();
 
-// In-memory store — replace with DB persistence when ready
-let treasuryPolicy = { dailyCap: '1000000000' }; // stroops as string (bigint-safe)
+const TREASURY_POLICY_KEY = 'treasury_policy_daily_cap';
+const DEFAULT_DAILY_CAP = '1000000000';
 
-router.get('/', authenticateAdmin, (_req: Request, res: Response) => {
-  res.json(successResponse({ ...treasuryPolicy, fetchedAt: new Date().toISOString() }));
+router.get('/', authenticateAdmin, async (_req: Request, res: Response) => {
+  const policy = await prisma.integrationState.findUnique({
+    where: { key: TREASURY_POLICY_KEY },
+  });
+  const dailyCap = policy?.value ?? DEFAULT_DAILY_CAP;
+  res.json(successResponse({ dailyCap, fetchedAt: new Date().toISOString() }));
 });
 
-router.put('/', authenticateAdmin, (req: Request, res: Response) => {
+router.put('/', authenticateAdmin, async (req: Request, res: Response) => {
   const { dailyCap } = req.body;
 
   if (typeof dailyCap !== 'string' || !/^\d+$/.test(dailyCap)) {
@@ -24,8 +29,12 @@ router.put('/', authenticateAdmin, (req: Request, res: Response) => {
     );
   }
 
-  treasuryPolicy = { dailyCap };
-  res.json(successResponse({ ...treasuryPolicy, updatedAt: new Date().toISOString() }));
+  await prisma.integrationState.upsert({
+    where: { key: TREASURY_POLICY_KEY },
+    create: { key: TREASURY_POLICY_KEY, value: dailyCap },
+    update: { value: dailyCap },
+  });
+  res.json(successResponse({ dailyCap, updatedAt: new Date().toISOString() }));
 });
 
 export default router;

--- a/backend/src/services/leaderboardService.ts
+++ b/backend/src/services/leaderboardService.ts
@@ -56,6 +56,17 @@ const cache = new Map<string, CacheEntry>();
 /** Safety-net TTL — entries are also evicted by event-driven invalidation. */
 const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
 
+const MAX_SORTED_SET_SCORE = BigInt(Number.MAX_SAFE_INTEGER);
+
+/** Redis scores are numbers, so cap BigInt amounts instead of converting silently. */
+export function toSafeSortedSetScore(value: bigint | string | null | undefined): number {
+  const amount = BigInt(value ?? 0);
+  if (amount > MAX_SORTED_SET_SCORE) {
+    return Number.MAX_SAFE_INTEGER;
+  }
+  return Number(amount);
+}
+
 function getCacheKey(
   type: string,
   period: TimePeriod,
@@ -146,7 +157,7 @@ eventBus.subscribe<TokenBurnedPayload>("token.burned", async (event) => {
   const { tokenId, amount } = event.payload;
   if (!tokenId) return;
 
-  const delta = Number(amount ?? "0");
+  const delta = toSafeSortedSetScore(amount);
 
   // A burn affects burn-volume, burn-count, and unique-burner leaderboards.
   invalidateCacheByType("most-burned");
@@ -273,7 +284,7 @@ async function recomputeMostBurned(
   // gaps are self-healing since a miss just falls back to recompute again.
   const allScores: SortedSetMemberInput[] = burnsByToken.map((b) => ({
     tokenId: b.tokenId,
-    score: Number(b._sum.amount || BigInt(0)),
+    score: toSafeSortedSetScore(b._sum.amount),
   }));
 
   return { data, total, allScores };


### PR DESCRIPTION
## Summary

- Enforce the governance threshold/quorum invariant with boundary coverage.
- Guard BigInt leaderboard amounts before passing scores to Redis.
- Persist the treasury daily cap through Prisma IntegrationState.
- Bound unmatched HTTP metric route labels and include nested mount paths.

## Validation

- Focused Vitest suites: 4 files, 103 tests passed.
- `npm run type-check` passed.
- `npm run lint` could not run because the installed dependencies did not include the `eslint` binary.
- The repository-wide test run exposed unrelated existing integration failures; the focused suites for these changes passed.

Closes #1788
Closes #1789
Closes #1790
Closes #1791