### PR TITLE
fix(backend): resolve silent service defects

### DIFF
--- a/backend/src/auth/token.service.spec.ts
+++ b/backend/src/auth/token.service.spec.ts
@@ -3,6 +3,7 @@ import { JwtModule, JwtService } from "@nestjs/jwt";
 import { ConfigModule, ConfigService } from "@nestjs/config";
 import { UnauthorizedException } from "@nestjs/common";
 import { TokenService } from "../token.service";
+import { AUTH_CONSTANTS } from "../auth.constants";
 
 describe("TokenService", () => {
   let service: TokenService;
@@ -54,6 +55,17 @@ describe("TokenService", () => {
       const r2 = service.generateTokenPair(testWallet);
 
       expect(r1.accessToken).not.toBe(r2.accessToken);
+    });
+
+    it("should derive expiresIn from the access token expiry constant", () => {
+      const originalExpiry = AUTH_CONSTANTS.JWT_ACCESS_EXPIRY;
+      AUTH_CONSTANTS.JWT_ACCESS_EXPIRY = "2h";
+
+      try {
+        expect(service.generateTokenPair(testWallet).expiresIn).toBe(2 * 60 * 60);
+      } finally {
+        AUTH_CONSTANTS.JWT_ACCESS_EXPIRY = originalExpiry;
+      }
     });
   });
 

--- a/backend/src/auth/token.service.ts
+++ b/backend/src/auth/token.service.ts
@@ -5,6 +5,24 @@ import { v4 as uuidv4 } from "uuid";
 import { AUTH_CONSTANTS } from "../auth.constants";
 import { AuthResponseDto, JwtPayloadDto } from "./dto/auth.dto";
 
+function parseExpiryToSeconds(expiry: string): number {
+  const match = expiry.match(/^(\d+(?:\.\d+)?)([smhdwy])$/);
+  if (!match) {
+    throw new Error(`Unsupported JWT expiry format: ${expiry}`);
+  }
+
+  const multipliers: Record<string, number> = {
+    s: 1,
+    m: 60,
+    h: 60 * 60,
+    d: 24 * 60 * 60,
+    w: 7 * 24 * 60 * 60,
+    y: 365 * 24 * 60 * 60,
+  };
+
+  return Number(match[1]) * multipliers[match[2]];
+}
+
 @Injectable()
 export class TokenService {
   private readonly logger = new Logger(TokenService.name);
@@ -46,7 +64,7 @@ export class TokenService {
     return {
       accessToken,
       refreshToken,
-      expiresIn: 15 * 60, // 15 minutes in seconds
+      expiresIn: parseExpiryToSeconds(AUTH_CONSTANTS.JWT_ACCESS_EXPIRY),
       tokenType: "Bearer",
       walletAddress,
     };

--- a/backend/src/lib/__tests__/stellar.test.ts
+++ b/backend/src/lib/__tests__/stellar.test.ts
@@ -222,16 +222,6 @@ describe("Stellar SDK operations", () => {
 
   describe("base fee operations", () => {
     it("gets current base fee (mocked)", async () => {
-      const mockLedgerResponse = {
-        records: [
-          {
-            sequence: "1000",
-            base_fee_in_stroops: "100",
-            max_tx_set_size: "1000",
-          },
-        ],
-      } as any;
-
       const mockFeeStatsResponse = {
         last_ledger: "1000",
         last_ledger_base_fee: "100",
@@ -240,38 +230,25 @@ describe("Stellar SDK operations", () => {
         max_fee: { mode: "200" },
       } as any;
 
-      const mockLedgers = {
-        limit: vi.fn().mockReturnValue({
-          order: vi.fn().mockReturnValue({
-            call: vi.fn().mockResolvedValue(mockLedgerResponse),
-          }),
-        }),
-      };
-
       const mockFeeStats = {
         call: vi.fn().mockResolvedValue(mockFeeStatsResponse),
       };
 
-      vi.spyOn(StellarSdk.Horizon.Server.prototype, "ledgers").mockReturnValue(
-        mockLedgers as any
-      );
-
+      const ledgers = vi.spyOn(StellarSdk.Horizon.Server.prototype, "ledgers");
       vi.spyOn(StellarSdk.Horizon.Server.prototype, "feeStats").mockReturnValue(
         mockFeeStats as any
       );
 
       const baseFee = await stellarLib.getCurrentBaseFee(testConfig);
 
-      expect(baseFee).toBeGreaterThanOrEqual(StellarSdk.BASE_FEE);
+      expect(baseFee).toBeGreaterThanOrEqual(Number(StellarSdk.BASE_FEE));
+      expect(ledgers).not.toHaveBeenCalled();
+      expect(mockFeeStats.call).toHaveBeenCalledTimes(1);
     });
 
     it("returns default fee on error", async () => {
-      vi.spyOn(StellarSdk.Horizon.Server.prototype, "ledgers").mockReturnValue({
-        limit: vi.fn().mockReturnValue({
-          order: vi.fn().mockReturnValue({
-            call: vi.fn().mockRejectedValue(new Error("Network error")),
-          }),
-        }),
+      vi.spyOn(StellarSdk.Horizon.Server.prototype, "feeStats").mockReturnValue({
+        call: vi.fn().mockRejectedValue(new Error("Network error")),
       } as any);
 
       const baseFee = await stellarLib.getCurrentBaseFee(testConfig);

--- a/backend/src/lib/health/__tests__/health.service.test.ts
+++ b/backend/src/lib/health/__tests__/health.service.test.ts
@@ -227,6 +227,13 @@ describe("HealthService", () => {
       expect(result.metrics.cpu).toBeDefined();
       expect(result.metrics.cpu.usage).toBeGreaterThanOrEqual(0);
       expect(result.metrics.database).toBeDefined();
+      expect(result.metrics.database).toEqual({
+        poolSize: 1,
+        activeConnections: 1,
+        idleConnections: 0,
+      });
+      const query = vi.mocked(prisma.$queryRaw).mock.calls.at(-1)?.[0];
+      expect(query?.join(" ")).toContain("pg_stat_activity");
       expect(result.metrics.requests).toBeDefined();
       expect(result.metrics.requests.total).toBeGreaterThanOrEqual(0);
       expect(result.metrics.requests.errorRate).toBeGreaterThanOrEqual(0);

--- a/backend/src/lib/health/health.service.ts
+++ b/backend/src/lib/health/health.service.ts
@@ -395,7 +395,9 @@ export class HealthService {
     try {
       // Prisma doesn't expose pool stats directly, but we can check connection
       const result = await prisma.$queryRaw<Array<{ count: bigint }>>`
-        SELECT COUNT(*) as count FROM sqlite_master WHERE type='table'
+        SELECT COUNT(*)::bigint AS count
+        FROM pg_stat_activity
+        WHERE datname = current_database()
       `;
       dbPoolStats = {
         poolSize: 1,

--- a/backend/src/lib/stellar/index.ts
+++ b/backend/src/lib/stellar/index.ts
@@ -128,10 +128,8 @@ export async function getCurrentBaseFee(
   config: StellarNetworkConfig = stellarConfig
 ): Promise<number> {
   const horizon = getHorizonServer(config);
-  const server = new StellarSdk.Horizon.Server(config.horizonUrl);
   try {
-    const ledger = await server.ledgers().limit(1).order("desc").call();
-    const feeStats = await server.feeStats().call();
+    const feeStats = await horizon.feeStats().call();
     return Math.max(
       StellarSdk.BASE_FEE,
       parseInt(feeStats.max_fee.mode as string)

--- a/backend/src/services/sagas/batchDeployGovernanceSaga.ts
+++ b/backend/src/services/sagas/batchDeployGovernanceSaga.ts
@@ -17,6 +17,7 @@
 import { PrismaClient } from "@prisma/client";
 import { SagaDefinition, SagaResult } from "../sagaCoordinator";
 import sagaCoordinator from "../sagaCoordinator";
+import { prisma } from "../../lib/prisma";
 import { callStellarDeploy, TokenDeployInput } from "../batchTokenDeployService";
 import { eventBus } from "../eventBus";
 
@@ -124,7 +125,7 @@ export function createBatchDeployGovernanceSaga(
   };
 }
 
-sagaCoordinator.registerSaga(createBatchDeployGovernanceSaga(new PrismaClient()));
+sagaCoordinator.registerSaga(createBatchDeployGovernanceSaga(prisma));
 
 /** Runs the batch-deploy-plus-governance-registration saga for the given token inputs. */
 export async function deployTokensWithGovernanceRegistration(


### PR DESCRIPTION
## Summary
- Derive token response expiry from `AUTH_CONSTANTS.JWT_ACCESS_EXPIRY`.
- Remove the redundant Horizon ledger request from base-fee lookup.
- Register the governance saga with the shared Prisma client.
- Use a PostgreSQL-compatible activity query for health metrics.

## Validation
- `npm run build` passed.
- `npm run type-check` passed.
- Focused health metrics tests passed.
- Focused base-fee regression test passed.
- The full focused suite has pre-existing environment blockers: several backend dependencies are undeclared, and unrelated health cache and Stellar invalid-fixture tests fail in the repository baseline.

Closes #1784
Closes #1785
Closes #1786
Closes #1787