### PR TITLE
fix: resolve token and webhook state reporting bugs

### DIFF
--- a/backend/prisma/migrations/20260827000000_add_token_deploy_tx_hash/migration.sql
+++ b/backend/prisma/migrations/20260827000000_add_token_deploy_tx_hash/migration.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "Token" ADD COLUMN "deployTxHash" TEXT;
+
+CREATE UNIQUE INDEX "Token_deployTxHash_key" ON "Token"("deployTxHash");
+
+CREATE INDEX "Token_deployTxHash_idx" ON "Token"("deployTxHash");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -10,6 +10,8 @@ datasource db {
 model Token {
   id            String        @id @default(uuid())
   address       String        @unique
+  /// Stellar transaction hash that registered/deployed this token.
+  deployTxHash  String?       @unique
   creator       String
   name          String
   symbol        String
@@ -42,6 +44,7 @@ model Token {
   governanceRegistration TokenGovernanceRegistration?
 
   @@index([address])
+  @@index([deployTxHash])
   @@index([creator])
   @@index([createdAt])
   @@index([totalSupply])

--- a/backend/src/routes/__tests__/events.catchup.test.ts
+++ b/backend/src/routes/__tests__/events.catchup.test.ts
@@ -83,6 +83,20 @@ describe('GET /api/events/catchup', () => {
     expect(res.body.events).toBeUndefined();
   });
 
+  it('signals a cursor reset when since is ahead of the current sequence', async () => {
+    bus._setSequence(3);
+    bus._setHistory([makeEvent(1), makeEvent(2), makeEvent(3)]);
+
+    const res = await request(makeApp()).get('/api/events/catchup?since=8');
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      truncated: true,
+      reason: 'cursor_reset',
+      currentSequence: 3,
+    });
+    expect(res.body.events).toBeUndefined();
+  });
+
   it('includes currentSequence in all responses', async () => {
     bus._setSequence(7);
     bus._setHistory([makeEvent(7)]);

--- a/backend/src/routes/__tests__/webhooks-deadletter.test.ts
+++ b/backend/src/routes/__tests__/webhooks-deadletter.test.ts
@@ -81,6 +81,12 @@ describe('POST /api/webhooks/dead-letter/:id/requeue', () => {
       ...mockEntry,
       requeueCount: 1,
     });
+    mockWebhookDeliveryService.deliverWebhook.mockResolvedValue({
+      success: true,
+      statusCode: 200,
+      attempts: 1,
+      error: null,
+    });
 
     const app = buildApp();
     const response = await request(app)
@@ -93,6 +99,41 @@ describe('POST /api/webhooks/dead-letter/:id/requeue', () => {
     });
     expect(mockWebhookDeadLetterService.getEntry).toHaveBeenCalledWith(deadLetterId);
     expect(mockWebhookDeadLetterService.requeueDeadLetter).toHaveBeenCalledWith(deadLetterId);
+    expect(mockWebhookDeliveryService.deliverWebhook).toHaveBeenCalledWith(
+      mockSubscription,
+      mockEntry.event,
+      { amount: 100 },
+      `requeue_${deadLetterId}`
+    );
+    expect(mockWebhookDeadLetterService.markResolved).toHaveBeenCalledWith(deadLetterId, 'retried');
+  });
+
+  it('leaves the entry unresolved when requeue delivery fails', async () => {
+    const mockEntry = {
+      id: 'dl-failed',
+      subscriptionId: 'sub-456',
+      event: 'payment.completed',
+      payload: JSON.stringify({ data: { amount: 100 } }),
+      requeueCount: 0,
+      resolvedAt: null,
+    };
+    const mockSubscription = { id: 'sub-456', url: 'https://webhook.example.com' };
+    mockWebhookDeadLetterService.getEntry.mockResolvedValue(mockEntry);
+    mockWebhookDeadLetterService.requeueDeadLetter.mockResolvedValue({ ...mockEntry, requeueCount: 1 });
+    mockWebhookService.getSubscription.mockResolvedValue(mockSubscription);
+    mockWebhookDeliveryService.deliverWebhook.mockResolvedValue({
+      success: false,
+      statusCode: 503,
+      attempts: 3,
+      error: 'Service Unavailable',
+    });
+
+    const response = await request(buildApp())
+      .post('/api/webhooks/dead-letter/dl-failed/requeue')
+      .expect(502);
+
+    expect(response.body.error.code).toBe('DELIVERY_FAILED');
+    expect(mockWebhookDeadLetterService.markResolved).not.toHaveBeenCalled();
   });
 
   it('returns 404 when dead-letter entry not found', async () => {

--- a/backend/src/routes/events.ts
+++ b/backend/src/routes/events.ts
@@ -27,6 +27,14 @@ router.get("/catchup", (req: Request, res: Response) => {
 
   const currentSequence = eventBus.currentSequence;
 
+  // The in-memory event bus resets its sequence after a process restart. A
+  // client cursor ahead of the new sequence is therefore stale and requires
+  // a full resync rather than an empty successful catch-up response.
+  if (since > currentSequence) {
+    res.json({ truncated: true, reason: "cursor_reset", currentSequence });
+    return;
+  }
+
   // Truncation guard — tell client to do a full refresh
   if (currentSequence - since > CATCHUP_LIMIT) {
     res.json({ truncated: true, currentSequence });

--- a/backend/src/routes/tokens.ts
+++ b/backend/src/routes/tokens.ts
@@ -470,13 +470,7 @@ router.get("/deployment-status/:txHash", async (req: Request, res: Response) => 
     // Look for token created within last 5 minutes with this txHash
     const token = await prisma.token.findFirst({
       where: {
-        // Note: Assuming burn records track deployment txHash
-        // If tokens table doesn't have txHash, this would need adaptation
-        burnRecords: {
-          some: {
-            txHash: txHash,
-          },
-        },
+        deployTxHash: txHash,
       },
       select: {
         id: true,

--- a/backend/src/routes/webhooks-deadletter.ts
+++ b/backend/src/routes/webhooks-deadletter.ts
@@ -138,12 +138,22 @@ router.post(
       // deliverWebhook starts its own retry loop at attempt 1, so this is
       // always a fresh attempt counter — never a resumption of the
       // exhausted one that landed the entry in the dead-letter queue.
-      await webhookDeliveryService.deliverWebhook(
+      const deliveryResult = await webhookDeliveryService.deliverWebhook(
         subscription,
         deadLetter.event,
         payload.data || payload,
         `admin_retry_${id}`
       );
+
+      if (!deliveryResult.success) {
+        return res.status(502).json(
+          errorResponse({
+            code: "DELIVERY_FAILED",
+            message: "Dead-letter delivery failed; entry remains unresolved",
+            details: deliveryResult,
+          }, req.correlationId)
+        );
+      }
 
       await webhookDeadLetterService.markResolved(id, "retried");
 
@@ -199,10 +209,40 @@ router.post(
 
       try {
         const requeued = await webhookDeadLetterService.requeueDeadLetter(id);
+        const subscription = await webhookService.getSubscription(
+          requeued.subscriptionId
+        );
+        if (!subscription) {
+          return res.status(404).json(
+            errorResponse({
+              code: "SUBSCRIPTION_NOT_FOUND",
+              message: "Associated webhook subscription no longer exists",
+            }, req.correlationId)
+          );
+        }
+
+        const payload = JSON.parse(requeued.payload);
+        const deliveryResult = await webhookDeliveryService.deliverWebhook(
+          subscription,
+          requeued.event,
+          payload.data || payload,
+          `requeue_${id}`
+        );
+        if (!deliveryResult.success) {
+          return res.status(502).json(
+            errorResponse({
+              code: "DELIVERY_FAILED",
+              message: "Dead-letter delivery failed; entry remains unresolved",
+              details: deliveryResult,
+            }, req.correlationId)
+          );
+        }
+
+        await webhookDeadLetterService.markResolved(id, "retried");
 
         res.json(
           successResponse({
-            message: "Dead-letter entry requeued for delivery",
+            message: "Dead-letter entry redelivered successfully",
             id,
             requeueCount: requeued.requeueCount,
           }, req.correlationId)

--- a/backend/src/routes/webhooks.ts
+++ b/backend/src/routes/webhooks.ts
@@ -410,12 +410,20 @@ router.post(
 
       // Re-deliver the webhook
       const payload = JSON.parse(deadLetter.payload);
-      await webhookDeliveryService.deliverWebhook(
+      const deliveryResult = await webhookDeliveryService.deliverWebhook(
         subscription,
         deadLetter.event,
         payload.data || payload,
         `retry_${id}`
       );
+
+      if (!deliveryResult.success) {
+        res.status(502).json({
+          success: false,
+          error: "Dead-letter delivery failed; entry remains unresolved",
+        });
+        return;
+      }
 
       // Mark as resolved
       await webhookDeadLetterService.markResolved(id, "retried");

--- a/backend/src/services/eventBus.ts
+++ b/backend/src/services/eventBus.ts
@@ -74,7 +74,7 @@ export class EventBus {
   private history: BusEvent[] = [];
   private deadLetterQueue: DeadLetterEntry[] = [];
 
-  /** Monotonically incrementing sequence counter (#1372). */
+  /** Monotonically incrementing sequence counter (#1372); resets on restart because this bus is in-memory. */
   private _sequence = 0;
 
   /** Maximum events kept in history. 0 = unlimited. */

--- a/backend/src/services/tokenEventParser.ts
+++ b/backend/src/services/tokenEventParser.ts
@@ -49,6 +49,7 @@ export class TokenEventParser {
       where: { address: event.tokenAddress },
       create: {
         address: event.tokenAddress,
+        deployTxHash: event.transactionHash,
         creator: event.creator ?? "",
         name: event.name ?? "",
         symbol: event.symbol ?? "",

--- a/backend/src/services/webhookDeliveryService.ts
+++ b/backend/src/services/webhookDeliveryService.ts
@@ -53,6 +53,13 @@ interface DeliveryTask {
   correlationId: string;
 }
 
+export interface WebhookDeliveryResult {
+  success: boolean;
+  statusCode: number | null;
+  attempts: number;
+  error: string | null;
+}
+
 export class WebhookDeliveryService {
   private circuitBreaker: CircuitBreaker;
   // Read at construction time so tests can override via process.env before new WebhookDeliveryService()
@@ -76,13 +83,14 @@ export class WebhookDeliveryService {
     );
     this.pool = new WorkerPool<DeliveryTask>({
       concurrency: WORKER_CONCURRENCY,
-      worker: (task) =>
-        this.deliverWebhook(
+      worker: async (task) => {
+        await this.deliverWebhook(
           task.subscription,
           task.event,
           task.data,
           task.correlationId
-        ),
+        );
+      },
     });
   }
 
@@ -174,7 +182,7 @@ export class WebhookDeliveryService {
     event: WebhookEventType,
     data: WebhookEventData,
     correlationId?: string
-  ): Promise<void> {
+  ): Promise<WebhookDeliveryResult> {
     const cid = correlationId || `whk_${Date.now().toString(36)}`;
 
     // Per-tenant rate limit: the subscription owner (createdBy) is the
@@ -188,7 +196,7 @@ export class WebhookDeliveryService {
         console.warn(
           JSON.stringify({ event: 'webhook.rate_limited', correlationId: cid, subscriptionId: subscription.id, tenantId })
         );
-        return;
+        return { success: false, statusCode: null, attempts: 0, error: "Rate limited" };
       }
     }
 
@@ -212,7 +220,7 @@ export class WebhookDeliveryService {
     // resolves once a token refills (see TenantWebhookRateLimiter).
     await this.rateLimiter.acquire(tenantId);
 
-    return this.circuitBreaker.execute(async () => {
+    return this.circuitBreaker.execute(async (): Promise<WebhookDeliveryResult> => {
       let lastError: string | null = null;
       let statusCode: number | null = null;
       let success = false;
@@ -342,6 +350,8 @@ export class WebhookDeliveryService {
           JSON.stringify({ event: 'webhook.failed', correlationId: cid, subscriptionId: subscription.id, attempts, ...(txHash && { txHash }) })
         );
       }
+
+      return { success, statusCode, attempts, error: lastError };
     });
   }
 


### PR DESCRIPTION
## Summary

- Resolve deployment status by the token deployment transaction hash instead of burn records.
- Signal a full resync when an event catch-up cursor is ahead of the in-memory event bus sequence.
- Return webhook delivery outcomes and only resolve dead-letter entries after successful delivery.
- Make dead-letter requeue trigger an actual redelivery attempt.
- Add the deployment transaction hash schema field and migration.

## Validation

- `npm exec vitest run src/routes/__tests__/deployment-status.test.ts src/routes/__tests__/events.catchup.test.ts src/routes/__tests__/webhooks-deadletter.test.ts` passed: 20 tests.
- Existing webhook delivery service suites passed.
- `npm run type-check` passed.
- `npm run lint` could not run because `eslint` is not installed or declared in the backend package.
- Full `npm test -- --run` reached unrelated integration failures and aborted in a native/V8-backed test.

Closes #1792
Closes #1793
Closes #1794
Closes #1795